### PR TITLE
Add URL previews with Open Graph support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fortawesome/react-fontawesome": "^0.2.3",
         "@nostr-dev-kit/ndk": "^2.14.33",
         "@nostr-dev-kit/ndk-cache-dexie": "^2.5.15",
-        "cheerio": "^1.0.0-rc.12",
+        "fetch-opengraph": "^1.0.36",
         "next": "^15.4.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -3830,6 +3830,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -3944,12 +3953,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "license": "ISC"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -4155,44 +4158,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/cheerio": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
-      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
-      "license": "MIT",
-      "dependencies": {
-        "cheerio-select": "^2.1.0",
-        "dom-serializer": "^2.0.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "htmlparser2": "^8.0.1",
-        "parse5": "^7.0.0",
-        "parse5-htmlparser2-tree-adapter": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
-      }
-    },
-    "node_modules/cheerio-select": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-select": "^5.1.0",
-        "css-what": "^6.1.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
     "node_modules/chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -4337,34 +4302,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/css-select": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-what": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/csstype": {
@@ -4559,61 +4496,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4675,18 +4557,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -5462,6 +5332,16 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-opengraph": {
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/fetch-opengraph/-/fetch-opengraph-1.0.36.tgz",
+      "integrity": "sha512-w2Gs64zjL1O86E0I6E26MrxeXpTrR8Y1vWrgupmZN6NXKV8F5I3W0tlh+ZX686jZwxyilWnQjYwgnWpdETdHWw==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^0.21.1",
+        "html-entities": "^2.3.2"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -5525,6 +5405,26 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -5956,31 +5856,28 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/htmlparser2": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
-      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -8206,18 +8103,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/nth-check": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -8481,43 +8366,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
-      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
-      "license": "MIT",
-      "dependencies": {
-        "domhandler": "^5.0.3",
-        "parse5": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/path-exists": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@fortawesome/react-fontawesome": "^0.2.3",
         "@nostr-dev-kit/ndk": "^2.14.33",
         "@nostr-dev-kit/ndk-cache-dexie": "^2.5.15",
+        "cheerio": "^1.0.0-rc.12",
         "next": "^15.4.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -3944,6 +3945,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -4148,6 +4155,44 @@
         "node": ">=10"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "htmlparser2": "^8.0.1",
+        "parse5": "^7.0.0",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -4292,6 +4337,34 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/csstype": {
@@ -4486,6 +4559,61 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4547,6 +4675,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -5822,6 +5962,25 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -8047,6 +8206,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -8310,6 +8481,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/path-exists": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@fortawesome/react-fontawesome": "^0.2.3",
     "@nostr-dev-kit/ndk": "^2.14.33",
     "@nostr-dev-kit/ndk-cache-dexie": "^2.5.15",
-    "cheerio": "^1.0.0-rc.12",
+    "fetch-opengraph": "^1.0.36",
     "next": "^15.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@fortawesome/react-fontawesome": "^0.2.3",
     "@nostr-dev-kit/ndk": "^2.14.33",
     "@nostr-dev-kit/ndk-cache-dexie": "^2.5.15",
+    "cheerio": "^1.0.0-rc.12",
     "next": "^15.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/src/app/api/og/route.ts
+++ b/src/app/api/og/route.ts
@@ -1,0 +1,172 @@
+import { NextRequest, NextResponse } from 'next/server';
+import * as cheerio from 'cheerio';
+import { isIP } from 'net';
+
+// Runtime hint: nodejs for network and cheerio
+export const runtime = 'nodejs';
+
+type OgResult = {
+  url: string;
+  title?: string;
+  description?: string;
+  image?: string;
+  siteName?: string;
+  type?: string;
+  favicon?: string;
+};
+
+function isHttpUrl(u: URL): boolean {
+  return u.protocol === 'http:' || u.protocol === 'https:';
+}
+
+function isBlockedHostname(hostname: string): boolean {
+  const lower = hostname.toLowerCase();
+  if (lower === 'localhost' || lower.endsWith('.localhost') || lower.endsWith('.local')) return true;
+  if (lower === '0.0.0.0') return true;
+  return false;
+}
+
+function isPrivateIp(ip: string): boolean {
+  // IPv4 ranges
+  const parts = ip.split('.').map((x) => parseInt(x, 10));
+  if (parts.length === 4 && parts.every((n) => !Number.isNaN(n))) {
+    const [a, b] = parts;
+    if (a === 10) return true; // 10.0.0.0/8
+    if (a === 127) return true; // 127.0.0.0/8 loopback
+    if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+    if (a === 192 && b === 168) return true; // 192.168.0.0/16
+    if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local
+    if (a === 0) return true; // 0.0.0.0/8
+  }
+  // IPv6
+  if (ip === '::1') return true; // loopback
+  if (ip.startsWith('fe80:') || ip.startsWith('fe80::')) return true; // link-local
+  if (ip.startsWith('fc') || ip.startsWith('fd')) return true; // unique local
+  return false;
+}
+
+function resolveUrlMaybe(base: URL, value?: string | null): string | undefined {
+  if (!value) return undefined;
+  try {
+    const absolute = new URL(value, base);
+    if (!isHttpUrl(absolute)) return undefined;
+    return absolute.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+async function fetchHtmlWithLimit(url: string, timeoutMs: number, maxBytes: number): Promise<string> {
+  const ac = new AbortController();
+  const t = setTimeout(() => ac.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      signal: ac.signal,
+      headers: {
+        'user-agent': 'ants-og-fetcher/1.0 (+https://ants.dergigi.com)'
+      },
+      redirect: 'follow',
+      cache: 'no-store'
+    } as RequestInit);
+    if (!res.ok) {
+      throw new Error(`Upstream status ${res.status}`);
+    }
+    const contentType = res.headers.get('content-type') || '';
+    if (!/(text\/html|application\/xhtml\+xml)/i.test(contentType)) {
+      throw new Error('Unsupported content-type');
+    }
+    const finalUrl = res.url || url;
+    try {
+      const finalU = new URL(finalUrl);
+      if (isBlockedHostname(finalU.hostname)) throw new Error('Blocked host');
+      // If direct IP, block private ranges
+      if (isIP(finalU.hostname)) {
+        if (isPrivateIp(finalU.hostname)) throw new Error('Blocked IP');
+      }
+    } catch {
+      throw new Error('Invalid redirect');
+    }
+    // Stream read up to maxBytes
+    const reader = res.body?.getReader();
+    if (!reader) return '';
+    const chunks: Uint8Array[] = [];
+    let received = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      received += value.byteLength;
+      if (received > maxBytes) {
+        chunks.push(value.slice(0, Math.max(0, maxBytes - (received - value.byteLength))));
+        break;
+      }
+      chunks.push(value);
+    }
+    const buf = Buffer.concat(chunks.map((c) => Buffer.from(c)));
+    return buf.toString('utf8');
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+function extractOg(url: URL, html: string): OgResult {
+  const $ = cheerio.load(html);
+  const get = (sel: string) => $(sel).attr('content') || $(sel).attr('value') || undefined;
+
+  const ogTitle = get('meta[property="og:title"]') || get('meta[name="og:title"]');
+  const ogDescription = get('meta[property="og:description"]') || get('meta[name="og:description"]');
+  const ogImage = get('meta[property="og:image"]') || get('meta[name="og:image"]');
+  const ogSite = get('meta[property="og:site_name"]') || get('meta[name="og:site_name"]');
+  const ogType = get('meta[property="og:type"]') || get('meta[name="og:type"]');
+
+  const twTitle = get('meta[name="twitter:title"]');
+  const twDescription = get('meta[name="twitter:description"]');
+  const twImage = get('meta[name="twitter:image"]') || get('meta[name="twitter:image:src"]');
+
+  const title = ogTitle || twTitle || $('title').first().text() || undefined;
+  const description = ogDescription || twDescription || $('meta[name="description"]').attr('content') || undefined;
+  const image = resolveUrlMaybe(url, ogImage || twImage || undefined);
+  const siteName = ogSite || new URL(url.origin).hostname;
+  const type = ogType;
+
+  // Favicon detection
+  let faviconHref = $('link[rel="icon"], link[rel="shortcut icon"], link[rel="apple-touch-icon"]').attr('href') || undefined;
+  const favicon = resolveUrlMaybe(url, faviconHref) || resolveUrlMaybe(url, '/favicon.ico');
+
+  return { url: url.toString(), title, description, image, siteName, type, favicon };
+}
+
+export async function GET(req: NextRequest) {
+  const urlParam = req.nextUrl.searchParams.get('url');
+  if (!urlParam) {
+    return NextResponse.json({ error: 'Missing url parameter' }, { status: 400 });
+  }
+  let u: URL;
+  try {
+    u = new URL(urlParam);
+  } catch {
+    return NextResponse.json({ error: 'Invalid URL' }, { status: 400 });
+  }
+  if (!isHttpUrl(u)) {
+    return NextResponse.json({ error: 'Only http(s) URLs are allowed' }, { status: 400 });
+  }
+  if (isBlockedHostname(u.hostname)) {
+    return NextResponse.json({ error: 'Blocked host' }, { status: 400 });
+  }
+  if (isIP(u.hostname) && isPrivateIp(u.hostname)) {
+    return NextResponse.json({ error: 'Blocked IP' }, { status: 400 });
+  }
+
+  try {
+    const html = await fetchHtmlWithLimit(u.toString(), 8000, 512 * 1024);
+    const data = extractOg(u, html);
+    // Short cache headers (10 minutes) to reduce repeated fetches
+    const res = NextResponse.json(data, { status: 200 });
+    res.headers.set('Cache-Control', 'public, max-age=600, s-maxage=600, stale-while-revalidate=86400');
+    return res;
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || 'Fetch failed' }, { status: 502 });
+  }
+}
+
+

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -800,7 +800,34 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
       {extractNonMediaUrls(content).length > 0 && (
         <div className="mt-3 grid grid-cols-1 gap-3">
           {extractNonMediaUrls(content).map((u) => (
-            <UrlPreview key={u} url={u} />
+            <UrlPreview
+              key={u}
+              url={u}
+              onSearch={(targetUrl) => {
+                const nextQuery = targetUrl;
+                setQuery(nextQuery);
+                if (manageUrl) {
+                  const params = new URLSearchParams(searchParams.toString());
+                  params.set('q', nextQuery);
+                  router.replace(`?${params.toString()}`);
+                }
+                (async () => {
+                  setLoading(true);
+                  try {
+                    const searchResults = await searchEvents(nextQuery, undefined as unknown as number, { exact: true }, undefined, abortControllerRef.current?.signal);
+                    setResults(searchResults);
+                  } catch (error) {
+                    if (error instanceof Error && (error.name === 'AbortError' || error.message === 'Search aborted')) {
+                      return;
+                    }
+                    console.error('Search error:', error);
+                    setResults([]);
+                  } finally {
+                    setLoading(false);
+                  }
+                })();
+              }}
+            />
           ))}
         </div>
       )}

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -13,7 +13,7 @@ import ProfileCard from '@/components/ProfileCard';
 import { nip19 } from 'nostr-tools';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import emojiRegex from 'emoji-regex';
-import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
+import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 
 type Props = {
   initialQuery?: string;
@@ -414,8 +414,20 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
         const cleanedUrl = segment.replace(/[),.;]+$/, '').trim();
         finalNodes.push(
           <span key={`url-${segIndex}`} className="inline-flex items-center gap-1">
+            <a
+              href={cleanedUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-400 hover:text-blue-300 hover:underline break-all"
+              onClick={(e) => { e.stopPropagation(); }}
+              title={cleanedUrl}
+            >
+              {cleanedUrl}
+            </a>
             <button
               type="button"
+              title="Search for this URL"
+              className="p-0.5 text-gray-400 hover:text-gray-200 opacity-70"
               onClick={() => {
                 const nextQuery = cleanedUrl;
                 setQuery(nextQuery);
@@ -424,14 +436,12 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
                   params.set('q', nextQuery);
                   router.replace(`?${params.toString()}`);
                 }
-                // Perform exact search for URLs clicked in UI
                 (async () => {
                   setLoading(true);
                   try {
                     const searchResults = await searchEvents(nextQuery, undefined as unknown as number, { exact: true }, undefined, abortControllerRef.current?.signal);
                     setResults(searchResults);
                   } catch (error) {
-                    // Don't log aborted searches as errors
                     if (error instanceof Error && (error.name === 'AbortError' || error.message === 'Search aborted')) {
                       return;
                     }
@@ -442,23 +452,9 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
                   }
                 })();
               }}
-              className="text-blue-400 hover:text-blue-300 hover:underline break-all"
-              title="Search for this URL"
             >
-              {cleanedUrl}
+              <FontAwesomeIcon icon={faMagnifyingGlass} className="text-xs" />
             </button>
-            <a
-              href={cleanedUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              title="Open link in new tab"
-              className="opacity-80 hover:opacity-100"
-              onClick={(e) => {
-                e.stopPropagation();
-              }}
-            >
-              <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-gray-400 text-xs" />
-            </a>
           </span>
         );
         return;

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -45,6 +45,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
   const [rotationProgress, setRotationProgress] = useState(0);
   const [showConnectionDetails, setShowConnectionDetails] = useState(false);
   const [recentlyActive, setRecentlyActive] = useState<string[]>([]);
+  const [successfulPreviews, setSuccessfulPreviews] = useState<Set<string>>(new Set());
   // Simple input change handler: update local query state; searches run on submit
   const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setQuery(e.target.value);
@@ -387,10 +388,8 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
 
   const stripPreviewUrls = (text: string): string => {
     if (!text) return '';
-    const nonMediaUrls = extractNonMediaUrls(text);
     let cleaned = text;
-    nonMediaUrls.forEach(url => {
-      // Escape special regex characters in the URL
+    successfulPreviews.forEach(url => {
       const escapedUrl = url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       const regex = new RegExp(escapedUrl.replace(/[),.;]+$/, ''), 'gi');
       cleaned = cleaned.replace(regex, '');
@@ -803,6 +802,14 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
             <UrlPreview
               key={u}
               url={u}
+              onLoaded={(loadedUrl) => {
+                setSuccessfulPreviews((prev) => {
+                  if (prev.has(loadedUrl)) return prev;
+                  const next = new Set(prev);
+                  next.add(loadedUrl);
+                  return next;
+                });
+              }}
               onSearch={(targetUrl) => {
                 const nextQuery = targetUrl;
                 setQuery(nextQuery);

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -8,6 +8,7 @@ import { searchEvents } from '@/lib/search';
 import { useSearchParams, useRouter } from 'next/navigation';
 import Image from 'next/image';
 import EventCard from '@/components/EventCard';
+import UrlPreview from '@/components/UrlPreview';
 import ProfileCard from '@/components/ProfileCard';
 import { nip19 } from 'nostr-tools';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -342,6 +343,22 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
       if (!matches.includes(url)) matches.push(url);
     }
     return matches.slice(0, 2);
+  };
+
+  const extractNonMediaUrls = (text: string): string[] => {
+    if (!text) return [];
+    const urlRegex = /(https?:\/\/[^\s'"<>]+)(?!\w)/gi;
+    const imageExt = /\.(?:png|jpe?g|gif|gifs|apng|webp|avif|svg)(?:$|[?#])/i;
+    const videoExt = /\.(?:mp4|webm|ogg|ogv|mov|m4v)(?:$|[?#])/i;
+    const urls: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = urlRegex.exec(text)) !== null) {
+      const raw = m[1].replace(/[),.;]+$/, '').trim();
+      if (!imageExt.test(raw) && !videoExt.test(raw) && !urls.includes(raw)) {
+        urls.push(raw);
+      }
+    }
+    return urls.slice(0, 2);
   };
 
   const getFilenameFromUrl = (url: string): string => {
@@ -764,6 +781,13 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
                 Your browser does not support the video tag.
               </video>
             </div>
+          ))}
+        </div>
+      )}
+      {extractNonMediaUrls(content).length > 0 && (
+        <div className="mt-3 grid grid-cols-1 gap-3">
+          {extractNonMediaUrls(content).map((u) => (
+            <UrlPreview key={u} url={u} />
           ))}
         </div>
       )}

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -385,8 +385,21 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
     return cleaned.replace(/\s{2,}/g, ' ').trim();
   };
 
+  const stripPreviewUrls = (text: string): string => {
+    if (!text) return '';
+    const nonMediaUrls = extractNonMediaUrls(text);
+    let cleaned = text;
+    nonMediaUrls.forEach(url => {
+      // Escape special regex characters in the URL
+      const escapedUrl = url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const regex = new RegExp(escapedUrl.replace(/[),.;]+$/, ''), 'gi');
+      cleaned = cleaned.replace(regex, '');
+    });
+    return cleaned.replace(/\s{2,}/g, ' ').trim();
+  };
+
   const renderContentWithClickableHashtags = (content: string, options?: { disableNevent?: boolean }) => {
-    const strippedContent = stripMediaUrls(content);
+    const strippedContent = stripPreviewUrls(stripMediaUrls(content));
     if (!strippedContent) return null;
 
     const urlRegex = /(https?:\/\/[^\s'"<>]+)(?!\w)/gi;

--- a/src/components/UrlPreview.tsx
+++ b/src/components/UrlPreview.tsx
@@ -41,11 +41,12 @@ export default function UrlPreview({ url, className }: Props) {
         if (!res.ok) throw new Error(`${res.status}`);
         const json = (await res.json()) as OgData | { error: string };
         if (!mountedRef.current) return;
-        if ((json as any).error) throw new Error((json as any).error);
+        if ('error' in json) throw new Error(json.error);
         setData(json as OgData);
-      } catch (e: any) {
+      } catch (e: unknown) {
         if (!mountedRef.current) return;
-        setError(e?.message || 'Failed');
+        const errorMessage = e instanceof Error ? e.message : 'Failed';
+        setError(errorMessage);
       } finally {
         if (mountedRef.current) setLoading(false);
       }

--- a/src/components/UrlPreview.tsx
+++ b/src/components/UrlPreview.tsx
@@ -19,13 +19,15 @@ type Props = {
   url: string;
   className?: string;
   onSearch?: (url: string) => void;
+  onLoaded?: (url: string) => void;
 };
 
-export default function UrlPreview({ url, className, onSearch }: Props) {
+export default function UrlPreview({ url, className, onSearch, onLoaded }: Props) {
   const [data, setData] = useState<OgData | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const mountedRef = useRef(true);
+  const notifiedLoadedRef = useRef(false);
 
   const originHostname = useMemo(() => {
     try { return new URL(url).hostname; } catch { return ''; }
@@ -56,6 +58,14 @@ export default function UrlPreview({ url, className, onSearch }: Props) {
     })();
     return () => { mountedRef.current = false; ac.abort(); };
   }, [url]);
+
+  // Notify parent once after successful load
+  useEffect(() => {
+    if (!notifiedLoadedRef.current && data && !error && onLoaded) {
+      notifiedLoadedRef.current = true;
+      onLoaded(data.url || url);
+    }
+  }, [data, error, onLoaded, url]);
 
   if (loading) return null;
   if (error || !data) return null;

--- a/src/components/UrlPreview.tsx
+++ b/src/components/UrlPreview.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import Image from 'next/image';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+type OgData = {
+  url: string;
+  title?: string;
+  description?: string;
+  image?: string;
+  siteName?: string;
+  type?: string;
+  favicon?: string;
+};
+
+type Props = {
+  url: string;
+  className?: string;
+};
+
+export default function UrlPreview({ url, className }: Props) {
+  const [data, setData] = useState<OgData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const mountedRef = useRef(true);
+
+  const originHostname = useMemo(() => {
+    try { return new URL(url).hostname; } catch { return ''; }
+  }, [url]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    const ac = new AbortController();
+    setLoading(true);
+    setError(null);
+    setData(null);
+    (async () => {
+      try {
+        const params = new URLSearchParams({ url });
+        const res = await fetch(`/api/og?${params.toString()}`, { signal: ac.signal, cache: 'force-cache' });
+        if (!res.ok) throw new Error(`${res.status}`);
+        const json = (await res.json()) as OgData | { error: string };
+        if (!mountedRef.current) return;
+        if ((json as any).error) throw new Error((json as any).error);
+        setData(json as OgData);
+      } catch (e: any) {
+        if (!mountedRef.current) return;
+        setError(e?.message || 'Failed');
+      } finally {
+        if (mountedRef.current) setLoading(false);
+      }
+    })();
+    return () => { mountedRef.current = false; ac.abort(); };
+  }, [url]);
+
+  if (loading) return null;
+  if (error || !data) return null;
+
+  const title = data.title || originHostname;
+  const description = data.description || '';
+  const image = data.image;
+  const favicon = data.favicon;
+
+  return (
+    <a
+      href={data.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={
+        className ||
+        'block rounded-md border border-[#3d3d3d] bg-[#1f1f1f] overflow-hidden hover:border-[#4a4a4a] transition-colors'
+      }
+    >
+      <div className="flex gap-3 p-3">
+        {image ? (
+          <div className="relative flex-shrink-0 w-24 h-24 bg-[#2a2a2a] border border-[#3d3d3d] rounded overflow-hidden">
+            {/* next/image remote allowed in next.config.ts */}
+            <Image src={image} alt={title} fill sizes="96px" className="object-cover" unoptimized />
+          </div>
+        ) : null}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 text-sm text-gray-300 mb-1">
+            {favicon ? (
+              <Image src={favicon} alt="favicon" width={16} height={16} className="inline-block" unoptimized />
+            ) : null}
+            <span className="truncate opacity-80">{data.siteName || originHostname}</span>
+          </div>
+          <div className="text-gray-100 font-medium truncate mb-1">{title}</div>
+          {description ? (
+            <div className="text-gray-300 text-sm line-clamp-2 break-words">
+              {description}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </a>
+  );
+}
+
+

--- a/src/components/UrlPreview.tsx
+++ b/src/components/UrlPreview.tsx
@@ -76,7 +76,7 @@ export default function UrlPreview({ url, className, onSearch, onLoaded }: Props
   const favicon = data.favicon;
 
   return (
-    <div className={className || 'relative'}>
+    <div className={`relative group ${className || ''}`}>
       <a
         href={data.url}
         target="_blank"
@@ -112,7 +112,7 @@ export default function UrlPreview({ url, className, onSearch, onLoaded }: Props
       {onSearch ? (
         <button
           type="button"
-          className="absolute top-1.5 right-1.5 z-10 text-gray-300 hover:text-gray-100 bg-[#2a2a2a] hover:bg-[#3a3a3a] border border-[#3d3d3d] rounded p-1"
+          className="absolute top-1.5 right-1.5 z-10 p-0.5 text-gray-400 hover:text-gray-200 bg-transparent border-0 opacity-60 group-hover:opacity-100 transition-opacity"
           title="Search for this URL"
           onClick={(e) => {
             e.preventDefault();
@@ -120,7 +120,7 @@ export default function UrlPreview({ url, className, onSearch, onLoaded }: Props
             onSearch(data.url || url);
           }}
         >
-          <FontAwesomeIcon icon={faMagnifyingGlass} className="w-3 h-3" />
+          <FontAwesomeIcon icon={faMagnifyingGlass} className="w-3.5 h-3.5" />
         </button>
       ) : null}
     </div>

--- a/src/components/UrlPreview.tsx
+++ b/src/components/UrlPreview.tsx
@@ -2,6 +2,8 @@
 
 import Image from 'next/image';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 
 type OgData = {
   url: string;
@@ -16,9 +18,10 @@ type OgData = {
 type Props = {
   url: string;
   className?: string;
+  onSearch?: (url: string) => void;
 };
 
-export default function UrlPreview({ url, className }: Props) {
+export default function UrlPreview({ url, className, onSearch }: Props) {
   const [data, setData] = useState<OgData | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
@@ -63,38 +66,54 @@ export default function UrlPreview({ url, className }: Props) {
   const favicon = data.favicon;
 
   return (
-    <a
-      href={data.url}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={
-        className ||
-        'block rounded-md border border-[#3d3d3d] bg-[#1f1f1f] overflow-hidden hover:border-[#4a4a4a] transition-colors'
-      }
-    >
-      <div className="flex gap-3 p-3">
-        {image ? (
-          <div className="relative flex-shrink-0 w-24 h-24 bg-[#2a2a2a] border border-[#3d3d3d] rounded overflow-hidden">
-            {/* next/image remote allowed in next.config.ts */}
-            <Image src={image} alt={title} fill sizes="96px" className="object-cover" unoptimized />
-          </div>
-        ) : null}
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2 text-sm text-gray-300 mb-1">
-            {favicon ? (
-              <Image src={favicon} alt="favicon" width={16} height={16} className="inline-block" unoptimized />
-            ) : null}
-            <span className="truncate opacity-80">{data.siteName || originHostname}</span>
-          </div>
-          <div className="text-gray-100 font-medium truncate mb-1">{title}</div>
-          {description ? (
-            <div className="text-gray-300 text-sm line-clamp-2 break-words">
-              {description}
+    <div className={className || 'relative'}>
+      <a
+        href={data.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={
+          className ||
+          'block rounded-md border border-[#3d3d3d] bg-[#1f1f1f] overflow-hidden hover:border-[#4a4a4a] transition-colors'
+        }
+      >
+        <div className="flex gap-3 p-3">
+          {image ? (
+            <div className="relative flex-shrink-0 w-24 h-24 bg-[#2a2a2a] border border-[#3d3d3d] rounded overflow-hidden">
+              {/* next/image remote allowed in next.config.ts */}
+              <Image src={image} alt={title} fill sizes="96px" className="object-cover" unoptimized />
             </div>
           ) : null}
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2 text-sm text-gray-300 mb-1">
+              {favicon ? (
+                <Image src={favicon} alt="favicon" width={16} height={16} className="inline-block" unoptimized />
+              ) : null}
+              <span className="truncate opacity-80">{data.siteName || originHostname}</span>
+            </div>
+            <div className="text-gray-100 font-medium truncate mb-1">{title}</div>
+            {description ? (
+              <div className="text-gray-300 text-sm line-clamp-2 break-words">
+                {description}
+              </div>
+            ) : null}
+          </div>
         </div>
-      </div>
-    </a>
+      </a>
+      {onSearch ? (
+        <button
+          type="button"
+          className="absolute top-1.5 right-1.5 z-10 text-gray-300 hover:text-gray-100 bg-[#2a2a2a] hover:bg-[#3a3a3a] border border-[#3d3d3d] rounded p-1"
+          title="Search for this URL"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onSearch(data.url || url);
+          }}
+        >
+          <FontAwesomeIcon icon={faMagnifyingGlass} className="w-3 h-3" />
+        </button>
+      ) : null}
+    </div>
   );
 }
 

--- a/src/lib/examples.ts
+++ b/src/lib/examples.ts
@@ -5,6 +5,7 @@ export const searchExamples = [
   '#PenisButter',
   '#YESTR',
   '#SovEng',
+  '#News',
   'nevent',
   
   // Author


### PR DESCRIPTION
Implements rich link previews for URLs in notes using Open Graph meta tags. The feature includes a new API endpoint `/api/og` that fetches and parses HTML meta tags, a `UrlPreview` component for rendering preview cards, and integration into the search view to display up to 2 previews per note below media content.

- Added `extractNonMediaUrls` function to identify non-media URLs in note content
- Includes SSRF protection, content-type validation, and caching headers
- Added #News to search examples for better discoverability