### PR TITLE
Add toggle JSON button for events and profiles

### DIFF
--- a/src/components/CardActions.tsx
+++ b/src/components/CardActions.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import React, { forwardRef } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCode, faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
+import { nip19 } from 'nostr-tools';
+import IconButton from '@/components/IconButton';
+
+type Props = {
+  eventId?: string;
+  showRaw: boolean;
+  onToggleRaw: () => void;
+  onToggleMenu: () => void;
+  menuButtonRef?: React.RefObject<HTMLButtonElement>;
+  className?: string;
+};
+
+const CardActions = forwardRef<HTMLDivElement, Props>(function CardActions(
+  { eventId, showRaw, onToggleRaw, onToggleMenu, menuButtonRef, className }: Props,
+  ref
+) {
+  if (!eventId) return null;
+
+  return (
+    <div ref={ref} className={`flex items-center gap-2 ${className || ''}`.trim()}>
+      <IconButton
+        title={showRaw ? 'Hide raw JSON' : 'Show raw JSON'}
+        ariaLabel="Toggle raw JSON"
+        onClick={(e) => { e.preventDefault(); e.stopPropagation(); onToggleRaw(); }}
+      >
+        <FontAwesomeIcon icon={faCode} className="text-xs" />
+      </IconButton>
+      <IconButton
+        ref={menuButtonRef}
+        title="Open in portals"
+        ariaLabel="Open in portals"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          onToggleMenu();
+        }}
+      >
+        ⋯
+      </IconButton>
+      <a
+        href={`nostr:${nip19.neventEncode({ id: eventId })}`}
+        title="Open in native client"
+        className="text-gray-400 hover:text-gray-200"
+        onClick={(e) => { e.stopPropagation(); }}
+      >
+        <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-xs" />
+      </a>
+    </div>
+  );
+});
+
+export default CardActions;

--- a/src/components/CardActions.tsx
+++ b/src/components/CardActions.tsx
@@ -11,7 +11,7 @@ type Props = {
   showRaw: boolean;
   onToggleRaw: () => void;
   onToggleMenu: () => void;
-  menuButtonRef?: React.RefObject<HTMLButtonElement>;
+  menuButtonRef?: React.RefObject<HTMLButtonElement | null>;
   className?: string;
 };
 

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCopy, faCheck } from '@fortawesome/free-solid-svg-icons';
+
+type Props = {
+  text: string;
+  title?: string;
+  className?: string;
+};
+
+export default function CopyButton({ text, title = 'Copy', className }: Props) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => { 
+    if (timerRef.current) clearTimeout(timerRef.current); 
+  }, []);
+
+  const handleCopy = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    try { 
+      await navigator.clipboard.writeText(text); 
+    } catch {}
+    setCopied(true);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <button
+      type="button"
+      title={copied ? 'Copied' : title}
+      aria-label={copied ? 'Copied' : title}
+      className={`w-6 h-6 rounded-md border border-[#3d3d3d] text-gray-300 hover:bg-[#2a2a2a] flex items-center justify-center ${className || ''}`.trim()}
+      onClick={handleCopy}
+    >
+      <FontAwesomeIcon icon={copied ? faCheck : faCopy} className="text-xs" />
+    </button>
+  );
+}

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -9,6 +9,7 @@ import { useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { createEventExplorerItems } from '@/lib/portals';
 import RawEventJson from '@/components/RawEventJson';
+import IconButton from '@/components/IconButton';
 
 type Props = {
   event: NDKEvent;
@@ -58,20 +59,17 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
               {event?.id ? (
                 <>
                   
-                  <button
-                    type="button"
-                    aria-label="Toggle raw JSON"
+                  <IconButton
                     title={showRaw ? 'Hide raw JSON' : 'Show raw JSON'}
+                    ariaLabel="Toggle raw JSON"
                     onClick={(e) => { e.preventDefault(); e.stopPropagation(); setShowRaw(v => !v); }}
-                    className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]"
                   >
                     <FontAwesomeIcon icon={faCode} className="text-xs" />
-                  </button>
-                  <button
+                  </IconButton>
+                  <IconButton
                     ref={portalButtonRef}
-                    type="button"
-                    aria-label="Open in portals"
                     title="Open in portals"
+                    ariaLabel="Open in portals"
                     onClick={(e) => {
                       e.preventDefault();
                       e.stopPropagation();
@@ -81,10 +79,9 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
                       }
                       setShowPortalMenu((v) => !v);
                     }}
-                    className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]"
                   >
                     ⋯
-                  </button>
+                  </IconButton>
                   <a
                     href={`nostr:${nip19.neventEncode({ id: event.id })}`}
                     title="Open in native client"

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -57,24 +57,7 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
               {footerRight}
               {event?.id ? (
                 <>
-                  <button
-                    ref={portalButtonRef}
-                    type="button"
-                    aria-label="Open in portals"
-                    title="Open in portals"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      if (portalButtonRef.current) {
-                        const rect = portalButtonRef.current.getBoundingClientRect();
-                        setMenuPosition({ top: rect.bottom + 4, left: rect.left });
-                      }
-                      setShowPortalMenu((v) => !v);
-                    }}
-                    className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]"
-                  >
-                    ⋯
-                  </button>
+                  
                   <button
                     type="button"
                     aria-label="Toggle raw JSON"

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -9,7 +9,7 @@ import { useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { createEventExplorerItems } from '@/lib/portals';
 import RawEventJson from '@/components/RawEventJson';
-import IconButton from '@/components/IconButton';
+import CardActions from '@/components/CardActions';
 
 type Props = {
   event: NDKEvent;
@@ -59,42 +59,19 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
           {footerRight ? (
             <div className="flex items-center gap-2">
               {footerRight}
-              {event?.id ? (
-                <>
-                  
-                  <IconButton
-                    title={showRaw ? 'Hide raw JSON' : 'Show raw JSON'}
-                    ariaLabel="Toggle raw JSON"
-                    onClick={(e) => { e.preventDefault(); e.stopPropagation(); setShowRaw(v => !v); }}
-                  >
-                    <FontAwesomeIcon icon={faCode} className="text-xs" />
-                  </IconButton>
-                  <IconButton
-                    ref={portalButtonRef}
-                    title="Open in portals"
-                    ariaLabel="Open in portals"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      if (portalButtonRef.current) {
-                        const rect = portalButtonRef.current.getBoundingClientRect();
-                        setMenuPosition({ top: rect.bottom + 4, left: rect.left });
-                      }
-                      setShowPortalMenu((v) => !v);
-                    }}
-                  >
-                    ⋯
-                  </IconButton>
-                  <a
-                    href={`nostr:${nip19.neventEncode({ id: event.id })}`}
-                    title="Open in native client"
-                    className="text-gray-400 hover:text-gray-200"
-                    onClick={(e) => { e.stopPropagation(); }}
-                  >
-                    <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-xs" />
-                  </a>
-                </>
-              ) : null}
+              <CardActions
+                eventId={event?.id}
+                showRaw={showRaw}
+                onToggleRaw={() => setShowRaw(v => !v)}
+                onToggleMenu={() => {
+                  if (portalButtonRef.current) {
+                    const rect = portalButtonRef.current.getBoundingClientRect();
+                    setMenuPosition({ top: rect.bottom + 4, left: rect.left });
+                  }
+                  setShowPortalMenu((v) => !v);
+                }}
+                menuButtonRef={portalButtonRef}
+              />
             </div>
           ) : null}
         </div>

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -55,15 +55,6 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
           {footerRight ? (
             <div className="flex items-center gap-2">
               {footerRight}
-              <button
-                type="button"
-                aria-label="Toggle raw JSON"
-                title={showRaw ? 'Hide raw JSON' : 'Show raw JSON'}
-                onClick={(e) => { e.preventDefault(); e.stopPropagation(); setShowRaw(v => !v); }}
-                className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]"
-              >
-                <FontAwesomeIcon icon={faCode} className="text-xs" />
-              </button>
               {event?.id ? (
                 <>
                   <button
@@ -83,6 +74,15 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
                     className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]"
                   >
                     ⋯
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="Toggle raw JSON"
+                    title={showRaw ? 'Hide raw JSON' : 'Show raw JSON'}
+                    onClick={(e) => { e.preventDefault(); e.stopPropagation(); setShowRaw(v => !v); }}
+                    className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]"
+                  >
+                    <FontAwesomeIcon icon={faCode} className="text-xs" />
                   </button>
                   <a
                     href={`nostr:${nip19.neventEncode({ id: event.id })}`}

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -4,7 +4,7 @@ import { NDKEvent } from '@nostr-dev-kit/ndk';
 import AuthorBadge from '@/components/AuthorBadge';
 import { nip19 } from 'nostr-tools';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faArrowUpRightFromSquare, faCode } from '@fortawesome/free-solid-svg-icons';
+import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 import { useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { createEventExplorerItems } from '@/lib/portals';

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -41,13 +41,16 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
 
   return (
     <div className={containerClasses}>
-      <div className={contentClasses}>{renderContent(event.content || '')}</div>
-      {showRaw && (
-        <div className="mt-3">
+      {showRaw ? (
+        <div className="mt-0">
           <RawEventJson event={event} />
         </div>
+      ) : (
+        <>
+          <div className={contentClasses}>{renderContent(event.content || '')}</div>
+          {variant !== 'inline' && mediaRenderer ? mediaRenderer(event.content || '') : null}
+        </>
       )}
-      {variant !== 'inline' && mediaRenderer ? mediaRenderer(event.content || '') : null}
       {showFooter && (
         <div className={variant === 'inline' ? 'text-xs text-gray-300 pt-1 border-t border-[#3d3d3d] flex items-center justify-between gap-2' : 'mt-4 text-xs text-gray-300 bg-[#2d2d2d] border-t border-[#3d3d3d] -mx-4 -mb-4 px-4 py-2 flex items-center justify-between gap-2 flex-wrap rounded-b-lg'}>
           <div className="flex items-center gap-2">

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -4,10 +4,11 @@ import { NDKEvent } from '@nostr-dev-kit/ndk';
 import AuthorBadge from '@/components/AuthorBadge';
 import { nip19 } from 'nostr-tools';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
+import { faArrowUpRightFromSquare, faCode } from '@fortawesome/free-solid-svg-icons';
 import { useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { createEventExplorerItems } from '@/lib/portals';
+import RawEventJson from '@/components/RawEventJson';
 
 type Props = {
   event: NDKEvent;
@@ -35,10 +36,16 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
   const [showPortalMenu, setShowPortalMenu] = useState(false);
   const [menuPosition, setMenuPosition] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
   const portalButtonRef = useRef<HTMLButtonElement>(null);
+  const [showRaw, setShowRaw] = useState(false);
 
   return (
     <div className={containerClasses}>
       <div className={contentClasses}>{renderContent(event.content || '')}</div>
+      {showRaw && (
+        <div className="mt-3">
+          <RawEventJson event={event} />
+        </div>
+      )}
       {variant !== 'inline' && mediaRenderer ? mediaRenderer(event.content || '') : null}
       {showFooter && (
         <div className={variant === 'inline' ? 'text-xs text-gray-300 pt-1 border-t border-[#3d3d3d] flex items-center justify-between gap-2' : 'mt-4 text-xs text-gray-300 bg-[#2d2d2d] border-t border-[#3d3d3d] -mx-4 -mb-4 px-4 py-2 flex items-center justify-between gap-2 flex-wrap rounded-b-lg'}>
@@ -48,6 +55,15 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
           {footerRight ? (
             <div className="flex items-center gap-2">
               {footerRight}
+              <button
+                type="button"
+                aria-label="Toggle raw JSON"
+                title={showRaw ? 'Hide raw JSON' : 'Show raw JSON'}
+                onClick={(e) => { e.preventDefault(); e.stopPropagation(); setShowRaw(v => !v); }}
+                className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]"
+              >
+                <FontAwesomeIcon icon={faCode} className="text-xs" />
+              </button>
               {event?.id ? (
                 <>
                   <button
@@ -103,7 +119,7 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
                       href={item.href}
                       target={item.href.startsWith('http') ? '_blank' : undefined}
                       rel={item.href.startsWith('http') ? 'noopener noreferrer' : undefined}
-                      className="block px-3 py-2 hover:bg-[#3a3a3a] flex items-center justify-between"
+                      className="px-3 py-2 hover:bg-[#3a3a3a] flex items-center justify-between"
                       onClick={(e) => { e.stopPropagation(); setShowPortalMenu(false); }}
                     >
                       <span>{item.name}</span>

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -84,6 +84,24 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
                   >
                     <FontAwesomeIcon icon={faCode} className="text-xs" />
                   </button>
+                  <button
+                    ref={portalButtonRef}
+                    type="button"
+                    aria-label="Open in portals"
+                    title="Open in portals"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      if (portalButtonRef.current) {
+                        const rect = portalButtonRef.current.getBoundingClientRect();
+                        setMenuPosition({ top: rect.bottom + 4, left: rect.left });
+                      }
+                      setShowPortalMenu((v) => !v);
+                    }}
+                    className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]"
+                  >
+                    ⋯
+                  </button>
                   <a
                     href={`nostr:${nip19.neventEncode({ id: event.id })}`}
                     title="Open in native client"

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import React, { forwardRef } from 'react';
+
+type Props = {
+  title: string;
+  ariaLabel?: string;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  className?: string;
+  type?: 'button' | 'submit' | 'reset';
+  children: React.ReactNode;
+};
+
+const baseClass = 'w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]';
+
+const IconButton = forwardRef<HTMLButtonElement, Props>(function IconButton(
+  { title, ariaLabel, onClick, className, type = 'button', children }: Props,
+  ref
+) {
+  return (
+    <button
+      ref={ref}
+      type={type}
+      aria-label={ariaLabel || title}
+      title={title}
+      onClick={onClick}
+      className={className ? `${baseClass} ${className}` : baseClass}
+    >
+      {children}
+    </button>
+  );
+});
+
+export default IconButton;
+
+

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -14,6 +14,7 @@ import { createPortal } from 'react-dom';
 import { createProfileExplorerItems } from '@/lib/portals';
 import { getIsKindTokens } from '@/lib/search/replacements';
 import RawEventJson from '@/components/RawEventJson';
+import IconButton from '@/components/IconButton';
 
 function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightning, npub, onToggleRaw, showRaw }: { pubkey: string; fallbackEventId?: string; fallbackCreatedAt?: number; lightning?: string; npub: string; onToggleRaw: () => void; showRaw: boolean }) {
   const [createdAt, setCreatedAt] = useState<number | null>(null);
@@ -95,20 +96,17 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
         ) : (
           <span>{sinceLabel}</span>
         )}
-        <button
-          type="button"
-          aria-label="Toggle raw JSON"
+        <IconButton
           title={showRaw ? 'Hide raw JSON' : 'Show raw JSON'}
+          ariaLabel="Toggle raw JSON"
           onClick={(e) => { e.preventDefault(); e.stopPropagation(); onToggleRaw(); }}
-          className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]"
         >
           <FontAwesomeIcon icon={faCode} className="text-xs" />
-        </button>
-        <button
+        </IconButton>
+        <IconButton
           ref={bottomButtonRef}
-          type="button"
-          aria-label="Open in portals"
           title="Open in portals"
+          ariaLabel="Open in portals"
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
@@ -118,10 +116,9 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
             }
             setShowPortalMenuBottom((v) => !v);
           }}
-          className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]"
         >
           ⋯
-        </button>
+        </IconButton>
         <a
           href={`nostr:${npub}`}
           title="Open in native client"

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -96,6 +96,15 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
           <span>{sinceLabel}</span>
         )}
         <button
+          type="button"
+          aria-label="Toggle raw JSON"
+          title={showRaw ? 'Hide raw JSON' : 'Show raw JSON'}
+          onClick={(e) => { e.preventDefault(); e.stopPropagation(); onToggleRaw(); }}
+          className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]"
+        >
+          <FontAwesomeIcon icon={faCode} className="text-xs" />
+        </button>
+        <button
           ref={bottomButtonRef}
           type="button"
           aria-label="Open in portals"
@@ -112,15 +121,6 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
           className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]"
         >
           ⋯
-        </button>
-        <button
-          type="button"
-          aria-label="Toggle raw JSON"
-          title={showRaw ? 'Hide raw JSON' : 'Show raw JSON'}
-          onClick={(e) => { e.preventDefault(); e.stopPropagation(); onToggleRaw(); }}
-          className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]"
-        >
-          <FontAwesomeIcon icon={faCode} className="text-xs" />
         </button>
         <a
           href={`nostr:${npub}`}

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -9,10 +9,11 @@ import { isAbsoluteHttpUrl } from '@/lib/urlPatterns';
 import { useEffect, useMemo, useState, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faArrowUpRightFromSquare, faCopy } from '@fortawesome/free-solid-svg-icons';
+import { faArrowUpRightFromSquare, faCopy, faCode } from '@fortawesome/free-solid-svg-icons';
 import { createPortal } from 'react-dom';
 import { createProfileExplorerItems } from '@/lib/portals';
 import { getIsKindTokens } from '@/lib/search/replacements';
+import RawEventJson from '@/components/RawEventJson';
 
 function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightning, npub }: { pubkey: string; fallbackEventId?: string; fallbackCreatedAt?: number; lightning?: string; npub: string }) {
   const [createdAt, setCreatedAt] = useState<number | null>(null);
@@ -139,7 +140,7 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
                     href={item.href}
                     target={item.href.startsWith('http') ? '_blank' : undefined}
                     rel={item.href.startsWith('http') ? 'noopener noreferrer' : undefined}
-                    className="block px-3 py-2 hover:bg-[#3a3a3a] flex items-center justify-between"
+                    className="px-3 py-2 hover:bg-[#3a3a3a] flex items-center justify-between"
                     onClick={(e) => { e.stopPropagation(); setShowPortalMenuBottom(false); }}
                   >
                     <span>{item.name}</span>
@@ -174,6 +175,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
   const [showPortalMenu, setShowPortalMenu] = useState(false);
   const [menuPosition, setMenuPosition] = useState({ top: 0, left: 0 });
   const buttonRef = useRef<HTMLButtonElement>(null);
+  const [showRaw, setShowRaw] = useState(false);
 
   const [quickSearchItems, setQuickSearchItems] = useState<string[]>([]);
   useEffect(() => {
@@ -355,6 +357,15 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
           <div className="flex items-center gap-2 max-w-[50%] text-right text-sm text-gray-400">
             <button
               type="button"
+              aria-label="Toggle raw JSON"
+              title={showRaw ? 'Hide raw JSON' : 'Show raw JSON'}
+              onClick={(e) => { e.preventDefault(); e.stopPropagation(); setShowRaw(v => !v); }}
+              className="p-1 rounded hover:bg-[#3a3a3a]"
+            >
+              <FontAwesomeIcon icon={faCode} className="text-gray-400 text-xs" />
+            </button>
+            <button
+              type="button"
               aria-label="Copy npub"
               title="Copy npub"
               onClick={async (e) => {
@@ -372,11 +383,15 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
           </div>
         )}
       </div>
-      {event.author?.profile?.about && (
+      {showRaw ? (
+        <div className="mt-4">
+          <RawEventJson event={event} />
+        </div>
+      ) : event.author?.profile?.about ? (
         <p className="mt-4 text-gray-300 break-words">
           {renderBioWithHashtags(event.author?.profile?.about)}
         </p>
-      )}
+      ) : null}
       </div>
       <ProfileCreatedAt
         pubkey={event.author.pubkey}

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -402,7 +402,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
       </div>
       {showRaw ? (
         <div className="mt-4">
-          <RawEventJson event={rawProfileEvent || event} loading={rawLoading} />
+          <RawEventJson event={rawProfileEvent || event} loading={rawLoading} title="Event JSON" parseContent={true} />
         </div>
       ) : event.author?.profile?.about ? (
         <p className="mt-4 text-gray-300 break-words">

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -9,7 +9,7 @@ import { isAbsoluteHttpUrl } from '@/lib/urlPatterns';
 import { useEffect, useMemo, useState, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faArrowUpRightFromSquare, faCopy, faCode } from '@fortawesome/free-solid-svg-icons';
+import { faArrowUpRightFromSquare, faCopy } from '@fortawesome/free-solid-svg-icons';
 import { createPortal } from 'react-dom';
 import { createProfileExplorerItems } from '@/lib/portals';
 import { getIsKindTokens } from '@/lib/search/replacements';

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -15,7 +15,7 @@ import { createProfileExplorerItems } from '@/lib/portals';
 import { getIsKindTokens } from '@/lib/search/replacements';
 import RawEventJson from '@/components/RawEventJson';
 
-function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightning, npub }: { pubkey: string; fallbackEventId?: string; fallbackCreatedAt?: number; lightning?: string; npub: string }) {
+function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightning, npub, onToggleRaw, showRaw }: { pubkey: string; fallbackEventId?: string; fallbackCreatedAt?: number; lightning?: string; npub: string; onToggleRaw: () => void; showRaw: boolean }) {
   const [createdAt, setCreatedAt] = useState<number | null>(null);
   const [createdEventId, setCreatedEventId] = useState<string | null>(null);
   const [updatedAt, setUpdatedAt] = useState<number | null>(null);
@@ -112,6 +112,15 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
           className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]"
         >
           ⋯
+        </button>
+        <button
+          type="button"
+          aria-label="Toggle raw JSON"
+          title={showRaw ? 'Hide raw JSON' : 'Show raw JSON'}
+          onClick={(e) => { e.preventDefault(); e.stopPropagation(); onToggleRaw(); }}
+          className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]"
+        >
+          <FontAwesomeIcon icon={faCode} className="text-xs" />
         </button>
         <a
           href={`nostr:${npub}`}
@@ -357,15 +366,6 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
           <div className="flex items-center gap-2 max-w-[50%] text-right text-sm text-gray-400">
             <button
               type="button"
-              aria-label="Toggle raw JSON"
-              title={showRaw ? 'Hide raw JSON' : 'Show raw JSON'}
-              onClick={(e) => { e.preventDefault(); e.stopPropagation(); setShowRaw(v => !v); }}
-              className="p-1 rounded hover:bg-[#3a3a3a]"
-            >
-              <FontAwesomeIcon icon={faCode} className="text-gray-400 text-xs" />
-            </button>
-            <button
-              type="button"
               aria-label="Copy npub"
               title="Copy npub"
               onClick={async (e) => {
@@ -399,6 +399,8 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
         fallbackCreatedAt={event.created_at}
         lightning={profile?.lud16}
         npub={event.author.npub}
+        onToggleRaw={() => setShowRaw(v => !v)}
+        showRaw={showRaw}
       />
       {showPortalMenu && typeof window !== 'undefined' && createPortal(
         <>

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -14,7 +14,7 @@ import { createPortal } from 'react-dom';
 import { createProfileExplorerItems } from '@/lib/portals';
 import { getIsKindTokens } from '@/lib/search/replacements';
 import RawEventJson from '@/components/RawEventJson';
-import IconButton from '@/components/IconButton';
+import CardActions from '@/components/CardActions';
 
 function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightning, npub, onToggleRaw, showRaw }: { pubkey: string; fallbackEventId?: string; fallbackCreatedAt?: number; lightning?: string; npub: string; onToggleRaw: () => void; showRaw: boolean }) {
   const [createdAt, setCreatedAt] = useState<number | null>(null);
@@ -96,37 +96,19 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
         ) : (
           <span>{sinceLabel}</span>
         )}
-        <IconButton
-          title={showRaw ? 'Hide raw JSON' : 'Show raw JSON'}
-          ariaLabel="Toggle raw JSON"
-          onClick={(e) => { e.preventDefault(); e.stopPropagation(); onToggleRaw(); }}
-        >
-          <FontAwesomeIcon icon={faCode} className="text-xs" />
-        </IconButton>
-        <IconButton
-          ref={bottomButtonRef}
-          title="Open in portals"
-          ariaLabel="Open in portals"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
+        <CardActions
+          eventId={fallbackEventId}
+          showRaw={showRaw}
+          onToggleRaw={onToggleRaw}
+          onToggleMenu={() => {
             if (bottomButtonRef.current) {
               const rect = bottomButtonRef.current.getBoundingClientRect();
               setMenuPositionBottom({ top: rect.bottom + 4, left: rect.left });
             }
             setShowPortalMenuBottom((v) => !v);
           }}
-        >
-          ⋯
-        </IconButton>
-        <a
-          href={`nostr:${npub}`}
-          title="Open in native client"
-          className="text-gray-400 hover:text-gray-200"
-          onClick={(e) => { e.stopPropagation(); }}
-        >
-          <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-xs" />
-        </a>
+          menuButtonRef={bottomButtonRef}
+        />
       </div>
       {showPortalMenuBottom && typeof window !== 'undefined' && createPortal(
         <>

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import { NDKEvent } from '@nostr-dev-kit/ndk';
 import AuthorBadge from '@/components/AuthorBadge';
 import { nip19 } from 'nostr-tools';
-import { getOldestProfileMetadata, getNewestProfileMetadata } from '@/lib/vertex';
+import { getOldestProfileMetadata, getNewestProfileMetadata, getNewestProfileEvent } from '@/lib/vertex';
 import { isAbsoluteHttpUrl } from '@/lib/urlPatterns';
 import { useEffect, useMemo, useState, useRef } from 'react';
 import { useRouter } from 'next/navigation';
@@ -206,8 +206,8 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
     (async () => {
       try {
         setRawLoading(true);
-        const newest = await getNewestProfileMetadata(event.author.pubkey);
-        if (!cancelled) setRawProfileEvent(newest || null);
+        const newestEvt = await getNewestProfileEvent(event.author.pubkey);
+        if (!cancelled) setRawProfileEvent(newestEvt || null);
       } catch {
         if (!cancelled) setRawProfileEvent(null);
       } finally {

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -402,7 +402,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
       </div>
       {showRaw ? (
         <div className="mt-4">
-          <RawEventJson event={rawProfileEvent || event} loading={rawLoading} title="Event JSON" parseContent={true} />
+          <RawEventJson event={rawProfileEvent || event} loading={rawLoading} parseContent={true} />
         </div>
       ) : event.author?.profile?.about ? (
         <p className="mt-4 text-gray-300 break-words">

--- a/src/components/RawEventJson.tsx
+++ b/src/components/RawEventJson.tsx
@@ -12,7 +12,7 @@ type Props = {
   parseContent?: boolean;
 };
 
-export default function RawEventJson({ event, loading = false, className, title = 'Event JSON', parseContent = true }: Props) {
+export default function RawEventJson({ event, loading = false, className, title, parseContent = true }: Props) {
   if (loading) return <div className={`text-xs text-gray-400 ${className || ''}`.trim()}>Loading…</div>;
   if (!event) return <div className={`text-xs text-gray-400 ${className || ''}`.trim()}>No event available</div>;
 
@@ -33,9 +33,11 @@ export default function RawEventJson({ event, loading = false, className, title 
 
   return (
     <div>
-      {title ? (
+      {(() => {
+        const headerTitle = typeof title === 'string' ? title : (typeof event?.kind === 'number' ? `kind:${event.kind}` : null);
+        return headerTitle ? (
         <div className="text-xs text-gray-300 mb-2 flex items-center justify-between">
-          <span className="font-semibold">{title}</span>
+          <span className="font-semibold">{headerTitle}</span>
           <button
             type="button"
             title="Copy JSON"
@@ -46,7 +48,8 @@ export default function RawEventJson({ event, loading = false, className, title 
             Copy
           </button>
         </div>
-      ) : null}
+        ) : null;
+      })()}
       <Highlight code={json} language="json" theme={themes.nightOwl}>
         {({ className: cls, style, tokens, getLineProps, getTokenProps }: RenderProps) => (
           <pre

--- a/src/components/RawEventJson.tsx
+++ b/src/components/RawEventJson.tsx
@@ -8,31 +8,62 @@ type Props = {
   event: NDKEvent | null | undefined;
   loading?: boolean;
   className?: string;
+  title?: string;
+  parseContent?: boolean;
 };
 
-export default function RawEventJson({ event, loading = false, className }: Props) {
+export default function RawEventJson({ event, loading = false, className, title = 'Event JSON', parseContent = true }: Props) {
   if (loading) return <div className={`text-xs text-gray-400 ${className || ''}`.trim()}>Loading…</div>;
   if (!event) return <div className={`text-xs text-gray-400 ${className || ''}`.trim()}>No event available</div>;
 
-  const json = JSON.stringify(toPlainEvent(event), null, 2);
+  const base = toPlainEvent(event) as Record<string, unknown>;
+  const data: Record<string, unknown> = { ...base };
+  try {
+    if (parseContent) {
+      const raw = data.content;
+      if (typeof raw === 'string') {
+        const trimmed = raw.trim();
+        if ((trimmed.startsWith('{') && trimmed.endsWith('}')) || (trimmed.startsWith('[') && trimmed.endsWith(']'))) {
+          data.content = JSON.parse(trimmed);
+        }
+      }
+    }
+  } catch {}
+  const json = JSON.stringify(data, null, 2);
 
   return (
-    <Highlight code={json} language="json" theme={themes.nightOwl}>
-      {({ className: cls, style, tokens, getLineProps, getTokenProps }: RenderProps) => (
-        <pre
-          className={`${cls} text-xs overflow-x-auto rounded-md p-3 bg-[#1f1f1f] border border-[#3d3d3d] ${className || ''}`.trim()}
-          style={{ ...style, background: 'transparent', whiteSpace: 'pre' }}
-        >
-          {tokens.map((line, i) => (
-            <div key={`l-${i}`} {...getLineProps({ line })}>
-              {line.map((token, key) => (
-                <span key={`t-${i}-${key}`} {...getTokenProps({ token })} />
-              ))}
-            </div>
-          ))}
-        </pre>
-      )}
-    </Highlight>
+    <div>
+      {title ? (
+        <div className="text-xs text-gray-300 mb-2 flex items-center justify-between">
+          <span className="font-semibold">{title}</span>
+          <button
+            type="button"
+            title="Copy JSON"
+            aria-label="Copy JSON"
+            className="px-2 py-0.5 rounded border border-[#3d3d3d] text-gray-300 hover:bg-[#2a2a2a]"
+            onClick={async (e) => { e.preventDefault(); try { await navigator.clipboard.writeText(json); } catch {} }}
+          >
+            Copy
+          </button>
+        </div>
+      ) : null}
+      <Highlight code={json} language="json" theme={themes.nightOwl}>
+        {({ className: cls, style, tokens, getLineProps, getTokenProps }: RenderProps) => (
+          <pre
+            className={`${cls} text-xs overflow-x-auto rounded-md p-3 bg-[#1f1f1f] border border-[#3d3d3d] ${className || ''}`.trim()}
+            style={{ ...style, background: 'transparent', whiteSpace: 'pre' }}
+          >
+            {tokens.map((line, i) => (
+              <div key={`l-${i}`} {...getLineProps({ line })}>
+                {line.map((token, key) => (
+                  <span key={`t-${i}-${key}`} {...getTokenProps({ token })} />
+                ))}
+              </div>
+            ))}
+          </pre>
+        )}
+      </Highlight>
+    </div>
   );
 }
 

--- a/src/components/RawEventJson.tsx
+++ b/src/components/RawEventJson.tsx
@@ -3,6 +3,9 @@
 import { NDKEvent } from '@nostr-dev-kit/ndk';
 import { Highlight, themes, type RenderProps } from 'prism-react-renderer';
 import { toPlainEvent } from '@/lib/toPlainEvent';
+import { useEffect, useRef, useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCopy, faCheck } from '@fortawesome/free-solid-svg-icons';
 
 type Props = {
   event: NDKEvent | null | undefined;
@@ -38,15 +41,29 @@ export default function RawEventJson({ event, loading = false, className, title,
         return headerTitle ? (
         <div className="text-xs text-gray-300 mb-2 flex items-center justify-between">
           <span className="font-semibold">{headerTitle}</span>
-          <button
-            type="button"
-            title="Copy JSON"
-            aria-label="Copy JSON"
-            className="px-2 py-0.5 rounded border border-[#3d3d3d] text-gray-300 hover:bg-[#2a2a2a]"
-            onClick={async (e) => { e.preventDefault(); try { await navigator.clipboard.writeText(json); } catch {} }}
-          >
-            Copy
-          </button>
+          {(() => {
+            const [copied, setCopied] = useState(false);
+            const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+            useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current); }, []);
+            const handleCopy = async (e: React.MouseEvent<HTMLButtonElement>) => {
+              e.preventDefault();
+              try { await navigator.clipboard.writeText(json); } catch {}
+              setCopied(true);
+              if (timerRef.current) clearTimeout(timerRef.current);
+              timerRef.current = setTimeout(() => setCopied(false), 1500);
+            };
+            return (
+              <button
+                type="button"
+                title={copied ? 'Copied' : 'Copy JSON'}
+                aria-label={copied ? 'Copied' : 'Copy JSON'}
+                className="w-6 h-6 rounded-md border border-[#3d3d3d] text-gray-300 hover:bg-[#2a2a2a] flex items-center justify-center"
+                onClick={handleCopy}
+              >
+                <FontAwesomeIcon icon={copied ? faCheck : faCopy} className="text-xs" />
+              </button>
+            );
+          })()}
         </div>
         ) : null;
       })()}

--- a/src/components/RawEventJson.tsx
+++ b/src/components/RawEventJson.tsx
@@ -2,6 +2,7 @@
 
 import { NDKEvent } from '@nostr-dev-kit/ndk';
 import { Highlight, themes, type RenderProps } from 'prism-react-renderer';
+import { toPlainEvent } from '@/lib/toPlainEvent';
 
 type Props = {
   event: NDKEvent | null | undefined;
@@ -13,19 +14,7 @@ export default function RawEventJson({ event, loading = false, className }: Prop
   if (loading) return <div className={`text-xs text-gray-400 ${className || ''}`.trim()}>Loading…</div>;
   if (!event) return <div className={`text-xs text-gray-400 ${className || ''}`.trim()}>No event available</div>;
 
-  const json = JSON.stringify(
-    {
-      id: event.id,
-      kind: event.kind,
-      created_at: event.created_at,
-      pubkey: event.pubkey,
-      content: event.content,
-      tags: event.tags,
-      sig: event.sig
-    },
-    null,
-    2
-  );
+  const json = JSON.stringify(toPlainEvent(event), null, 2);
 
   return (
     <Highlight code={json} language="json" theme={themes.nightOwl}>

--- a/src/components/RawEventJson.tsx
+++ b/src/components/RawEventJson.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { NDKEvent } from '@nostr-dev-kit/ndk';
+import { Highlight, themes, type RenderProps } from 'prism-react-renderer';
+
+type Props = {
+  event: NDKEvent | null | undefined;
+  loading?: boolean;
+  className?: string;
+};
+
+export default function RawEventJson({ event, loading = false, className }: Props) {
+  if (loading) return <div className={`text-xs text-gray-400 ${className || ''}`.trim()}>Loading…</div>;
+  if (!event) return <div className={`text-xs text-gray-400 ${className || ''}`.trim()}>No event available</div>;
+
+  const json = JSON.stringify(
+    {
+      id: event.id,
+      kind: event.kind,
+      created_at: event.created_at,
+      pubkey: event.pubkey,
+      content: event.content,
+      tags: event.tags,
+      sig: event.sig
+    },
+    null,
+    2
+  );
+
+  return (
+    <Highlight code={json} language="json" theme={themes.nightOwl}>
+      {({ className: cls, style, tokens, getLineProps, getTokenProps }: RenderProps) => (
+        <pre
+          className={`${cls} text-xs overflow-x-auto rounded-md p-3 bg-[#1f1f1f] border border-[#3d3d3d] ${className || ''}`.trim()}
+          style={{ ...style, background: 'transparent', whiteSpace: 'pre' }}
+        >
+          {tokens.map((line, i) => (
+            <div key={`l-${i}`} {...getLineProps({ line })}>
+              {line.map((token, key) => (
+                <span key={`t-${i}-${key}`} {...getTokenProps({ token })} />
+              ))}
+            </div>
+          ))}
+        </pre>
+      )}
+    </Highlight>
+  );
+}
+
+

--- a/src/components/RawEventJson.tsx
+++ b/src/components/RawEventJson.tsx
@@ -3,9 +3,7 @@
 import { NDKEvent } from '@nostr-dev-kit/ndk';
 import { Highlight, themes, type RenderProps } from 'prism-react-renderer';
 import { toPlainEvent } from '@/lib/toPlainEvent';
-import { useEffect, useRef, useState } from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCopy, faCheck } from '@fortawesome/free-solid-svg-icons';
+import CopyButton from '@/components/CopyButton';
 
 type Props = {
   event: NDKEvent | null | undefined;
@@ -41,29 +39,7 @@ export default function RawEventJson({ event, loading = false, className, title,
         return headerTitle ? (
         <div className="text-xs text-gray-300 mb-2 flex items-center justify-between">
           <span className="font-semibold">{headerTitle}</span>
-          {(() => {
-            const [copied, setCopied] = useState(false);
-            const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-            useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current); }, []);
-            const handleCopy = async (e: React.MouseEvent<HTMLButtonElement>) => {
-              e.preventDefault();
-              try { await navigator.clipboard.writeText(json); } catch {}
-              setCopied(true);
-              if (timerRef.current) clearTimeout(timerRef.current);
-              timerRef.current = setTimeout(() => setCopied(false), 1500);
-            };
-            return (
-              <button
-                type="button"
-                title={copied ? 'Copied' : 'Copy JSON'}
-                aria-label={copied ? 'Copied' : 'Copy JSON'}
-                className="w-6 h-6 rounded-md border border-[#3d3d3d] text-gray-300 hover:bg-[#2a2a2a] flex items-center justify-center"
-                onClick={handleCopy}
-              >
-                <FontAwesomeIcon icon={copied ? faCheck : faCopy} className="text-xs" />
-              </button>
-            );
-          })()}
+          <CopyButton text={json} title="Copy JSON" />
         </div>
         ) : null;
       })()}

--- a/src/components/RawEventJson.tsx
+++ b/src/components/RawEventJson.tsx
@@ -14,7 +14,18 @@ export default function RawEventJson({ event, loading = false, className }: Prop
   if (loading) return <div className={`text-xs text-gray-400 ${className || ''}`.trim()}>Loading…</div>;
   if (!event) return <div className={`text-xs text-gray-400 ${className || ''}`.trim()}>No event available</div>;
 
-  const json = JSON.stringify(toPlainEvent(event), null, 2);
+  const base = toPlainEvent(event) as Record<string, unknown>;
+  const data: Record<string, unknown> = { ...base };
+  try {
+    const raw = data.content;
+    if (typeof raw === 'string') {
+      const trimmed = raw.trim();
+      if ((trimmed.startsWith('{') && trimmed.endsWith('}')) || (trimmed.startsWith('[') && trimmed.endsWith(']'))) {
+        data.content = JSON.parse(trimmed);
+      }
+    }
+  } catch {}
+  const json = JSON.stringify(data, null, 2);
 
   return (
     <Highlight code={json} language="json" theme={themes.nightOwl}>

--- a/src/components/RawEventJson.tsx
+++ b/src/components/RawEventJson.tsx
@@ -14,18 +14,7 @@ export default function RawEventJson({ event, loading = false, className }: Prop
   if (loading) return <div className={`text-xs text-gray-400 ${className || ''}`.trim()}>Loading…</div>;
   if (!event) return <div className={`text-xs text-gray-400 ${className || ''}`.trim()}>No event available</div>;
 
-  const base = toPlainEvent(event) as Record<string, unknown>;
-  const data: Record<string, unknown> = { ...base };
-  try {
-    const raw = data.content;
-    if (typeof raw === 'string') {
-      const trimmed = raw.trim();
-      if ((trimmed.startsWith('{') && trimmed.endsWith('}')) || (trimmed.startsWith('[') && trimmed.endsWith(']'))) {
-        data.content = JSON.parse(trimmed);
-      }
-    }
-  } catch {}
-  const json = JSON.stringify(data, null, 2);
+  const json = JSON.stringify(toPlainEvent(event), null, 2);
 
   return (
     <Highlight code={json} language="json" theme={themes.nightOwl}>

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -1382,10 +1382,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
                       event={event}
                       onAuthorClick={goToProfile}
                       renderContent={() => (
-                        <div>
-                          <div className="mb-2 text-xs text-gray-400">Rendering raw event (kind {event.kind}).</div>
-                          <RawEventJson event={event} />
-                        </div>
+                        <RawEventJson event={event} />
                       )}
                       className={noteCardClasses}
                       footerRight={(

--- a/src/lib/toPlainEvent.ts
+++ b/src/lib/toPlainEvent.ts
@@ -1,0 +1,37 @@
+import { NDKEvent } from '@nostr-dev-kit/ndk';
+
+// Safely convert NDKEvent (which may contain circular refs) to a plain JSON-serializable object
+export function toPlainEvent(evt: NDKEvent): Record<string, unknown> {
+  try {
+    const hasRaw = typeof (evt as unknown as { rawEvent?: () => unknown }).rawEvent === 'function';
+    const base = hasRaw
+      ? (evt as unknown as { rawEvent: () => Record<string, unknown> }).rawEvent()
+      : {
+          id: evt.id,
+          kind: evt.kind,
+          created_at: evt.created_at,
+          pubkey: evt.pubkey,
+          content: evt.content,
+          tags: evt.tags,
+          sig: evt.sig
+        };
+    const extra: Record<string, unknown> = {};
+    const maybeRelaySource = (evt as unknown as { relaySource?: string }).relaySource;
+    const maybeRelaySources = (evt as unknown as { relaySources?: string[] }).relaySources;
+    if (typeof maybeRelaySource === 'string') extra.relaySource = maybeRelaySource;
+    if (Array.isArray(maybeRelaySources)) extra.relaySources = maybeRelaySources;
+    return { ...base, ...extra };
+  } catch {
+    return {
+      id: evt.id,
+      kind: evt.kind,
+      created_at: evt.created_at,
+      pubkey: evt.pubkey,
+      content: evt.content,
+      tags: evt.tags,
+      sig: evt.sig
+    };
+  }
+}
+
+

--- a/src/lib/vertex.ts
+++ b/src/lib/vertex.ts
@@ -534,6 +534,23 @@ export async function getNewestProfileMetadata(pubkey: string): Promise<{ id: st
   }
 }
 
+// Return the full newest profile metadata NDKEvent for a pubkey
+export async function getNewestProfileEvent(pubkey: string): Promise<NDKEvent | null> {
+  try {
+    const events = await subscribeAndCollectProfiles({ kinds: [0], authors: [pubkey], limit: 8000 }, 8000);
+    if (!events || events.length === 0) return null;
+    let newest: NDKEvent | null = null;
+    for (const e of events) {
+      if (!newest || ((e.created_at || 0) > (newest.created_at || 0))) {
+        newest = e;
+      }
+    }
+    return newest;
+  } catch {
+    return null;
+  }
+}
+
 async function getDirectFollows(pubkey: string): Promise<Set<string>> {
   const events = await subscribeAndCollectProfiles({ kinds: [3], authors: [pubkey], limit: 1 });
   const follows = new Set<string>();


### PR DESCRIPTION
This PR adds a toggle JSON button (fa-code icon) that displays the raw JSON of events and profiles. The button is positioned between the three-dot menu and external link icon for consistency across all views. When toggled, the raw JSON replaces the original content and includes proper syntax highlighting with a copy button that provides visual feedback.

Key changes:
- Added `RawEventJson` component with syntax highlighting and copy functionality
- Created `CardActions` component to maintain consistent button ordering
- Extracted `CopyButton` component for reusable copy functionality
- Modified `EventCard` and `ProfileCard` to support raw JSON display
- Added `toPlainEvent` utility for safe JSON serialization
- Enhanced profile view to fetch newest metadata for accurate raw JSON display