### PR TITLE
Add inline nevent rendering with EventCard component

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -31,11 +31,11 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
       <div className={contentClasses}>{renderContent(event.content || '')}</div>
       {variant !== 'inline' && mediaRenderer ? mediaRenderer(event.content || '') : null}
       {showFooter && (
-        <div className={variant === 'inline' ? 'text-xs text-gray-300 pt-1 border-t border-[#3d3d3d]' : 'mt-4 text-xs text-gray-300 bg-[#2d2d2d] border-t border-[#3d3d3d] -mx-4 -mb-4 px-4 py-2 flex items-center justify-between gap-2 flex-wrap rounded-b-lg'}>
+        <div className={variant === 'inline' ? 'text-xs text-gray-300 pt-1 border-t border-[#3d3d3d] flex items-center justify-between gap-2' : 'mt-4 text-xs text-gray-300 bg-[#2d2d2d] border-t border-[#3d3d3d] -mx-4 -mb-4 px-4 py-2 flex items-center justify-between gap-2 flex-wrap rounded-b-lg'}>
           <div className="flex items-center gap-2">
             <AuthorBadge user={event.author} onAuthorClick={onAuthorClick} />
           </div>
-          {variant !== 'inline' ? (
+          {footerRight ? (
             <div className="flex items-center gap-2">{footerRight}</div>
           ) : null}
         </div>

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { NDKEvent } from '@nostr-dev-kit/ndk';
+import AuthorBadge from '@/components/AuthorBadge';
+import Image from 'next/image';
+
+type Props = {
+  event: NDKEvent;
+  onAuthorClick?: (npub: string) => void;
+  renderContent: (content: string) => React.ReactNode;
+  variant?: 'card' | 'inline';
+  mediaRenderer?: (content: string) => React.ReactNode;
+  footerRight?: React.ReactNode;
+  className?: string;
+  showFooter?: boolean;
+};
+
+function extractImageUrls(text: string): string[] {
+  if (!text) return [];
+  const regex = /(https?:\/\/[^\s'"<>]+?\.(?:png|jpe?g|gif|gifs|apng|webp|avif|svg))(?!\w)/gi;
+  const matches: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = regex.exec(text)) !== null) {
+    const url = m[1].replace(/[),.;]+$/, '').trim();
+    if (!matches.includes(url)) matches.push(url);
+  }
+  return matches.slice(0, 3);
+}
+
+function extractVideoUrls(text: string): string[] {
+  if (!text) return [];
+  const regex = /(https?:\/\/[^\s'"<>]+?\.(?:mp4|webm|ogg|ogv|mov|m4v))(?!\w)/gi;
+  const matches: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = regex.exec(text)) !== null) {
+    const url = m[1].replace(/[),.;]+$/, '').trim();
+    if (!matches.includes(url)) matches.push(url);
+  }
+  return matches.slice(0, 2);
+}
+
+export default function EventCard({ event, onAuthorClick, renderContent, variant = 'card', mediaRenderer, footerRight, className, showFooter = true }: Props) {
+  const baseContainerClasses = variant === 'inline'
+    ? 'flex w-full max-w-full flex-col gap-1 px-3 py-2 rounded-md bg-[#1f1f1f] border border-[#3d3d3d]'
+    : 'relative p-4 bg-[#2d2d2d] border border-[#3d3d3d] rounded-lg';
+  const containerClasses = className ? `${baseContainerClasses} ${className}` : baseContainerClasses;
+
+  const contentClasses = variant === 'inline'
+    ? 'text-gray-100 whitespace-pre-wrap break-words'
+    : 'text-gray-100 whitespace-pre-wrap break-words';
+
+  return (
+    <div className={containerClasses}>
+      <div className={contentClasses}>{renderContent(event.content || '')}</div>
+      {variant !== 'inline' && mediaRenderer ? mediaRenderer(event.content || '') : null}
+      {showFooter && (
+        <div className={variant === 'inline' ? 'text-xs text-gray-300 pt-1 border-t border-[#3d3d3d]' : 'mt-4 text-xs text-gray-300 bg-[#2d2d2d] border-t border-[#3d3d3d] -mx-4 -mb-4 px-4 py-2 flex items-center justify-between gap-2 flex-wrap rounded-b-lg'}>
+          <div className="flex items-center gap-2">
+            <AuthorBadge user={event.author} onAuthorClick={onAuthorClick} />
+          </div>
+          {variant !== 'inline' ? (
+            <div className="flex items-center gap-2">{footerRight}</div>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}
+
+

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -2,7 +2,6 @@
 
 import { NDKEvent } from '@nostr-dev-kit/ndk';
 import AuthorBadge from '@/components/AuthorBadge';
-import Image from 'next/image';
 
 type Props = {
   event: NDKEvent;
@@ -15,29 +14,7 @@ type Props = {
   showFooter?: boolean;
 };
 
-function extractImageUrls(text: string): string[] {
-  if (!text) return [];
-  const regex = /(https?:\/\/[^\s'"<>]+?\.(?:png|jpe?g|gif|gifs|apng|webp|avif|svg))(?!\w)/gi;
-  const matches: string[] = [];
-  let m: RegExpExecArray | null;
-  while ((m = regex.exec(text)) !== null) {
-    const url = m[1].replace(/[),.;]+$/, '').trim();
-    if (!matches.includes(url)) matches.push(url);
-  }
-  return matches.slice(0, 3);
-}
-
-function extractVideoUrls(text: string): string[] {
-  if (!text) return [];
-  const regex = /(https?:\/\/[^\s'"<>]+?\.(?:mp4|webm|ogg|ogv|mov|m4v))(?!\w)/gi;
-  const matches: string[] = [];
-  let m: RegExpExecArray | null;
-  while ((m = regex.exec(text)) !== null) {
-    const url = m[1].replace(/[),.;]+$/, '').trim();
-    if (!matches.includes(url)) matches.push(url);
-  }
-  return matches.slice(0, 2);
-}
+// No local media helpers; media should be rendered by the provided mediaRenderer prop to keep this component generic.
 
 export default function EventCard({ event, onAuthorClick, renderContent, variant = 'card', mediaRenderer, footerRight, className, showFooter = true }: Props) {
   const baseContainerClasses = variant === 'inline'

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { connect, getCurrentExample, nextExample, ndk, ConnectionStatus, addConnectionStatusListener, removeConnectionStatusListener, getRecentlyActiveRelays } from '@/lib/ndk';
-import { NDKEvent, NDKUser, NDKRelaySet } from '@nostr-dev-kit/ndk';
+import { NDKEvent, NDKRelaySet, NDKUser } from '@nostr-dev-kit/ndk';
 import { searchEvents } from '@/lib/search';
 
 import { useSearchParams, useRouter } from 'next/navigation';
@@ -12,121 +12,14 @@ import ProfileCard from '@/components/ProfileCard';
 import { nip19 } from 'nostr-tools';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import emojiRegex from 'emoji-regex';
-import { faArrowUpRightFromSquare, faCircleCheck, faCircleXmark, faCircleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 
 type Props = {
   initialQuery?: string;
   manageUrl?: boolean;
 };
 
-type Nip05CheckResult = {
-  isVerified: boolean;
-  value: string | undefined;
-};
-
-const nip05Cache = new Map<string, boolean>();
-
-async function verifyNip05(pubkeyHex: string, nip05?: string): Promise<boolean> {
-  if (!nip05) return false;
-  const cacheKey = `${nip05}|${pubkeyHex}`;
-  if (nip05Cache.has(cacheKey)) return nip05Cache.get(cacheKey) as boolean;
-
-  try {
-    const [namePart, domainPartCandidate] = nip05.includes('@') ? nip05.split('@') : ['_', nip05];
-    const name = namePart || '_';
-    const domain = (domainPartCandidate || '').trim();
-    if (!domain) {
-      nip05Cache.set(cacheKey, false);
-      return false;
-    }
-    const url = `https://${domain}/.well-known/nostr.json?name=${encodeURIComponent(name)}`;
-    const res = await fetch(url, { method: 'GET' });
-    if (!res.ok) {
-      nip05Cache.set(cacheKey, false);
-      return false;
-    }
-    const data = await res.json();
-    const mapped = (data?.names?.[name] as string | undefined)?.toLowerCase();
-    const result = mapped === pubkeyHex.toLowerCase();
-    nip05Cache.set(cacheKey, result);
-    return result;
-  } catch {
-    nip05Cache.set(cacheKey, false);
-    return false;
-  }
-}
-
-function useNip05Status(user: NDKUser): Nip05CheckResult {
-  const [verified, setVerified] = useState(false);
-  const nip05 = user.profile?.nip05;
-  const pubkey = user.pubkey;
-
-  useEffect(() => {
-    let isMounted = true;
-    (async () => {
-      const result = await verifyNip05(pubkey, nip05);
-      if (isMounted) setVerified(result);
-    })();
-    return () => { isMounted = false; };
-  }, [pubkey, nip05]);
-
-  return { isVerified: verified, value: nip05 };
-}
-
-function AuthorBadge({ user, onAuthorClick }: { user: NDKUser, onAuthorClick?: (npub: string) => void }) {
-  const [loaded, setLoaded] = useState(false);
-  const [name, setName] = useState('');
-  const { isVerified, value } = useNip05Status(user);
-
-  useEffect(() => {
-    let isMounted = true;
-    (async () => {
-      try {
-        await user.fetchProfile();
-      } catch {}
-      if (!isMounted) return;
-      const display = user.profile?.displayName || user.profile?.name || '';
-      setName(display);
-      setLoaded(true);
-    })();
-    return () => { isMounted = false; };
-  }, [user]);
-
-  const nip05Part = value ? (
-    <button
-      type="button"
-      onClick={() => onAuthorClick && onAuthorClick(user.npub)}
-      className={`inline-flex items-center gap-1 ${isVerified ? 'text-green-400' : 'text-red-400'} hover:underline`}
-      title={value}
-    >
-      <FontAwesomeIcon icon={isVerified ? faCircleCheck : faCircleXmark} className="h-3 w-3" />
-      <span className="truncate max-w-[14rem]">{value}</span>
-    </button>
-  ) : (
-    <span className="inline-flex items-center gap-1 text-yellow-400">
-      <FontAwesomeIcon icon={faCircleExclamation} className="h-3 w-3" />
-      <span className="text-gray-400">no NIP-05</span>
-    </span>
-  );
-
-  return (
-    <div className="flex items-center gap-2">
-      {loaded ? (
-        <button
-          type="button"
-          onClick={() => onAuthorClick && onAuthorClick(user.npub)}
-          className="font-medium text-gray-100 hover:underline truncate max-w-[10rem] text-left"
-          title={name || 'Unknown'}
-        >
-          {name || 'Unknown'}
-        </button>
-      ) : (
-        <span className="font-medium text-gray-100 truncate max-w-[10rem]">Loading...</span>
-      )}
-      <span className="truncate">{nip05Part}</span>
-    </div>
-  );
-}
+// (Local AuthorBadge removed; using global `components/AuthorBadge` inside EventCard.)
 
 export default function SearchView({ initialQuery = '', manageUrl = true }: Props) {
   const router = useRouter();
@@ -647,7 +540,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
               } else {
                 setError('Not found');
               }
-            } catch (e) {
+            } catch {
               if (!isMounted) return;
               setError('Invalid nevent');
             } finally {

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -561,10 +561,8 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
           );
         }
 
-        const created = embedded.created_at ? new Date(embedded.created_at * 1000).toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }) : '';
         return (
           <div className="w-full">
-            <div className="text-xs text-gray-400 mb-1">Quoted note{created ? ` · ${created}` : ''}</div>
             <EventCard
               event={embedded}
               onAuthorClick={goToProfile}
@@ -574,6 +572,9 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
                 </div>
               )}
               variant="inline"
+              footerRight={embedded.created_at ? (
+                <span className="opacity-80">{new Date(embedded.created_at * 1000).toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}</span>
+              ) : null}
             />
           </div>
         );

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -573,7 +573,26 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
               )}
               variant="inline"
               footerRight={embedded.created_at ? (
-                <span className="opacity-80">{new Date(embedded.created_at * 1000).toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}</span>
+                <button
+                  type="button"
+                  className="text-xs hover:underline opacity-80"
+                  title="Search this nevent"
+                  onClick={() => {
+                    try {
+                      const nevent = nip19.neventEncode({ id: embedded.id });
+                      const q = nevent;
+                      setQuery(q);
+                      if (manageUrl) {
+                        const params = new URLSearchParams(searchParams.toString());
+                        params.set('q', q);
+                        router.replace(`?${params.toString()}`);
+                      }
+                      handleSearch(q);
+                    } catch {}
+                  }}
+                >
+                  {new Date(embedded.created_at * 1000).toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
+                </button>
               ) : null}
             />
           </div>

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -603,11 +603,11 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
             const coreToken2 = m2 ? m2[1] : sub;
             const trailing2 = (m2 && m2[2]) || '';
             finalNodes.push(
-              <span key={`nevent-${segIndex}-${chunkIdx}-${subIdx}`} className="inline">
+              <div key={`nevent-${segIndex}-${chunkIdx}-${subIdx}`} className="my-2 w-full">
                 <InlineNevent token={coreToken2} />
-                {trailing2}
-              </span>
+              </div>
             );
+            if (trailing2) finalNodes.push(trailing2);
             return;
           }
 
@@ -790,7 +790,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
             event={parentEvent}
             onAuthorClick={goToProfile}
             renderContent={(text) => (
-              <p className="text-gray-100 whitespace-pre-wrap break-words">{renderContentWithClickableHashtags(text)}</p>
+              <div className="text-gray-100 whitespace-pre-wrap break-words">{renderContentWithClickableHashtags(text)}</div>
             )}
             mediaRenderer={renderNoteMedia}
             className="p-0 border-0 bg-transparent"
@@ -1006,7 +1006,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
                     event={event}
                     onAuthorClick={goToProfile}
                     renderContent={(text) => (
-                      <p className="text-gray-100 whitespace-pre-wrap break-words">{renderContentWithClickableHashtags(text)}</p>
+                      <div className="text-gray-100 whitespace-pre-wrap break-words">{renderContentWithClickableHashtags(text)}</div>
                     )}
                     mediaRenderer={renderNoteMedia}
                     footerRight={(

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -552,7 +552,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
 
         if (loading) {
           return (
-            <span className="inline-block align-middle text-gray-400 bg-[#262626] border border-[#3d3d3d] rounded px-2 py-1">Loading quote…</span>
+            <span className="inline-block align-middle text-gray-400 bg-[#262626] border border-[#3d3d3d] rounded px-2 py-1">Loading note...</span>
           );
         }
         if (error || !embedded) {

--- a/src/lib/examples.ts
+++ b/src/lib/examples.ts
@@ -5,6 +5,7 @@ export const searchExamples = [
   '#PenisButter',
   '#YESTR',
   '#SovEng',
+  'nevent',
   
   // Author
   'by:dergigi',


### PR DESCRIPTION
Implements inline rendering of nostr:nevent tokens as embedded quoted notes with a reusable EventCard component. The feature fetches events by ID using relay hints from nevent, renders them as full-width inline cards, and prevents infinite nesting by disabling nevent parsing within embeds. The EventCard component provides consistent rendering across main notes and embedded quotes with configurable variants and content slots.

- Added `EventCard` component for unified note rendering with card and inline variants
- Enhanced `renderContentWithClickableHashtags` to detect and render nostr:nevent tokens
- Fixed HTML nesting issues by using divs instead of p elements for content containers