### PR TITLE
Fix OR logic: recursive parentheses expansion, author scoping, and query preview

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,6 +19,7 @@
 - [x] Same for gifs (`has:gif` and `is:gif`)
 - [x] Add more examples to pre-fill search field
 - [x] Show different examples periodically for discovery
+- [ ] Fix "OR" logic
 - [ ] Update UI with placeholders immediatly after any search is triggered
 - [ ] Add support for `is:tweet` and `is:short` (<= 210 chars)
 - [ ] Hide note content if it is longer than 210 chars, adding "show more"

--- a/TODO.md
+++ b/TODO.md
@@ -35,3 +35,4 @@
 - [ ] Build a little tool that allows users to create new replacements
 - [ ] Explain that users need Vertex credits for the username lookup to work properly
 - [ ] Fix the one weird profile-specific search UI bug
+- [ ] Refactor to use nepsilon/search-query-parser (?)

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -394,7 +394,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
           const finalQueries = Array.from(finalQueriesSet);
 
           // Format compact preview
-          const preview = finalQueries.length > 0 ? finalQueries.join(' • ') : afterReplacements;
+          const preview = finalQueries.length > 0 ? finalQueries.join('\n') : afterReplacements;
           if (!cancelled) setTranslation(preview);
         } catch {
           if (!cancelled) setTranslation('');
@@ -1137,7 +1137,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
         </div>
         
         {translation && (
-          <div className="mt-1 pl-4 text-[11px] text-gray-400 font-mono break-words">
+          <div className="mt-1 pl-4 text-[11px] text-gray-400 font-mono break-words whitespace-pre-wrap">
             {translation}
           </div>
         )}

--- a/src/lib/examples.ts
+++ b/src/lib/examples.ts
@@ -51,6 +51,7 @@ export const searchExamples = [
   'Gregzaj1-ln_strike.gif',
   'giphy.gif',
   'by:gregzaj has:gif',
+  '(GM OR GN) by:dergigi has:image',
 
   // Kinds filter examples
   'is:muted by:fiatjaf',

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -718,7 +718,30 @@ export async function searchEvents(
     return Array.from(dedupe.values()).slice(0, limit);
   }
 
-  // Check for OR operator
+  // First, expand any parenthesized OR seeds by distributing surrounding terms
+  const expandedSeeds = expandParenthesizedOr(cleanedQuery);
+  if (expandedSeeds.length > 1) {
+    // Execute each expanded seed independently and merge (OR semantics)
+    const merged: NDKEvent[] = [];
+    const seen = new Set<string>();
+    for (const seed of expandedSeeds) {
+      try {
+        const partResults = await searchEvents(seed, limit, options, chosenRelaySet, abortSignal);
+        for (const evt of partResults) {
+          if (!seen.has(evt.id)) { seen.add(evt.id); merged.push(evt); }
+        }
+      } catch (error) {
+        if (error instanceof Error && (error.name === 'AbortError' || error.message === 'Search aborted')) {
+          // no-op
+        } else {
+          console.warn('Expanded seed failed:', seed, error);
+        }
+      }
+    }
+    return merged.sort((a, b) => (b.created_at || 0) - (a.created_at || 0)).slice(0, limit);
+  }
+
+  // Check for top-level OR operator (outside parentheses)
   const orParts = parseOrQuery(cleanedQuery);
   if (orParts.length > 1) {
     console.log('Processing OR query with parts:', orParts);

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -47,6 +47,33 @@ export const GIF_EXTENSIONS = ['gif', 'gifs', 'apng'] as const;
 // Use a search-capable relay set explicitly for NIP-50 queries
 const searchRelaySet = relaySets.search();
 
+// Extract human-language OR tokens from parenthesized groups, excluding media/URL/key:value tokens
+function extractHumanOrTokens(query: string): string[] {
+  const tokens: string[] = [];
+  const matches = Array.from(query.matchAll(/\(([^)]+)\)/g));
+  for (const m of matches) {
+    const inner = (m[1] || '').trim();
+    if (!/\s+OR\s+/i.test(inner)) continue;
+    const parts = inner.split(/\s+OR\s+/i).map((p) => p.trim()).filter(Boolean);
+    for (const p of parts) {
+      if (p.startsWith('.')) continue; // file extensions
+      if (/^https?:\/\//i.test(p)) continue; // URLs
+      if (/^[a-z]+:/i.test(p)) continue; // key:value like kind:, site:, nostr:
+      tokens.push(p);
+    }
+  }
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const t of tokens) { const k = t.toLowerCase(); if (!seen.has(k)) { seen.add(k); out.push(t); } }
+  return out;
+}
+
+function contentIncludesAny(event: NDKEvent, tokens: string[]): boolean {
+  if (tokens.length === 0) return true;
+  const c = (event.content || '').toLowerCase();
+  return tokens.some((t) => c.includes(t.toLowerCase()));
+}
+
 // Extract NIP-50 extensions from the raw query string
 function extractNip50Extensions(rawQuery: string): { cleaned: string; extensions: Nip50Extensions } {
   let cleaned = rawQuery;
@@ -760,7 +787,10 @@ export async function searchEvents(
         }
       }
     }
-    return merged.sort((a, b) => (b.created_at || 0) - (a.created_at || 0)).slice(0, limit);
+    // Enforce presence of any human OR tokens in content (e.g., GM/GN)
+    const humanOr = extractHumanOrTokens(cleanedQuery);
+    const filteredByHuman = humanOr.length > 0 ? merged.filter((e) => contentIncludesAny(e, humanOr)) : merged;
+    return filteredByHuman.sort((a, b) => (b.created_at || 0) - (a.created_at || 0)).slice(0, limit);
   }
 
   // Check for top-level OR operator (outside parentheses)
@@ -792,7 +822,9 @@ export async function searchEvents(
     
     // Sort by creation time (newest first) and limit results
     const merged = allResults;
-    return merged
+    const humanOr = extractHumanOrTokens(cleanedQuery);
+    const filteredByHuman = humanOr.length > 0 ? merged.filter((e) => contentIncludesAny(e, humanOr)) : merged;
+    return filteredByHuman
       .sort((a, b) => (b.created_at || 0) - (a.created_at || 0))
       .slice(0, limit);
   }

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -757,12 +757,10 @@ export async function searchEvents(
       const authorOnly = await subscribeAndCollect({ kinds: effectiveKinds, authors: [pubkey], limit: Math.max(limit, 600) }, 10000, broadRelaySet, abortSignal);
       const needle = termStr.toLowerCase();
       res = authorOnly.filter((e) => (e.content || '').toLowerCase().includes(needle));
-    }
-    // For short tokens (e.g., GM/GN), some relays may return noisy results.
-    // Apply client-side content filter regardless of non-empty results.
-    if (hasShortToken && termStr) {
+    } else if (res.length === 0 && hasShortToken) {
+      const authorOnly = await subscribeAndCollect({ kinds: effectiveKinds, authors: [pubkey], limit: Math.max(limit, 600) }, 10000, broadRelaySet, abortSignal);
       const needle = termStr.toLowerCase();
-      res = res.filter((e) => (e.content || '').toLowerCase().includes(needle));
+      res = authorOnly.filter((e) => (e.content || '').toLowerCase().includes(needle));
     }
     const dedupe = new Map<string, NDKEvent>();
     for (const e of res) { if (!dedupe.has(e.id)) dedupe.set(e.id, e); }
@@ -1060,10 +1058,10 @@ export async function searchEvents(
         const authorOnly = await subscribeAndCollect({ kinds: effectiveKinds, authors: [pubkey], limit: Math.max(limit, 600) }, 10000, broadRelaySet, abortSignal);
         const needle = termStr.toLowerCase();
         res = authorOnly.filter((e) => (e.content || '').toLowerCase().includes(needle));
-      }
-      if (hasShortToken && termStr) {
+      } else if (res.length === 0 && hasShortToken) {
+        const authorOnly = await subscribeAndCollect({ kinds: effectiveKinds, authors: [pubkey], limit: Math.max(limit, 600) }, 10000, broadRelaySet, abortSignal);
         const needle = termStr.toLowerCase();
-        res = res.filter((e) => (e.content || '').toLowerCase().includes(needle));
+        res = authorOnly.filter((e) => (e.content || '').toLowerCase().includes(needle));
       }
       let mergedResults: NDKEvent[] = res;
       // Dedupe

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -757,10 +757,12 @@ export async function searchEvents(
       const authorOnly = await subscribeAndCollect({ kinds: effectiveKinds, authors: [pubkey], limit: Math.max(limit, 600) }, 10000, broadRelaySet, abortSignal);
       const needle = termStr.toLowerCase();
       res = authorOnly.filter((e) => (e.content || '').toLowerCase().includes(needle));
-    } else if (res.length === 0 && hasShortToken) {
-      const authorOnly = await subscribeAndCollect({ kinds: effectiveKinds, authors: [pubkey], limit: Math.max(limit, 600) }, 10000, broadRelaySet, abortSignal);
+    }
+    // For short tokens (e.g., GM/GN), some relays may return noisy results.
+    // Apply client-side content filter regardless of non-empty results.
+    if (hasShortToken && termStr) {
       const needle = termStr.toLowerCase();
-      res = authorOnly.filter((e) => (e.content || '').toLowerCase().includes(needle));
+      res = res.filter((e) => (e.content || '').toLowerCase().includes(needle));
     }
     const dedupe = new Map<string, NDKEvent>();
     for (const e of res) { if (!dedupe.has(e.id)) dedupe.set(e.id, e); }
@@ -1058,10 +1060,10 @@ export async function searchEvents(
         const authorOnly = await subscribeAndCollect({ kinds: effectiveKinds, authors: [pubkey], limit: Math.max(limit, 600) }, 10000, broadRelaySet, abortSignal);
         const needle = termStr.toLowerCase();
         res = authorOnly.filter((e) => (e.content || '').toLowerCase().includes(needle));
-      } else if (res.length === 0 && hasShortToken) {
-        const authorOnly = await subscribeAndCollect({ kinds: effectiveKinds, authors: [pubkey], limit: Math.max(limit, 600) }, 10000, broadRelaySet, abortSignal);
+      }
+      if (hasShortToken && termStr) {
         const needle = termStr.toLowerCase();
-        res = authorOnly.filter((e) => (e.content || '').toLowerCase().includes(needle));
+        res = res.filter((e) => (e.content || '').toLowerCase().includes(needle));
       }
       let mergedResults: NDKEvent[] = res;
       // Dedupe


### PR DESCRIPTION
This PR fixes boolean OR handling by distributing parenthesized terms recursively and applying author scoping correctly. It also adds a compact preview of the final queries after author resolution, replacements, recursive OR expansion, and top-level OR splitting.\n\n- Distribute OR inside parentheses before  handling to avoid scope bleed\n- Preserve whitespace during expansion to prevent unintended token merges (e.g., 'GM .png')\n- Show final expanded queries (one per line) under the search input