### PR TITLE
Open notes and profiles in native client; add external explorers

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -64,7 +64,7 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
                       }
                       setShowPortalMenu((v) => !v);
                     }}
-                    className="w-5 h-5 rounded-md bg-[#2a2a2a] text-gray-200 border border-[#4a4a4a] shadow-sm flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a] hover:border-[#5a5a5a]"
+                    className="w-5 h-5 rounded-md bg-[#2a2a2a] text-gray-200 shadow-sm flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]"
                   >
                     ⋯
                   </button>

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -7,7 +7,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 import { useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { PORTAL_LINKS } from '@/lib/portals';
+import { EVENT_EXPLORERS } from '@/lib/portals';
 
 type Props = {
   event: NDKEvent;
@@ -89,7 +89,7 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
           onClick={(e) => { e.preventDefault(); e.stopPropagation(); setShowPortalMenu(false); }}
         >
           <ul className="py-1 text-sm text-gray-200">
-            {PORTAL_LINKS.map((p) => {
+            {EVENT_EXPLORERS.map((p) => {
               const nevent = nip19.neventEncode({ id: event.id });
               return (
                 <li key={p.name}>

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -83,31 +83,37 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
         </div>
       )}
       {showPortalMenu && typeof window !== 'undefined' && event?.id && createPortal(
-        <div
-          className="fixed z-[9999] w-56 rounded-md bg-[#2d2d2d]/95 border border-[#3d3d3d] shadow-lg backdrop-blur-sm"
-          style={{ top: menuPosition.top, left: menuPosition.left }}
-          onClick={(e) => { e.preventDefault(); e.stopPropagation(); setShowPortalMenu(false); }}
-        >
-          <ul className="py-1 text-sm text-gray-200">
-            {EVENT_EXPLORERS.map((p) => {
-              const nevent = nip19.neventEncode({ id: event.id });
-              return (
-                <li key={p.name}>
-                  <a
-                    href={`${p.base}${nevent}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="block px-3 py-2 hover:bg-[#3a3a3a] flex items-center justify-between"
-                    onClick={(e) => { e.stopPropagation(); }}
-                  >
-                    <span>{p.name}</span>
-                    <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-gray-400 text-xs" />
-                  </a>
-                </li>
-              );
-            })}
-          </ul>
-        </div>,
+        <>
+          <div
+            className="fixed inset-0 z-[9998]"
+            onClick={(e) => { e.preventDefault(); setShowPortalMenu(false); }}
+          />
+          <div
+            className="fixed z-[9999] w-56 rounded-md bg-[#2d2d2d]/95 border border-[#3d3d3d] shadow-lg backdrop-blur-sm"
+            style={{ top: menuPosition.top, left: menuPosition.left }}
+            onClick={(e) => { e.stopPropagation(); }}
+          >
+            <ul className="py-1 text-sm text-gray-200">
+              {EVENT_EXPLORERS.map((p) => {
+                const nevent = nip19.neventEncode({ id: event.id });
+                return (
+                  <li key={p.name}>
+                    <a
+                      href={`${p.base}${nevent}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="block px-3 py-2 hover:bg-[#3a3a3a] flex items-center justify-between"
+                      onClick={(e) => { e.stopPropagation(); setShowPortalMenu(false); }}
+                    >
+                      <span>{p.name}</span>
+                      <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-gray-400 text-xs" />
+                    </a>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        </>,
         document.body
       )}
     </div>

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -2,6 +2,9 @@
 
 import { NDKEvent } from '@nostr-dev-kit/ndk';
 import AuthorBadge from '@/components/AuthorBadge';
+import { nip19 } from 'nostr-tools';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 
 type Props = {
   event: NDKEvent;
@@ -36,7 +39,19 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
             <AuthorBadge user={event.author} onAuthorClick={onAuthorClick} />
           </div>
           {footerRight ? (
-            <div className="flex items-center gap-2">{footerRight}</div>
+            <div className="flex items-center gap-2">
+              {footerRight}
+              {event?.id ? (
+                <a
+                  href={`nostr:${nip19.neventEncode({ id: event.id })}`}
+                  title="Open in native client"
+                  className="text-gray-400 hover:text-gray-200"
+                  onClick={(e) => { e.stopPropagation(); }}
+                >
+                  <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-xs" />
+                </a>
+              ) : null}
+            </div>
           ) : null}
         </div>
       )}

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -50,14 +50,6 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
               {footerRight}
               {event?.id ? (
                 <>
-                  <a
-                    href={`nostr:${nip19.neventEncode({ id: event.id })}`}
-                    title="Open in native client"
-                    className="text-gray-400 hover:text-gray-200"
-                    onClick={(e) => { e.stopPropagation(); }}
-                  >
-                    <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-xs" />
-                  </a>
                   <button
                     ref={portalButtonRef}
                     type="button"
@@ -76,6 +68,14 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
                   >
                     ⋯
                   </button>
+                  <a
+                    href={`nostr:${nip19.neventEncode({ id: event.id })}`}
+                    title="Open in native client"
+                    className="text-gray-400 hover:text-gray-200"
+                    onClick={(e) => { e.stopPropagation(); }}
+                  >
+                    <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-xs" />
+                  </a>
                 </>
               ) : null}
             </div>

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -64,7 +64,7 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
                       }
                       setShowPortalMenu((v) => !v);
                     }}
-                    className="w-5 h-5 rounded-md bg-[#2a2a2a] text-gray-200 shadow-sm flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]"
+                    className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]"
                   >
                     ⋯
                   </button>

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -7,7 +7,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 import { useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { EVENT_EXPLORERS } from '@/lib/portals';
+import { createEventExplorerItems } from '@/lib/portals';
 
 type Props = {
   event: NDKEvent;
@@ -94,23 +94,24 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
             onClick={(e) => { e.stopPropagation(); }}
           >
             <ul className="py-1 text-sm text-gray-200">
-              {EVENT_EXPLORERS.map((p) => {
+              {(() => {
                 const nevent = nip19.neventEncode({ id: event.id });
-                return (
-                  <li key={p.name}>
+                const items = createEventExplorerItems(nevent);
+                return items.map((item) => (
+                  <li key={item.name}>
                     <a
-                      href={`${p.base}${nevent}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
+                      href={item.href}
+                      target={item.href.startsWith('http') ? '_blank' : undefined}
+                      rel={item.href.startsWith('http') ? 'noopener noreferrer' : undefined}
                       className="block px-3 py-2 hover:bg-[#3a3a3a] flex items-center justify-between"
                       onClick={(e) => { e.stopPropagation(); setShowPortalMenu(false); }}
                     >
-                      <span>{p.name}</span>
+                      <span>{item.name}</span>
                       <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-gray-400 text-xs" />
                     </a>
                   </li>
-                );
-              })}
+                ));
+              })()}
             </ul>
           </div>
         </>,

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -5,6 +5,9 @@ import AuthorBadge from '@/components/AuthorBadge';
 import { nip19 } from 'nostr-tools';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
+import { useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { PORTAL_LINKS } from '@/lib/portals';
 
 type Props = {
   event: NDKEvent;
@@ -29,6 +32,10 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
     ? 'text-gray-100 whitespace-pre-wrap break-words'
     : 'text-gray-100 whitespace-pre-wrap break-words';
 
+  const [showPortalMenu, setShowPortalMenu] = useState(false);
+  const [menuPosition, setMenuPosition] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
+  const portalButtonRef = useRef<HTMLButtonElement>(null);
+
   return (
     <div className={containerClasses}>
       <div className={contentClasses}>{renderContent(event.content || '')}</div>
@@ -42,18 +49,66 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
             <div className="flex items-center gap-2">
               {footerRight}
               {event?.id ? (
-                <a
-                  href={`nostr:${nip19.neventEncode({ id: event.id })}`}
-                  title="Open in native client"
-                  className="text-gray-400 hover:text-gray-200"
-                  onClick={(e) => { e.stopPropagation(); }}
-                >
-                  <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-xs" />
-                </a>
+                <>
+                  <a
+                    href={`nostr:${nip19.neventEncode({ id: event.id })}`}
+                    title="Open in native client"
+                    className="text-gray-400 hover:text-gray-200"
+                    onClick={(e) => { e.stopPropagation(); }}
+                  >
+                    <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-xs" />
+                  </a>
+                  <button
+                    ref={portalButtonRef}
+                    type="button"
+                    aria-label="Open in portals"
+                    title="Open in portals"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      if (portalButtonRef.current) {
+                        const rect = portalButtonRef.current.getBoundingClientRect();
+                        setMenuPosition({ top: rect.bottom + 4, left: rect.left });
+                      }
+                      setShowPortalMenu((v) => !v);
+                    }}
+                    className="w-5 h-5 rounded-md bg-[#2a2a2a] text-gray-200 border border-[#4a4a4a] shadow-sm flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a] hover:border-[#5a5a5a]"
+                  >
+                    ⋯
+                  </button>
+                </>
               ) : null}
             </div>
           ) : null}
         </div>
+      )}
+      {showPortalMenu && typeof window !== 'undefined' && event?.id && createPortal(
+        <div
+          className="fixed z-[9999] w-56 rounded-md bg-[#2d2d2d]/95 border border-[#3d3d3d] shadow-lg backdrop-blur-sm"
+          style={{ top: menuPosition.top, left: menuPosition.left }}
+          onClick={(e) => { e.preventDefault(); e.stopPropagation(); setShowPortalMenu(false); }}
+        >
+          <ul className="py-1 text-sm text-gray-200">
+            {PORTAL_LINKS.map((p) => {
+              const nevent = nip19.neventEncode({ id: event.id });
+              return (
+                <li key={p.name}>
+                  <a
+                    href={`${p.base}${nevent}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block px-3 py-2 hover:bg-[#3a3a3a] flex items-center justify-between"
+                    onClick={(e) => { e.stopPropagation(); }}
+                  >
+                    <span>{p.name}</span>
+                    <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-gray-400 text-xs" />
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
+        </div>,
+        document.body
       )}
     </div>
   );

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -117,28 +117,34 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
         </a>
       </div>
       {showPortalMenuBottom && typeof window !== 'undefined' && createPortal(
-        <div
-          className="fixed z-[9999] w-56 rounded-md bg-[#2d2d2d]/95 border border-[#3d3d3d] shadow-lg backdrop-blur-sm"
-          style={{ top: menuPositionBottom.top, left: menuPositionBottom.left }}
-          onClick={(e) => { e.preventDefault(); e.stopPropagation(); setShowPortalMenuBottom(false); }}
-        >
-          <ul className="py-1 text-sm text-gray-200">
-            {PROFILE_EXPLORERS.map((p) => (
-              <li key={p.name}>
-                <a
-                  href={`${p.base}${npub}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="block px-3 py-2 hover:bg-[#3a3a3a] flex items-center justify-between"
-                  onClick={(e) => { e.stopPropagation(); }}
-                >
-                  <span>{p.name}</span>
-                  <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-gray-400 text-xs" />
-                </a>
-              </li>
-            ))}
-          </ul>
-        </div>,
+        <>
+          <div
+            className="fixed inset-0 z-[9998]"
+            onClick={(e) => { e.preventDefault(); setShowPortalMenuBottom(false); }}
+          />
+          <div
+            className="fixed z-[9999] w-56 rounded-md bg-[#2d2d2d]/95 border border-[#3d3d3d] shadow-lg backdrop-blur-sm"
+            style={{ top: menuPositionBottom.top, left: menuPositionBottom.left }}
+            onClick={(e) => { e.stopPropagation(); }}
+          >
+            <ul className="py-1 text-sm text-gray-200">
+              {PROFILE_EXPLORERS.map((p) => (
+                <li key={p.name}>
+                  <a
+                    href={`${p.base}${npub}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block px-3 py-2 hover:bg-[#3a3a3a] flex items-center justify-between"
+                    onClick={(e) => { e.stopPropagation(); setShowPortalMenuBottom(false); }}
+                  >
+                    <span>{p.name}</span>
+                    <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-gray-400 text-xs" />
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </>,
         document.body
       )}
     </div>

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -170,7 +170,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
   const [menuPosition, setMenuPosition] = useState({ top: 0, left: 0 });
   const buttonRef = useRef<HTMLButtonElement>(null);
 
-  const portalItems = useMemo(() => createProfileExplorerItems(event.author.npub), [event.author.npub]);
+  const portalItems = useMemo(() => createProfileExplorerItems(event.author.npub, event.author.pubkey), [event.author.npub, event.author.pubkey]);
 
   const renderBioWithHashtags = useMemo(() => {
     return (text?: string) => {

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'next/navigation';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowUpRightFromSquare, faCopy } from '@fortawesome/free-solid-svg-icons';
 import { createPortal } from 'react-dom';
+import { PORTAL_LINKS } from '@/lib/portals';
 
 function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightning }: { pubkey: string; fallbackEventId?: string; fallbackCreatedAt?: number; lightning?: string }) {
   const [createdAt, setCreatedAt] = useState<number | null>(null);
@@ -108,13 +109,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
   const [menuPosition, setMenuPosition] = useState({ top: 0, left: 0 });
   const buttonRef = useRef<HTMLButtonElement>(null);
 
-  const portalLinks = [
-    { name: 'njump.me', base: 'https://njump.me/' },
-    { name: 'nostr.at', base: 'https://nostr.at/' },
-    { name: 'npub.world', base: 'https://npub.world/' },
-    { name: 'nosta.me', base: 'https://nosta.me/' },
-    { name: 'castr.me', base: 'https://castr.me/' },
-  ];
+  const portalLinks = PORTAL_LINKS;
 
   const renderBioWithHashtags = useMemo(() => {
     return (text?: string) => {

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -10,7 +10,7 @@ import { useRouter } from 'next/navigation';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowUpRightFromSquare, faCopy } from '@fortawesome/free-solid-svg-icons';
 import { createPortal } from 'react-dom';
-import { PROFILE_EXPLORERS } from '@/lib/portals';
+import { createProfileExplorerItems } from '@/lib/portals';
 
 function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightning, npub }: { pubkey: string; fallbackEventId?: string; fallbackCreatedAt?: number; lightning?: string; npub: string }) {
   const [createdAt, setCreatedAt] = useState<number | null>(null);
@@ -20,6 +20,7 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
   const [showPortalMenuBottom, setShowPortalMenuBottom] = useState(false);
   const [menuPositionBottom, setMenuPositionBottom] = useState({ top: 0, left: 0 });
   const bottomButtonRef = useRef<HTMLButtonElement>(null);
+  const bottomItems = useMemo(() => createProfileExplorerItems(npub), [npub]);
 
   useEffect(() => {
     let isMounted = true;
@@ -128,16 +129,16 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
             onClick={(e) => { e.stopPropagation(); }}
           >
             <ul className="py-1 text-sm text-gray-200">
-              {PROFILE_EXPLORERS.map((p) => (
-                <li key={p.name}>
+              {bottomItems.map((item) => (
+                <li key={item.name}>
                   <a
-                    href={`${p.base}${npub}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
+                    href={item.href}
+                    target={item.href.startsWith('http') ? '_blank' : undefined}
+                    rel={item.href.startsWith('http') ? 'noopener noreferrer' : undefined}
                     className="block px-3 py-2 hover:bg-[#3a3a3a] flex items-center justify-between"
                     onClick={(e) => { e.stopPropagation(); setShowPortalMenuBottom(false); }}
                   >
-                    <span>{p.name}</span>
+                    <span>{item.name}</span>
                     <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-gray-400 text-xs" />
                   </a>
                 </li>
@@ -169,7 +170,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
   const [menuPosition, setMenuPosition] = useState({ top: 0, left: 0 });
   const buttonRef = useRef<HTMLButtonElement>(null);
 
-  const portalLinks = PROFILE_EXPLORERS;
+  const portalItems = useMemo(() => createProfileExplorerItems(event.author.npub), [event.author.npub]);
 
   const renderBioWithHashtags = useMemo(() => {
     return (text?: string) => {
@@ -363,28 +364,34 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
         npub={event.author.npub}
       />
       {showPortalMenu && typeof window !== 'undefined' && createPortal(
-        <div
-          className="fixed z-[9999] w-56 rounded-md bg-[#2d2d2d]/95 border border-[#3d3d3d] shadow-lg backdrop-blur-sm"
-          style={{ top: menuPosition.top, left: menuPosition.left }}
-          onClick={(e) => { e.preventDefault(); e.stopPropagation(); setShowPortalMenu(false); }}
-        >
-          <ul className="py-1 text-sm text-gray-200">
-            {portalLinks.map((p) => (
-              <li key={p.name}>
-                <a
-                  href={`${p.base}${event.author.npub}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="block px-3 py-2 hover:bg-[#3a3a3a] flex items-center justify-between"
-                  onClick={(e) => { e.stopPropagation(); }}
-                >
-                  <span>{p.name}</span>
-                  <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-gray-400 text-xs" />
-                </a>
-              </li>
-            ))}
-          </ul>
-        </div>,
+        <>
+          <div
+            className="fixed inset-0 z-[9998]"
+            onClick={(e) => { e.preventDefault(); setShowPortalMenu(false); }}
+          />
+          <div
+            className="fixed z-[9999] w-56 rounded-md bg-[#2d2d2d]/95 border border-[#3d3d3d] shadow-lg backdrop-blur-sm"
+            style={{ top: menuPosition.top, left: menuPosition.left }}
+            onClick={(e) => { e.stopPropagation(); }}
+          >
+            <ul className="py-1 text-sm text-gray-200">
+              {portalItems.map((item) => (
+                <li key={item.name}>
+                  <a
+                    href={item.href}
+                    target={item.href.startsWith('http') ? '_blank' : undefined}
+                    rel={item.href.startsWith('http') ? 'noopener noreferrer' : undefined}
+                    className="block px-3 py-2 hover:bg-[#3a3a3a] flex items-center justify-between"
+                    onClick={(e) => { e.stopPropagation(); setShowPortalMenu(false); }}
+                  >
+                    <span>{item.name}</span>
+                    <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-gray-400 text-xs" />
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </>,
         document.body
       )}
     </div>

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -10,7 +10,7 @@ import { useRouter } from 'next/navigation';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowUpRightFromSquare, faCopy } from '@fortawesome/free-solid-svg-icons';
 import { createPortal } from 'react-dom';
-import { PORTAL_LINKS } from '@/lib/portals';
+import { PROFILE_EXPLORERS } from '@/lib/portals';
 
 function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightning }: { pubkey: string; fallbackEventId?: string; fallbackCreatedAt?: number; lightning?: string }) {
   const [createdAt, setCreatedAt] = useState<number | null>(null);
@@ -109,7 +109,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
   const [menuPosition, setMenuPosition] = useState({ top: 0, left: 0 });
   const buttonRef = useRef<HTMLButtonElement>(null);
 
-  const portalLinks = PORTAL_LINKS;
+  const portalLinks = PROFILE_EXPLORERS;
 
   const renderBioWithHashtags = useMemo(() => {
     return (text?: string) => {

--- a/src/lib/portals.ts
+++ b/src/lib/portals.ts
@@ -1,3 +1,4 @@
+import { nip19 } from 'nostr-tools';
 export type ExplorerLink = {
   name: string;
   base: string;
@@ -22,14 +23,28 @@ export const EVENT_EXPLORERS: readonly ExplorerLink[] = [
 
 export type ExplorerItem = { name: string; href: string };
 
-export function createProfileExplorerItems(npub: string): readonly ExplorerItem[] {
+export function createProfileExplorerItems(npub: string, pubkey?: string): readonly ExplorerItem[] {
   const items: ExplorerItem[] = PROFILE_EXPLORERS.map((p) => ({ name: p.name, href: `${p.base}${npub}` }));
-  items.push({ name: 'Native App', href: `nostr:${npub}` });
+  let nprofile: string | null = null;
+  if (pubkey) {
+    try {
+      nprofile = nip19.nprofileEncode({ pubkey });
+    } catch {
+      nprofile = null;
+    }
+  }
+  if (nprofile) {
+    items.push({ name: 'Web Client', href: `web+nostr:${nprofile}` });
+  } else {
+    items.push({ name: 'Web Client', href: `web+nostr:${npub}` });
+  }
+  items.push({ name: 'Native App', href: `nostr:${nprofile || npub}` });
   return items;
 }
 
 export function createEventExplorerItems(nevent: string): readonly ExplorerItem[] {
   const items: ExplorerItem[] = EVENT_EXPLORERS.map((p) => ({ name: p.name, href: `${p.base}${nevent}` }));
+  items.push({ name: 'Web Client', href: `web+nostr:${nevent}` });
   items.push({ name: 'Native App', href: `nostr:${nevent}` });
   return items;
 }

--- a/src/lib/portals.ts
+++ b/src/lib/portals.ts
@@ -1,0 +1,14 @@
+export type PortalLink = {
+  name: string;
+  base: string;
+};
+
+export const PORTAL_LINKS: readonly PortalLink[] = [
+  { name: 'njump.me', base: 'https://njump.me/' },
+  { name: 'nostr.at', base: 'https://nostr.at/' },
+  { name: 'npub.world', base: 'https://npub.world/' },
+  { name: 'nosta.me', base: 'https://nosta.me/' },
+  { name: 'castr.me', base: 'https://castr.me/' },
+] as const;
+
+

--- a/src/lib/portals.ts
+++ b/src/lib/portals.ts
@@ -10,6 +10,7 @@ export const PROFILE_EXPLORERS: readonly ExplorerLink[] = [
   { name: 'npub.world', base: 'https://npub.world/' },
   { name: 'nosta.me', base: 'https://nosta.me/' },
   { name: 'castr.me', base: 'https://castr.me/' },
+  { name: 'zaplife.lol', base: 'https://zaplife.lol/p/' },
 ] as const;
 
 export const EVENT_EXPLORERS: readonly ExplorerLink[] = [

--- a/src/lib/portals.ts
+++ b/src/lib/portals.ts
@@ -1,14 +1,20 @@
-export type PortalLink = {
+export type ExplorerLink = {
   name: string;
   base: string;
 };
 
-export const PORTAL_LINKS: readonly PortalLink[] = [
+export const PROFILE_EXPLORERS: readonly ExplorerLink[] = [
   { name: 'njump.me', base: 'https://njump.me/' },
   { name: 'nostr.at', base: 'https://nostr.at/' },
   { name: 'npub.world', base: 'https://npub.world/' },
   { name: 'nosta.me', base: 'https://nosta.me/' },
   { name: 'castr.me', base: 'https://castr.me/' },
 ] as const;
+
+export const EVENT_EXPLORERS: readonly ExplorerLink[] = [
+  { name: 'njump.me', base: 'https://njump.me/' },
+  { name: 'nostr.at', base: 'https://nostr.at/' },
+  { name: 'habla.news', base: 'https://habla.news/' },
+];
 
 

--- a/src/lib/portals.ts
+++ b/src/lib/portals.ts
@@ -19,4 +19,18 @@ export const EVENT_EXPLORERS: readonly ExplorerLink[] = [
   { name: 'habla.news', base: 'https://habla.news/' },
 ];
 
+export type ExplorerItem = { name: string; href: string };
+
+export function createProfileExplorerItems(npub: string): readonly ExplorerItem[] {
+  const items: ExplorerItem[] = PROFILE_EXPLORERS.map((p) => ({ name: p.name, href: `${p.base}${npub}` }));
+  items.push({ name: 'Native App', href: `nostr:${npub}` });
+  return items;
+}
+
+export function createEventExplorerItems(nevent: string): readonly ExplorerItem[] {
+  const items: ExplorerItem[] = EVENT_EXPLORERS.map((p) => ({ name: p.name, href: `${p.base}${nevent}` }));
+  items.push({ name: 'Native App', href: `nostr:${nevent}` });
+  return items;
+}
+
 

--- a/src/lib/portals.ts
+++ b/src/lib/portals.ts
@@ -6,6 +6,7 @@ export type ExplorerLink = {
 export const PROFILE_EXPLORERS: readonly ExplorerLink[] = [
   { name: 'njump.me', base: 'https://njump.me/' },
   { name: 'nostr.at', base: 'https://nostr.at/' },
+  { name: 'nostr.band', base: 'https://nostr.band/' },
   { name: 'npub.world', base: 'https://npub.world/' },
   { name: 'nosta.me', base: 'https://nosta.me/' },
   { name: 'castr.me', base: 'https://castr.me/' },
@@ -14,6 +15,7 @@ export const PROFILE_EXPLORERS: readonly ExplorerLink[] = [
 export const EVENT_EXPLORERS: readonly ExplorerLink[] = [
   { name: 'njump.me', base: 'https://njump.me/' },
   { name: 'nostr.at', base: 'https://nostr.at/' },
+  { name: 'nostr.band', base: 'https://nostr.band/' },
   { name: 'habla.news', base: 'https://habla.news/' },
 ];
 

--- a/src/lib/portals.ts
+++ b/src/lib/portals.ts
@@ -18,7 +18,6 @@ export const EVENT_EXPLORERS: readonly ExplorerLink[] = [
   { name: 'njump.me', base: 'https://njump.me/' },
   { name: 'nostr.at', base: 'https://nostr.at/' },
   { name: 'nostr.band', base: 'https://nostr.band/' },
-  { name: 'habla.news', base: 'https://habla.news/' },
 ];
 
 export type ExplorerItem = { name: string; href: string };


### PR DESCRIPTION
This PR adds native deep-linking and a lightweight external explorer menu for notes and profiles, improving navigation and interoperability across Nostr clients.

- Adds `nostr:` open-in-native icon to `EventCard` and `ProfileCard`
- Adds three-dot menu with external explorers and `web+nostr:` / `nostr:` entries
- Introduces shared helpers `createEventExplorerItems` and `createProfileExplorerItems` and explorer lists

Also includes small UI tweaks (hover background, menu overlay, order swap).