### PR TITLE
Improve three-dot menus; add explorers and dynamic quick-search

### DIFF
--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -11,6 +11,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowUpRightFromSquare, faCopy } from '@fortawesome/free-solid-svg-icons';
 import { createPortal } from 'react-dom';
 import { createProfileExplorerItems } from '@/lib/portals';
+import { getIsKindTokens } from '@/lib/search/replacements';
 
 function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightning, npub }: { pubkey: string; fallbackEventId?: string; fallbackCreatedAt?: number; lightning?: string; npub: string }) {
   const [createdAt, setCreatedAt] = useState<number | null>(null);
@@ -171,19 +172,19 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   const portalItems = useMemo(() => createProfileExplorerItems(event.author.npub, event.author.pubkey), [event.author.npub, event.author.pubkey]);
-  const quickSearchItems = useMemo(() => [
-    'is:repost',
-    'is:reaction',
-    'is:picture',
-    'is:file',
-    'is:patch',
-    'is:issue',
-    'is:report',
-    'is:zap',
-    'is:muted',
-    'is:pin',
-    'is:bookmark'
-  ], []);
+  const [quickSearchItems, setQuickSearchItems] = useState<string[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const tokens = await getIsKindTokens();
+        if (!cancelled) setQuickSearchItems(tokens);
+      } catch {
+        if (!cancelled) setQuickSearchItems([]);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
 
   const renderBioWithHashtags = useMemo(() => {
     return (text?: string) => {

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -171,6 +171,19 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   const portalItems = useMemo(() => createProfileExplorerItems(event.author.npub, event.author.pubkey), [event.author.npub, event.author.pubkey]);
+  const quickSearchItems = useMemo(() => [
+    'is:repost',
+    'is:reaction',
+    'is:picture',
+    'is:file',
+    'is:patch',
+    'is:issue',
+    'is:report',
+    'is:zap',
+    'is:muted',
+    'is:pin',
+    'is:bookmark'
+  ], []);
 
   const renderBioWithHashtags = useMemo(() => {
     return (text?: string) => {
@@ -375,18 +388,21 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
             onClick={(e) => { e.stopPropagation(); }}
           >
             <ul className="py-1 text-sm text-gray-200">
-              {portalItems.map((item) => (
-                <li key={item.name}>
-                  <a
-                    href={item.href}
-                    target={item.href.startsWith('http') ? '_blank' : undefined}
-                    rel={item.href.startsWith('http') ? 'noopener noreferrer' : undefined}
-                    className="block px-3 py-2 hover:bg-[#3a3a3a] flex items-center justify-between"
-                    onClick={(e) => { e.stopPropagation(); setShowPortalMenu(false); }}
+              {quickSearchItems.map((token) => (
+                <li key={token}>
+                  <button
+                    type="button"
+                    className="block w-full text-left px-3 py-2 hover:bg-[#3a3a3a]"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      const params = new URLSearchParams();
+                      params.set('q', `${token} by:${event.author.npub}`);
+                      router.push(`/?${params.toString()}`);
+                      setShowPortalMenu(false);
+                    }}
                   >
-                    <span>{item.name}</span>
-                    <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-gray-400 text-xs" />
-                  </a>
+                    {token}
+                  </button>
                 </li>
               ))}
             </ul>

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -171,7 +171,6 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
   const [menuPosition, setMenuPosition] = useState({ top: 0, left: 0 });
   const buttonRef = useRef<HTMLButtonElement>(null);
 
-  const portalItems = useMemo(() => createProfileExplorerItems(event.author.npub, event.author.pubkey), [event.author.npub, event.author.pubkey]);
   const [quickSearchItems, setQuickSearchItems] = useState<string[]>([]);
   useEffect(() => {
     let cancelled = false;

--- a/src/lib/examples.ts
+++ b/src/lib/examples.ts
@@ -30,6 +30,7 @@ export const searchExamples = [
   // Profile lookup / NIP-05
   'p:fiatjaf',
   'p:hodl',
+  'p:dergigi.com',
   '@dergigi.com',
 
   // Operators & media

--- a/src/lib/portals.ts
+++ b/src/lib/portals.ts
@@ -7,6 +7,8 @@ export type ExplorerLink = {
 export const PROFILE_EXPLORERS: readonly ExplorerLink[] = [
   { name: 'njump.me', base: 'https://njump.me/' },
   { name: 'nostr.at', base: 'https://nostr.at/' },
+  { name: 'nostr.eu', base: 'https://nostr.eu/' },
+  { name: 'nostr.ae', base: 'https://nostr.ae/' },
   { name: 'nostr.band', base: 'https://nostr.band/' },
   { name: 'npub.world', base: 'https://npub.world/' },
   { name: 'nosta.me', base: 'https://nosta.me/' },
@@ -17,6 +19,8 @@ export const PROFILE_EXPLORERS: readonly ExplorerLink[] = [
 export const EVENT_EXPLORERS: readonly ExplorerLink[] = [
   { name: 'njump.me', base: 'https://njump.me/' },
   { name: 'nostr.at', base: 'https://nostr.at/' },
+  { name: 'nostr.eu', base: 'https://nostr.eu/' },
+  { name: 'nostr.ae', base: 'https://nostr.ae/' },
   { name: 'nostr.band', base: 'https://nostr.band/' },
 ];
 

--- a/src/lib/portals.ts
+++ b/src/lib/portals.ts
@@ -14,6 +14,7 @@ export const PROFILE_EXPLORERS: readonly ExplorerLink[] = [
   { name: 'nosta.me', base: 'https://nosta.me/' },
   { name: 'castr.me', base: 'https://castr.me/' },
   { name: 'zaplife.lol', base: 'https://zaplife.lol/p/' },
+  { name: 'nostx.io', base: 'https://nostx.io/' },
 ] as const;
 
 export const EVENT_EXPLORERS: readonly ExplorerLink[] = [
@@ -22,6 +23,7 @@ export const EVENT_EXPLORERS: readonly ExplorerLink[] = [
   { name: 'nostr.eu', base: 'https://nostr.eu/' },
   { name: 'nostr.ae', base: 'https://nostr.ae/' },
   { name: 'nostr.band', base: 'https://nostr.band/' },
+  { name: 'nostx.io', base: 'https://nostx.io/' },
 ];
 
 export type ExplorerItem = { name: string; href: string };

--- a/src/lib/search/replacements.ts
+++ b/src/lib/search/replacements.ts
@@ -58,7 +58,7 @@ export async function applySimpleReplacements(input: string): Promise<string> {
 export async function getIsKindTokens(): Promise<string[]> {
   const rules = await loadRules();
   return rules
-    .filter((r) => r.kind === 'is' && /^kind:/i.test(r.expansion))
+    .filter((r) => r.kind === 'is')
     .map((r) => `is:${r.key}`);
 }
 

--- a/src/lib/search/replacements.ts
+++ b/src/lib/search/replacements.ts
@@ -55,4 +55,11 @@ export async function applySimpleReplacements(input: string): Promise<string> {
   return q.replace(/\s{2,}/g, ' ').trim();
 }
 
+export async function getIsKindTokens(): Promise<string[]> {
+  const rules = await loadRules();
+  return rules
+    .filter((r) => r.kind === 'is' && /^kind:/i.test(r.expansion))
+    .map((r) => `is:${r.key}`);
+}
+
 


### PR DESCRIPTION
This PR refines the event and profile menus, adds new explorers, and makes the profile quick-search dynamic using `replacements.txt`.

- Converts the top-left profile menu into quick-search with dynamically loaded `is:` tokens via `getIsKindTokens`
- Adds multiple explorers (`nostr.eu`, `nostr.ae`, `nostx.io`) and small UI tweaks