### PR TITLE
Add kind filter examples to showcase new `is:*` shortcuts

### DIFF
--- a/src/lib/examples.ts
+++ b/src/lib/examples.ts
@@ -54,7 +54,7 @@ export const searchExamples = [
   // Kinds filter examples
   'is:muted by:fiatjaf',
   'is:zap by:marty',
-  'is:bookmark by:pablo',
+  'is:bookmark by:hzrd',
   'is:file',
 
   // Relay filters (removed)

--- a/src/lib/examples.ts
+++ b/src/lib/examples.ts
@@ -51,6 +51,12 @@ export const searchExamples = [
   'giphy.gif',
   'by:gregzaj has:gif',
 
+  // Kinds filter examples
+  'is:muted by:fiatjaf',
+  'is:zap by:marty',
+  'is:bookmark by:pablo',
+  'is:file',
+
   // Relay filters (removed)
 
   // NIP-50 extensions


### PR DESCRIPTION
This PR extends the example searches to include queries using the new kind aliases, making it easier to discover and test the `kind:` filtering support introduced earlier.

- Add `is:muted by:fiatjaf`, `is:zap by:marty`, `is:bookmark by:pablo`, `is:file`
- Keeps examples lightweight and representative