### PR TITLE
Improve profile UI, images, replies and add footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ A simple search interface for Nostr events.
 
 ### Combined Search
 - `GM by:dergigi` - Find "GM" messages from dergigi
-- `#YESTR by:gigi` - Find #YESTR events from gigi
-- `👀 by:gigi` - Find events with 👀 from gigi
+- `#YESTR by:dergigi` - Find #YESTR events from gigi
+- `👀 by:dergigi` - Find events with 👀 from gigi
 - `.jpg by:corndalorian` - Find .jpg events from corndalorian
 
 ### Direct NPUB Search

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   /* config options here */
   images: {
+    unoptimized: true,
     // Allow loading images from any remote host (http and https)
     remotePatterns: [
       { protocol: 'https', hostname: '**' },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "next lint && tsc --noEmit",
     "test": "jest"
   },
   "dependencies": {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout({
         <div className="flex-1">
           {children}
         </div>
-        <footer className="text-center text-xs text-gray-400 py-6 select-none">
+        <footer className="text-center text-xs text-gray-400 py-6 select-none bg-[#1a1a1a]">
           <p>
             Made with love by <a href="https://dergigi.com" className="underline hover:text-gray-300" target="_blank" rel="noopener noreferrer">Gigi</a> - okay... vibed with love.
           </p>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,7 +35,7 @@ export default function RootLayout({
             Made with love by <a href="https://dergigi.com" className="underline hover:text-gray-300" target="_blank" rel="noopener noreferrer">Gigi</a> - okay... vibed with love.
           </p>
           <p className="mt-1">
-            <a href="https://github.com/dergigi" className="underline hover:text-gray-300" target="_blank" rel="noopener noreferrer">GitHub</a>
+            <a href="https://github.com/dergigi/ants/" className="underline hover:text-gray-300" target="_blank" rel="noopener noreferrer">GitHub</a>
             <span className="mx-2">·</span>
             <a href="https://npub.world/npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc" className="underline hover:text-gray-300" target="_blank" rel="noopener noreferrer">Nostr</a>
             <span className="mx-2">·</span>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,9 +25,23 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className={`${geistSans.variable} ${geistMono.variable}`}>
-      <body className="font-sans">
+      <body className="font-sans min-h-screen flex flex-col">
         <LoginButton />
-        {children}
+        <div className="flex-1">
+          {children}
+        </div>
+        <footer className="text-center text-xs text-gray-400 py-6 select-none">
+          <p>
+            Made with love by <a href="https://dergigi.com" className="underline hover:text-gray-300" target="_blank" rel="noopener noreferrer">Gigi</a> - okay... vibed with love.
+          </p>
+          <p className="mt-1">
+            <a href="https://github.com/dergigi" className="underline hover:text-gray-300" target="_blank" rel="noopener noreferrer">GitHub</a>
+            <span className="mx-2">·</span>
+            <a href="https://npub.world/npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc" className="underline hover:text-gray-300" target="_blank" rel="noopener noreferrer">Nostr</a>
+            <span className="mx-2">·</span>
+            Birthed during SEC-04
+          </p>
+        </footer>
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,7 +39,7 @@ export default function RootLayout({
             <span className="mx-2">·</span>
             <a href="https://npub.world/npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc" className="underline hover:text-gray-300" target="_blank" rel="noopener noreferrer">Nostr</a>
             <span className="mx-2">·</span>
-            Birthed during SEC-04
+            <a href="https://sovereignengineering.io/" className="underline hover:text-gray-300" target="_blank" rel="noopener noreferrer">Birthed during SEC-04</a>
           </p>
         </footer>
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -316,7 +316,7 @@ function SearchComponent() {
       }
       setExpandedParents((prev) => ({ ...prev, [parentId]: 'loading' }));
       const fetched = await fetchEventById(parentId);
-      setExpandedParents((prev) => ({ ...prev, [parentId]: fetched || undefined } as any));
+      setExpandedParents((prev) => ({ ...prev, [parentId]: fetched || 'loading' }));
     };
 
     if (!parentEvent) {
@@ -496,23 +496,10 @@ function SearchComponent() {
         {results.length > 0 && (
           <div className="mt-8 space-y-4">
             {results.map((event) => {
-              const nevent = nip19.neventEncode({ id: event.id });
               const parentId = getReplyToEventId(event);
               const parent = parentId ? expandedParents[parentId] : undefined;
               const isLoadingParent = parent === 'loading';
               const parentEvent = parent && parent !== 'loading' ? (parent as NDKEvent) : null;
-              const handleToggleParent = async () => {
-                if (!parentId) return;
-                if (expandedParents[parentId]) {
-                  const updated = { ...expandedParents };
-                  delete updated[parentId];
-                  setExpandedParents(updated);
-                  return;
-                }
-                setExpandedParents((prev) => ({ ...prev, [parentId]: 'loading' }));
-                const fetched = await fetchEventById(parentId);
-                setExpandedParents((prev) => ({ ...prev, [parentId]: fetched || undefined } as any));
-              };
               const hasCollapsedBar = Boolean(parentId && !parentEvent && !isLoadingParent);
               const hasExpandedParent = Boolean(parentEvent);
               const noteCardClasses = `p-4 bg-[#2d2d2d] border border-[#3d3d3d] ${

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -463,27 +463,29 @@ function SearchComponent() {
                 const fetched = await fetchEventById(parentId);
                 setExpandedParents((prev) => ({ ...prev, [parentId]: fetched || undefined } as any));
               };
+              const hasCollapsedBar = Boolean(parentId && !parentEvent && !isLoadingParent);
+              const noteCardClasses = `p-4 bg-[#2d2d2d] border border-[#3d3d3d] ${hasCollapsedBar ? 'rounded-b-lg rounded-t-none border-t-0' : 'rounded-lg'}`;
               return (
-              <div key={event.id} className="p-4 bg-[#2d2d2d] rounded-lg border border-[#3d3d3d]">
-                {parentId && (
-                  <div className="-mt-1 -mx-1 mb-3">
+              <div key={event.id}>
+                {parentId && !parentEvent && (
+                  <div className={`text-xs text-gray-300 bg-[#1f1f1f] border border-[#3d3d3d] rounded-t-lg rounded-b-none ${hasCollapsedBar ? 'border-b-0' : ''}`}>
                     <button
                       type="button"
                       onClick={handleToggleParent}
-                      className="w-full text-left text-xs text-gray-300 bg-[#1f1f1f] border border-[#3d3d3d] rounded-md px-3 py-2 hover:bg-[#262626]"
+                      className="w-full text-left px-4 py-2 hover:bg-[#262626] rounded-t-lg"
                     >
                       {isLoadingParent ? 'Loading parent…' : `Replying to: ${nip19.neventEncode({ id: parentId })}`}
                     </button>
-                    {parentEvent && (
-                      <div className="mt-3 p-3 bg-[#2a2a2a] rounded-md border border-[#3c3c3c]">
-                        {renderNoteBody(parentEvent)}
-                      </div>
-                    )}
+                  </div>
+                )}
+                {parentEvent && (
+                  <div className="p-4 bg-[#2d2d2d] rounded-lg border border-[#3d3d3d] mb-3">
+                    {renderNoteBody(parentEvent)}
                   </div>
                 )}
                 {event.kind === 0 ? (
                   // Profile metadata
-                  <div>
+                  <div className={noteCardClasses}>
                     <div className="flex items-center gap-4">
                       {event.author.profile?.image && (
                         <Image 
@@ -503,9 +505,9 @@ function SearchComponent() {
                   </div>
                 ) : (
                   // Regular note
-                  <>
+                  <div className={noteCardClasses}>
                     {renderNoteBody(event)}
-                  </>
+                  </div>
                 )}
               </div>
             );})}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -69,6 +69,7 @@ function AuthorBadge({ user }: { user: NDKUser }) {
   const [loaded, setLoaded] = useState(false);
   const [name, setName] = useState('');
   const { isVerified, value } = useNip05Status(user);
+  const profileUrl = `https://npub.world/${user.npub}`;
 
   useEffect(() => {
     let isMounted = true;
@@ -85,10 +86,16 @@ function AuthorBadge({ user }: { user: NDKUser }) {
   }, [user]);
 
   const nip05Part = value ? (
-    <span className={`inline-flex items-center gap-1 ${isVerified ? 'text-green-400' : 'text-yellow-400'}`}>
+    <a
+      href={profileUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`inline-flex items-center gap-1 ${isVerified ? 'text-green-400' : 'text-yellow-400'} hover:underline`}
+      title={value}
+    >
       <FontAwesomeIcon icon={isVerified ? faCircleCheck : faTriangleExclamation} className="h-4 w-4" />
       <span className="truncate max-w-[14rem]">{value}</span>
-    </span>
+    </a>
   ) : (
     <span className="text-gray-400">no NIP-05</span>
   );
@@ -97,7 +104,7 @@ function AuthorBadge({ user }: { user: NDKUser }) {
     <div className="flex items-center gap-2">
       {loaded ? (
         <a
-          href={`https://npub.world/${user.npub}`}
+          href={profileUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="font-medium text-gray-100 hover:underline truncate max-w-[10rem]"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -93,9 +93,9 @@ function AuthorBadge({ user }: { user: NDKUser }) {
   );
 
   return (
-    <div className="flex flex-col">
-      <span className="font-medium text-gray-100 truncate max-w-[14rem]">{loaded ? (name || 'Unknown') : 'Loading...'}</span>
-      <span className="text-sm">{nip05Part}</span>
+    <div className="flex items-center gap-2">
+      <span className="font-medium text-gray-100 truncate max-w-[10rem]">{loaded ? (name || 'Unknown') : 'Loading...'}</span>
+      <span className="text-sm truncate">{nip05Part}</span>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import { useSearchParams, useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleCheck, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { nip19 } from 'nostr-tools';
 
 type Nip05CheckResult = {
   isVerified: boolean;
@@ -366,7 +367,9 @@ function SearchComponent() {
 
         {results.length > 0 && (
           <div className="mt-8 space-y-4">
-            {results.map((event) => (
+            {results.map((event) => {
+              const nevent = nip19.neventEncode({ id: event.id });
+              return (
               <div key={event.id} className="p-4 bg-[#2d2d2d] rounded-lg border border-[#3d3d3d]">
                 {event.kind === 0 ? (
                   // Profile metadata
@@ -424,12 +427,19 @@ function SearchComponent() {
                       <div className="flex items-center gap-2">
                         <AuthorBadge user={event.author} />
                       </div>
-                      <span>{event.created_at ? formatDate(event.created_at) : 'Unknown date'}</span>
+                      <a
+                        href={`https://njump.me/${nevent}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="hover:underline"
+                      >
+                        {event.created_at ? formatDate(event.created_at) : 'Unknown date'}
+                      </a>
                     </div>
                   </>
                 )}
               </div>
-            ))}
+            );})}
           </div>
         )}
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -464,7 +464,12 @@ function SearchComponent() {
                 setExpandedParents((prev) => ({ ...prev, [parentId]: fetched || undefined } as any));
               };
               const hasCollapsedBar = Boolean(parentId && !parentEvent && !isLoadingParent);
-              const noteCardClasses = `p-4 bg-[#2d2d2d] border border-[#3d3d3d] ${hasCollapsedBar ? 'rounded-b-lg rounded-t-none border-t-0' : 'rounded-lg'}`;
+              const hasExpandedParent = Boolean(parentEvent);
+              const noteCardClasses = `p-4 bg-[#2d2d2d] border border-[#3d3d3d] ${
+                hasCollapsedBar || hasExpandedParent
+                  ? 'rounded-b-lg rounded-t-none border-t-0'
+                  : 'rounded-lg'
+              }`;
               return (
               <div key={event.id}>
                 {parentId && !parentEvent && (
@@ -479,7 +484,7 @@ function SearchComponent() {
                   </div>
                 )}
                 {parentEvent && (
-                  <div className="p-4 bg-[#2d2d2d] rounded-lg border border-[#3d3d3d] mb-3">
+                  <div className="p-4 bg-[#2d2d2d] border border-[#3d3d3d] rounded-t-lg rounded-b-none border-b-0">
                     {renderNoteBody(parentEvent)}
                   </div>
                 )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -334,6 +334,7 @@ function SearchComponent() {
                           width={64}
                           height={64}
                           className="rounded-full"
+                          unoptimized
                         />
                       )}
                       <AuthorBadge user={event.author} />
@@ -356,7 +357,7 @@ function SearchComponent() {
                               width={1024}
                               height={1024}
                               className="h-auto w-full object-contain"
-                              unoptimized={false}
+                              unoptimized
                             />
                           </div>
                         ))}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -279,8 +279,8 @@ function SearchComponent() {
 
   return (
     <main className="min-h-screen bg-[#1a1a1a] text-gray-100">
-      <div className={`max-w-2xl mx-auto px-4 pr-16 ${results.length > 0 ? 'pt-4' : 'min-h-screen flex items-center'}`}>
-        <form onSubmit={handleSubmit} className="w-full">
+      <div className={`max-w-2xl mx-auto px-4 ${results.length > 0 ? 'pt-4' : 'min-h-screen flex items-center'}`}>
+        <form onSubmit={handleSubmit} className="w-full pr-16">
           <div className="flex gap-2">
             <div className="flex-1 relative">
               <input

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -279,7 +279,7 @@ function SearchComponent() {
 
   return (
     <main className="min-h-screen bg-[#1a1a1a] text-gray-100">
-      <div className={`max-w-2xl mx-auto px-4 ${results.length > 0 ? 'pt-4' : 'min-h-screen flex items-center'}`}>
+      <div className={`max-w-2xl mx-auto px-4 pr-16 ${results.length > 0 ? 'pt-4' : 'min-h-screen flex items-center'}`}>
         <form onSubmit={handleSubmit} className="w-full">
           <div className="flex gap-2">
             <div className="flex-1 relative">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -65,7 +65,7 @@ function useNip05Status(user: NDKUser): Nip05CheckResult {
   return { isVerified: verified, value: nip05 };
 }
 
-function AuthorBadge({ user }: { user: NDKUser }) {
+function AuthorBadge({ user, onAuthorClick }: { user: NDKUser, onAuthorClick?: (npub: string) => void }) {
   const [loaded, setLoaded] = useState(false);
   const [name, setName] = useState('');
   const { isVerified, value } = useNip05Status(user);
@@ -103,15 +103,14 @@ function AuthorBadge({ user }: { user: NDKUser }) {
   return (
     <div className="flex items-center gap-2">
       {loaded ? (
-        <a
-          href={profileUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="font-medium text-gray-100 hover:underline truncate max-w-[10rem]"
+        <button
+          type="button"
+          onClick={() => onAuthorClick && onAuthorClick(user.npub)}
+          className="font-medium text-gray-100 hover:underline truncate max-w-[10rem] text-left"
           title={name || 'Unknown'}
         >
           {name || 'Unknown'}
-        </a>
+        </button>
       ) : (
         <span className="font-medium text-gray-100 truncate max-w-[10rem]">Loading...</span>
       )}
@@ -245,6 +244,15 @@ function SearchComponent() {
     });
   }
 
+  const goToProfile = useCallback((npub: string) => {
+    const nextQuery = `p:${npub}`;
+    setQuery(nextQuery);
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('q', nextQuery);
+    router.replace(`?${params.toString()}`);
+    handleSearch(nextQuery);
+  }, [handleSearch, router, searchParams]);
+
   const renderNoteBody = (event: NDKEvent) => (
     <>
       <p className="text-gray-100 whitespace-pre-wrap break-words">{stripMediaUrls(event.content)}</p>
@@ -278,7 +286,7 @@ function SearchComponent() {
       )}
       <div className="mt-2 flex justify-between items-center text-sm text-gray-400">
         <div className="flex items-center gap-2">
-          <AuthorBadge user={event.author} />
+          <AuthorBadge user={event.author} onAuthorClick={goToProfile} />
         </div>
         <a
           href={`https://njump.me/${nip19.neventEncode({ id: event.id })}`}
@@ -529,7 +537,7 @@ function SearchComponent() {
                           unoptimized
                         />
                       )}
-                      <AuthorBadge user={event.author} />
+                      <AuthorBadge user={event.author} onAuthorClick={goToProfile} />
                     </div>
                     {event.author.profile?.about && (
                       <p className="mt-4 text-gray-300">{event.author.profile.about}</p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -94,7 +94,19 @@ function AuthorBadge({ user }: { user: NDKUser }) {
 
   return (
     <div className="flex items-center gap-2">
-      <span className="font-medium text-gray-100 truncate max-w-[10rem]">{loaded ? (name || 'Unknown') : 'Loading...'}</span>
+      {loaded ? (
+        <a
+          href={`https://npub.world/${user.npub}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-gray-100 hover:underline truncate max-w-[10rem]"
+          title={name || 'Unknown'}
+        >
+          {name || 'Unknown'}
+        </a>
+      ) : (
+        <span className="font-medium text-gray-100 truncate max-w-[10rem]">Loading...</span>
+      )}
       <span className="text-sm truncate">{nip05Part}</span>
     </div>
   );

--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -79,6 +79,7 @@ export function LoginButton() {
 
   return (
     <button
+      id="header-avatar"
       onClick={user ? handleLogout : handleLogin}
       className="fixed top-4 right-4 hover:opacity-90 transition-opacity"
       aria-label={user ? 'Open profile / logout' : 'login'}

--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -3,6 +3,7 @@
 import { login, restoreLogin, logout } from '@/lib/nip07';
 import { useState, useEffect } from 'react';
 import { NDKUser } from '@nostr-dev-kit/ndk';
+import Image from 'next/image';
 
 function getDisplayName(user: NDKUser): string {
   if (!user) return '';
@@ -79,9 +80,29 @@ export function LoginButton() {
   return (
     <button
       onClick={user ? handleLogout : handleLogin}
-      className="fixed top-4 right-4 text-sm text-gray-400 hover:text-gray-200 transition-colors"
+      className="fixed top-4 right-4 hover:opacity-90 transition-opacity"
+      aria-label={user ? 'Open profile / logout' : 'login'}
     >
-      {user ? getDisplayName(user) : 'login'}
+      {user ? (
+        <div className="w-10 h-10 rounded-lg overflow-hidden bg-[#3d3d3d] border border-[#3d3d3d]">
+          {user.profile?.image ? (
+            <Image
+              src={user.profile.image}
+              alt="Profile"
+              width={40}
+              height={40}
+              className="w-full h-full object-cover"
+              unoptimized
+            />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center text-xs text-gray-300">
+              {getDisplayName(user).slice(0, 2).toUpperCase()}
+            </div>
+          )}
+        </div>
+      ) : (
+        <span className="text-sm text-gray-400 hover:text-gray-200">login</span>
+      )}
     </button>
   );
 } 


### PR DESCRIPTION
This PR refines the UI and UX across the app. It replaces the header name with an avatar, ensures remote images load reliably, adds clickable profile names/NIP-05/timestamps, and introduces reply threading with expandable parent notes. It also adds a subtle footer with links and fixes layout overlaps.

- Show square avatar in header; fix search overlap dynamically
- Load all remote images; add clickable npub.world and njump links
- Indicate and expand replies (supports nested chains); add subtle footer