### PR TITLE
Fix profile page search behavior and URL management

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -34,6 +34,6 @@
 - [ ] Make up a kind for the stuff that is in `replacements.txt` & fetch it from nostr
 - [ ] Build a little tool that allows users to create new replacements
 - [ ] Explain that users need Vertex credits for the username lookup to work properly
-- [ ] Fix the one weird profile-specific search UI bug
+- [x] Fix the one weird profile-specific search UI bug
 - [ ] Refactor to use nepsilon/search-query-parser (?)
 - [ ] Add NIP-56 support to allow for nudity/profanity/illegal/spam/impersonation content filters

--- a/src/app/p/[npub]/page.tsx
+++ b/src/app/p/[npub]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useParams } from 'next/navigation';
+import { useParams, useSearchParams } from 'next/navigation';
 import { ndk, connect } from '@/lib/ndk';
 import { NDKEvent, NDKUser } from '@nostr-dev-kit/ndk';
 import { nip19 } from 'nostr-tools';
@@ -70,6 +70,8 @@ function useNostrUser(npub: string | undefined) {
 export default function ProfilePage() {
   const params = useParams<{ npub: string }>();
   const npub = params?.npub;
+  const searchParams = useSearchParams();
+  const q = searchParams?.get('q') || null;
   const { profileEvent } = useNostrUser(npub);
 
   return (
@@ -81,7 +83,7 @@ export default function ProfilePage() {
 
         {npub ? (
           <div className="mt-4">
-            <SearchView initialQuery={`by:${npub}`} manageUrl={false} />
+            <SearchView initialQuery={q || `by:${npub}`} manageUrl={false} />
           </div>
         ) : null}
       </div>

--- a/src/app/p/[npub]/page.tsx
+++ b/src/app/p/[npub]/page.tsx
@@ -83,7 +83,7 @@ export default function ProfilePage() {
 
         {npub ? (
           <div className="mt-4">
-            <SearchView initialQuery={q || `by:${npub}`} manageUrl={false} />
+            <SearchView initialQuery={q || `by:${npub}`} manageUrl={true} />
           </div>
         ) : null}
       </div>

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -1152,11 +1152,8 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
                   setBaseResults([]);
                   setLoading(false);
                   setResolvingAuthor(false);
-                  if (manageUrl) {
-                    const params = new URLSearchParams(searchParams.toString());
-                    params.delete('q');
-                    router.replace(`?${params.toString()}`);
-                  }
+                  // Always reset to root path when clearing
+                  router.replace('/');
                 }}
                 className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200 transition-colors bg-[#2d2d2d] hover:bg-[#3d3d3d] rounded-full w-6 h-6 flex items-center justify-center text-sm font-bold"
                 aria-label="Clear search"

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -283,13 +283,13 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
         setConnectionStatus('timeout');
       }
       
-      if (initialQuery) {
+      if (initialQuery && !manageUrl) {
         setQuery(initialQuery);
         handleSearch(initialQuery);
       }
     };
     initializeNDK();
-  }, [handleSearch, initialQuery]);
+  }, [handleSearch, initialQuery, manageUrl]);
 
   // Listen for connection status changes
   useEffect(() => {

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -221,7 +221,8 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
           const currentProfileMatch = (pathname || '').match(/^\/p\/(npub1[0-9a-z]+)/i);
           const currentProfileNpub = currentProfileMatch ? currentProfileMatch[1] : null;
           if (onProfilePage && currentProfileNpub && currentProfileNpub.toLowerCase() !== resolvedNpub.toLowerCase()) {
-            const carry = encodeURIComponent(effectiveQuery);
+            const implicitQ = toImplicitUrlQuery(effectiveQuery, resolvedNpub);
+            const carry = encodeURIComponent(implicitQ);
             router.push(`/p/${resolvedNpub}?q=${carry}`);
             setResolvingAuthor(false);
             setLoading(false);
@@ -374,11 +375,18 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
       setQuery(display);
       const backend = ensureAuthorForBackend(urlQuery, currentProfileNpub);
       handleSearch(backend);
+      // Normalize URL to implicit form if needed
+      const implicit = toImplicitUrlQuery(urlQuery, currentProfileNpub);
+      if (implicit !== urlQuery) {
+        const params = new URLSearchParams(searchParams.toString());
+        params.set('q', implicit);
+        router.replace(`?${params.toString()}`);
+      }
     } else if (urlQuery) {
       setQuery(urlQuery);
       handleSearch(urlQuery);
     }
-  }, [searchParams, handleSearch, manageUrl, pathname]);
+  }, [searchParams, handleSearch, manageUrl, pathname, router]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/lib/examples.ts
+++ b/src/lib/examples.ts
@@ -17,6 +17,7 @@ export const searchExamples = [
   // Combined
   'GM by:dergigi',
   'GM fiat by:fiatjaf',
+  'good by:socrates',
   '#YESTR by:dergigi',
   '👀 by:dergigi',
   'NIP-EE by:jeffg',

--- a/src/lib/examples.ts
+++ b/src/lib/examples.ts
@@ -28,6 +28,7 @@ export const searchExamples = [
 
   // Direct npub
   'GN by:npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc',
+  'proof-of-work by:npub1satsv3728d65nenvkmzthrge0aduj8088dvwkxk70rydm407cl4s87sfhu',
 
   // Profile lookup / NIP-05
   'p:fiatjaf',

--- a/src/lib/search/queryTransforms.ts
+++ b/src/lib/search/queryTransforms.ts
@@ -1,0 +1,41 @@
+// Utilities to keep profile-page query handling DRY
+
+// Regexes
+const BY_TOKEN_RX = /(^|\s)by:(\S+)(?=\s|$)/i;
+const BY_NPUB_RX = /(^|\s)by:(npub1[0-9a-z]+)(?=\s|$)/ig;
+
+export function getCurrentProfileNpub(pathname: string | null | undefined): string | null {
+  if (!pathname) return null;
+  const m = pathname.match(/^\/p\/(npub1[0-9a-z]+)/i);
+  return m ? m[1] : null;
+}
+
+// For the URL bar on /p pages: strip a matching by:<current npub> from the query
+export function toImplicitUrlQuery(explicitQuery: string, currentNpub: string | null): string {
+  if (!explicitQuery) return '';
+  if (!currentNpub) return explicitQuery.trim();
+  return explicitQuery
+    .replace(BY_NPUB_RX, (m, pre: string, npub: string) => {
+      return npub.toLowerCase() === currentNpub.toLowerCase() ? (pre ? pre : '') : m;
+    })
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}
+
+// For the input on /p pages: ensure by:<current npub> is visible/explicit alongside urlQuery
+export function toExplicitInputFromUrl(urlQuery: string, currentNpub: string | null): string {
+  if (!currentNpub) return (urlQuery || '').trim();
+  const base = (urlQuery || '').trim();
+  if (!base) return `by:${currentNpub}`;
+  return /(^|\s)by:\S+(?=\s|$)/i.test(base) ? base : `${base} by:${currentNpub}`;
+}
+
+// For backend searches on /p pages: ensure by:<current npub> filter is included
+export function ensureAuthorForBackend(query: string, currentNpub: string | null): string {
+  const base = (query || '').trim();
+  if (!currentNpub) return base;
+  if (BY_TOKEN_RX.test(base)) return base; // already has a by: token
+  return base ? `${base} by:${currentNpub}` : `by:${currentNpub}`;
+}
+
+


### PR DESCRIPTION
Improve the search experience on profile pages by making the `by:` filter implicit in URLs while keeping it explicit in the search input. The clear button now properly resets to the root path, and profile navigation works correctly when switching between different authors.

- Clear button resets URL to root and clears search state
- Profile pages show explicit `by:` in input but implicit in URL (`?q=`)
- Auto-append `by:<current npub>` to input on submit when missing
- Redirect to correct profile when `by:` targets different author
- DRY refactor of profile-page query handling via `queryTransforms.ts`