### PR TITLE
Add slash-command support to search and CLI-style EventCard output

### DIFF
--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -46,6 +46,28 @@ export function LoginButton() {
     };
 
     initLogin();
+    // Listen for external auth changes (e.g., slash-commands)
+    const onAuthChange = () => {
+      (async () => {
+        try {
+          const u = await restoreLogin();
+          if (u) {
+            try { await u.fetchProfile(); } catch {}
+          }
+          setUser(u);
+        } catch {
+          setUser(null);
+        }
+      })();
+    };
+    if (typeof window !== 'undefined') {
+      window.addEventListener('nip07:auth-change', onAuthChange as EventListener);
+    }
+    return () => {
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('nip07:auth-change', onAuthChange as EventListener);
+      }
+    };
   }, []);
 
   const handleLogin = async () => {

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -235,6 +235,13 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
     abortControllerRef.current = abortController;
     const searchId = ++currentSearchId.current;
 
+    // Clear previous UI immediately
+    const isCmd = isSlashCommand(searchQuery);
+    if (!isCmd) {
+      setTopCommandText(null);
+      setTopExamples(null);
+    }
+    setResults([]);
     setLoading(true);
     
     // Check if we need to resolve an author first
@@ -488,6 +495,9 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
         params.set('q', raw);
         router.replace(`?${params.toString()}`);
       }
+      // Clear prior results immediately before async search
+      setResults([]);
+      setTopCommandText(buildCli(raw.replace(/^\//, ''), topExamples ? topExamples : ''));
       if (raw) handleSearch(raw);
       else setResults([]);
       return;

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -61,10 +61,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
   const [expandedParents, setExpandedParents] = useState<Record<string, NDKEvent | 'loading'>>({});
   const [avatarOverlap, setAvatarOverlap] = useState(false);
   const searchRowRef = useRef<HTMLFormElement | null>(null);
-  const [expandedLabel, setExpandedLabel] = useState<string | null>(null);
-  const [expandedTerms, setExpandedTerms] = useState<string[]>([]);
-  const [activeFilters, setActiveFilters] = useState<Set<string>>(new Set());
-  const [baseResults, setBaseResults] = useState<NDKEvent[]>([]);
+  // Removed expanded-term chip UI and related state to simplify UX
   const [rotationProgress, setRotationProgress] = useState(0);
   const [showConnectionDetails, setShowConnectionDetails] = useState(false);
   const [recentlyActive, setRecentlyActive] = useState<string[]>([]);
@@ -124,7 +121,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
     }
     setTopCommandText(buildCli(cmd, 'Unknown command'));
     setTopExamples(null);
-  }, [buildCli, setTopCommandText, setPlaceholder]);
+  }, [buildCli, setTopCommandText, setPlaceholder, SLASH_COMMANDS]);
 
   // Simple input change handler: update local query state; searches run on submit
   const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -224,9 +221,6 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
   const handleSearch = useCallback(async (searchQuery: string) => {
     if (!searchQuery.trim()) {
       setResults([]);
-      setExpandedLabel(null);
-      setExpandedTerms([]);
-      setActiveFilters(new Set());
       setResolvingAuthor(false);
       return;
     }
@@ -277,13 +271,8 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
         const gifTerms = ['gif','gifs','apng'];
         seedTerms = (hasGif || isGif) ? gifTerms : (hasVideo || isVideo) ? videoTerms : imageTerms;
         seedActive = new Set(seedTerms);
-        setExpandedLabel(seedTerms.join(' '));
-        setExpandedTerms(seedTerms);
-        setActiveFilters(seedActive);
       } else {
-        setExpandedLabel(null);
-        setExpandedTerms([]);
-        setActiveFilters(new Set());
+        // no-op
       }
 
       // Check if search was aborted before making the call
@@ -332,7 +321,6 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
         return;
       }
 
-      setBaseResults(searchResults);
       const filtered = applyClientFilters(searchResults, seedTerms, seedActive);
       setResults(filtered);
     } catch (error) {
@@ -1240,10 +1228,6 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
                   currentSearchId.current++;
                   setQuery('');
                   setResults([]);
-                  setExpandedLabel(null);
-                  setExpandedTerms([]);
-                  setActiveFilters(new Set());
-                  setBaseResults([]);
                   setLoading(false);
                   setResolvingAuthor(false);
                   setTopCommandText(null);
@@ -1538,7 +1522,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
             })}
           </div>
         );
-      }, [fuseFilteredResults, expandedParents, manageUrl, searchParams, goToProfile, handleSearch, renderContentWithClickableHashtags, renderNoteMedia, renderParentChain, router, getReplyToEventId, topCommandText])}
+      }, [fuseFilteredResults, expandedParents, manageUrl, searchParams, goToProfile, handleSearch, renderContentWithClickableHashtags, renderNoteMedia, renderParentChain, router, getReplyToEventId, topCommandText, topExamples])}
     </div>
   );
 }

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -70,6 +70,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
     const cmd = rawInput.replace(/^\s*\//, '').trim().toLowerCase();
     const buildHelp = () => [
       '$ ants --help',
+      '',
       'Available commands:',
       '  ants --help   Show this help',
       '  ants examples List example queries',
@@ -82,23 +83,23 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
     }
     if (cmd === 'examples') {
       const examples = getFilteredExamples(isLoggedIn()).slice(0, 30);
-      setTopCommandText(['$ ants examples', ...examples.map(e => `  - ${e}`)].join('\n'));
+      setTopCommandText(['$ ants examples', '', ...examples.map(e => `  - ${e}`)].join('\n'));
       return;
     }
     if (cmd === 'login') {
-      setTopCommandText('$ ants login\nAttempting login…');
+      setTopCommandText('$ ants login\n\nAttempting login…');
       (async () => {
         try {
           const user = await login();
           if (user) {
             try { await user.fetchProfile(); } catch {}
-            setTopCommandText(`$ ants login\nLogged in as ${user.profile?.displayName || user.profile?.name || user.npub}`);
+            setTopCommandText(`$ ants login\n\nLogged in as ${user.profile?.displayName || user.profile?.name || user.npub}`);
             setPlaceholder(nextExample());
           } else {
-            setTopCommandText('$ ants login\nLogin cancelled');
+            setTopCommandText('$ ants login\n\nLogin cancelled');
           }
         } catch {
-          setTopCommandText('$ ants login\nLogin failed. Ensure a NIP-07 extension is installed.');
+          setTopCommandText('$ ants login\n\nLogin failed. Ensure a NIP-07 extension is installed.');
         }
       })();
       return;
@@ -106,14 +107,14 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
     if (cmd === 'logout') {
       try {
         logout();
-        setTopCommandText('$ ants logout\nLogged out');
+        setTopCommandText('$ ants logout\n\nLogged out');
         setPlaceholder(nextExample());
       } catch {
-        setTopCommandText('$ ants logout\nLogout failed');
+        setTopCommandText('$ ants logout\n\nLogout failed');
       }
       return;
     }
-    setTopCommandText(`$ ants ${cmd}\nUnknown command`);
+    setTopCommandText(`$ ants ${cmd}\n\nUnknown command`);
   }, [setTopCommandText, setPlaceholder]);
 
   // Simple input change handler: update local query state; searches run on submit

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -84,8 +84,8 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
       return;
     }
     if (cmd === 'examples') {
-      const examples = getFilteredExamples(isLoggedIn()).slice(0, 30);
-      setTopExamples(examples);
+      const examples = getFilteredExamples(isLoggedIn());
+      setTopExamples(Array.from(examples));
       setTopCommandText(buildCli('examples'));
       return;
     }

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -38,6 +38,12 @@ type Props = {
 // (Local AuthorBadge removed; using global `components/AuthorBadge` inside EventCard.)
 
 export default function SearchView({ initialQuery = '', manageUrl = true }: Props) {
+  const SLASH_COMMANDS = useMemo(() => ([
+    { key: 'help', label: '/help', description: 'Show this help' },
+    { key: 'examples', label: '/examples', description: 'List example queries' },
+    { key: 'login', label: '/login', description: 'Connect with NIP-07' },
+    { key: 'logout', label: '/logout', description: 'Clear session' }
+  ] as const), []);
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -75,13 +81,8 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
   const runSlashCommand = useCallback((rawInput: string) => {
     const cmd = rawInput.replace(/^\s*\//, '').trim().toLowerCase();
     if (cmd === 'help') {
-      setTopCommandText(buildCli('--help', [
-        'Available commands:',
-        '  ants --help   Show this help',
-        '  ants examples List example queries',
-        '  ants login    Connect with NIP-07',
-        '  ants logout   Clear session',
-      ]));
+      const lines = ['Available commands:', ...SLASH_COMMANDS.map(c => `  ${c.label.padEnd(12)} ${c.description}`)];
+      setTopCommandText(buildCli('--help', lines));
       setTopExamples(null);
       return;
     }

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -1192,7 +1192,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
   }, [getReplyToEventId, expandedParents, setExpandedParents, fetchEventById, renderNoteMedia, goToProfile, renderContentWithClickableHashtags]);
 
   return (
-    <div className={`w-full ${results.length > 0 ? 'pt-4' : 'min-h-screen flex items-center'}`}>
+    <div className={`w-full ${(results.length > 0 || topCommandText) ? 'pt-4' : 'min-h-screen flex items-center'}`}>
       <form ref={searchRowRef} onSubmit={handleSubmit} className={`w-full ${avatarOverlap ? 'pr-16' : ''}`} id="search-row">
         <div className="flex gap-2">
           <div className="flex-1 relative">

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -88,7 +88,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
     if (cmd === 'examples') {
       const examples = getFilteredExamples(isLoggedIn()).slice(0, 30);
       setTopExamples(examples);
-      setTopCommandText(buildCli('examples', ['Examples:', ...examples.map(e => `  - ${e}`)]));
+      setTopCommandText(buildCli('examples'));
       return;
     }
     if (cmd === 'login') {
@@ -1433,7 +1433,6 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
                     <pre className="text-xs overflow-x-auto rounded-md p-3 bg-[#1f1f1f] border border-[#3d3d3d]">
                       <div>$ ants examples</div>
                       <div>&nbsp;</div>
-                      <div>Examples:</div>
                       {topExamples.map((ex) => (
                         <div key={ex}>
                           <button
@@ -1449,7 +1448,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
                               handleSearch(ex);
                             }}
                           >
-                            {`- ${ex}`}
+                            {ex}
                           </button>
                         </div>
                       ))}

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -1511,7 +1511,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
             })}
           </div>
         );
-      }, [fuseFilteredResults, expandedParents, manageUrl, searchParams, goToProfile, handleSearch, renderContentWithClickableHashtags, renderNoteMedia, renderParentChain, router, getReplyToEventId])}
+      }, [fuseFilteredResults, expandedParents, manageUrl, searchParams, goToProfile, handleSearch, renderContentWithClickableHashtags, renderNoteMedia, renderParentChain, router, getReplyToEventId, topCommandText])}
     </div>
   );
 }

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -462,17 +462,22 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
     const urlQuery = searchParams.get('q') || '';
     const currentProfileNpub = getCurrentProfileNpub(pathname);
     if (currentProfileNpub) {
-      const display = toExplicitInputFromUrl(urlQuery, currentProfileNpub);
-      setQuery(display);
-      const backend = ensureAuthorForBackend(urlQuery, currentProfileNpub);
-      if (isSlashCommand(urlQuery)) runSlashCommand(urlQuery);
-      handleSearch(backend);
-      // Normalize URL to implicit form if needed
-      const implicit = toImplicitUrlQuery(urlQuery, currentProfileNpub);
-      if (implicit !== urlQuery) {
-        const params = new URLSearchParams(searchParams.toString());
-        params.set('q', implicit);
-        router.replace(`?${params.toString()}`);
+      if (isSlashCommand(urlQuery)) {
+        setQuery(urlQuery);
+        runSlashCommand(urlQuery);
+        handleSearch(urlQuery);
+      } else {
+        const display = toExplicitInputFromUrl(urlQuery, currentProfileNpub);
+        setQuery(display);
+        const backend = ensureAuthorForBackend(urlQuery, currentProfileNpub);
+        handleSearch(backend);
+        // Normalize URL to implicit form if needed
+        const implicit = toImplicitUrlQuery(urlQuery, currentProfileNpub);
+        if (implicit !== urlQuery) {
+          const params = new URLSearchParams(searchParams.toString());
+          params.set('q', implicit);
+          router.replace(`?${params.toString()}`);
+        }
       }
     } else if (urlQuery) {
       setQuery(urlQuery);
@@ -488,6 +493,15 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
     // Slash-commands: show CLI-style top card but still run normal search
     if (isSlashCommand(raw)) {
       runSlashCommand(raw);
+      setQuery(raw);
+      if (manageUrl) {
+        const params = new URLSearchParams(searchParams.toString());
+        params.set('q', raw);
+        router.replace(`?${params.toString()}`);
+      }
+      if (raw) handleSearch(raw);
+      else setResults([]);
+      return;
     } else {
       // Clear any previous command card for non-command searches
       setTopCommandText(null);

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -69,12 +69,12 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
   const runSlashCommand = useCallback((rawInput: string) => {
     const cmd = rawInput.replace(/^\s*\//, '').trim().toLowerCase();
     const buildHelp = () => [
-      '$ /help',
+      '$ ants --help',
       'Available commands:',
-      '  /help      Show this help',
-      '  /examples  List example queries',
-      '  /login     Connect with NIP-07',
-      '  /logout    Clear session',
+      '  ants --help   Show this help',
+      '  ants examples List example queries',
+      '  ants login    Connect with NIP-07',
+      '  ants logout   Clear session',
     ].join('\n');
     if (cmd === 'help') {
       setTopCommandText(buildHelp());
@@ -82,23 +82,23 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
     }
     if (cmd === 'examples') {
       const examples = getFilteredExamples(isLoggedIn()).slice(0, 30);
-      setTopCommandText(['$ /examples', ...examples.map(e => `  - ${e}`)].join('\n'));
+      setTopCommandText(['$ ants examples', ...examples.map(e => `  - ${e}`)].join('\n'));
       return;
     }
     if (cmd === 'login') {
-      setTopCommandText('$ /login\nAttempting login…');
+      setTopCommandText('$ ants login\nAttempting login…');
       (async () => {
         try {
           const user = await login();
           if (user) {
             try { await user.fetchProfile(); } catch {}
-            setTopCommandText(`$ /login\nLogged in as ${user.profile?.displayName || user.profile?.name || user.npub}`);
+            setTopCommandText(`$ ants login\nLogged in as ${user.profile?.displayName || user.profile?.name || user.npub}`);
             setPlaceholder(nextExample());
           } else {
-            setTopCommandText('$ /login\nLogin cancelled');
+            setTopCommandText('$ ants login\nLogin cancelled');
           }
         } catch {
-          setTopCommandText('$ /login\nLogin failed. Ensure a NIP-07 extension is installed.');
+          setTopCommandText('$ ants login\nLogin failed. Ensure a NIP-07 extension is installed.');
         }
       })();
       return;
@@ -106,14 +106,14 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
     if (cmd === 'logout') {
       try {
         logout();
-        setTopCommandText('$ /logout\nLogged out');
+        setTopCommandText('$ ants logout\nLogged out');
         setPlaceholder(nextExample());
       } catch {
-        setTopCommandText('$ /logout\nLogout failed');
+        setTopCommandText('$ ants logout\nLogout failed');
       }
       return;
     }
-    setTopCommandText(`$ /${cmd}\nUnknown command`);
+    setTopCommandText(`$ ants ${cmd}\nUnknown command`);
   }, [setTopCommandText, setPlaceholder]);
 
   // Simple input change handler: update local query state; searches run on submit

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -1382,29 +1382,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
           </div>
         )}
         
-        {expandedLabel && expandedTerms.length > 0 && (
-          <div className="mt-1 text-xs text-gray-400 flex items-center gap-1 flex-wrap">
-            {expandedTerms.map((term, i) => {
-              const active = activeFilters.has(term);
-              return (
-                <button
-                  key={`${term}-${i}`}
-                  type="button"
-                  className={`px-1.5 py-0.5 rounded border ${active ? 'bg-[#3a3a3a] border-[#4a4a4a] text-gray-100' : 'bg-[#2d2d2d] border-[#3d3d3d] text-gray-300'} hover:bg-[#3a3a3a]`}
-                  onClick={() => {
-                    const next = new Set(activeFilters);
-                    if (active) next.delete(term); else next.add(term);
-                    setActiveFilters(next);
-                    const filtered = applyClientFilters(baseResults, expandedTerms, next);
-                    setResults(filtered);
-                  }}
-                >
-                  <span className="font-mono">{term}</span>
-                </button>
-              );
-            })}
-          </div>
-        )}
+        {/* Removed inline expanded-term filter buttons (gif/gifs/apng etc.) per design update */}
       </form>
 
       {/* Command output will be injected as first result card below */}

--- a/src/lib/examples.ts
+++ b/src/lib/examples.ts
@@ -76,6 +76,9 @@ export const searchExamples = [
 
   // NIP-50 extensions
   'bitcoin include:spam',
+
+  // Slash Commands
+  '/help',
 ] as const;
 
 // Examples that require login to work properly

--- a/src/lib/examples.ts
+++ b/src/lib/examples.ts
@@ -39,6 +39,7 @@ export const searchExamples = [
   'p:nostrplebs.com',
   'p:dave',
   'kind:0 #bitcoin',
+  '(p:dad OR p:husband OR p:father)',
 
   // Operators & media
   'bitcoin OR lightning',

--- a/src/lib/nip07.ts
+++ b/src/lib/nip07.ts
@@ -3,6 +3,14 @@ import { ndk, connect } from './ndk';
 
 const NIP07_PUBKEY_KEY = 'nip07_pubkey';
 
+function emitAuthChange(): void {
+  try {
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('nip07:auth-change'));
+    }
+  } catch {}
+}
+
 export async function login(): Promise<NDKUser | null> {
   if (!(window as { nostr?: unknown }).nostr) {
     throw new Error('NIP-07 extension not found');
@@ -23,7 +31,7 @@ export async function login(): Promise<NDKUser | null> {
     
     // Ensure the user has the NDK instance set
     user.ndk = ndk;
-    
+    emitAuthChange();
     return user;
   } catch (error) {
     console.error('Error getting public key:', error);
@@ -42,6 +50,7 @@ export function getStoredPubkey(): string | null {
 export function logout(): void {
   localStorage.removeItem(NIP07_PUBKEY_KEY);
   ndk.signer = undefined;
+  emitAuthChange();
 }
 
 export async function restoreLogin(): Promise<NDKUser | null> {


### PR DESCRIPTION
Implements slash-command handling in the search bar that runs a normal search and injects a CLI-styled output as the first `EventCard`. Commands: /help, /examples, /login, /logout. Also wires NIP-07 login/logout and updates the header avatar on auth changes.

- Renders command card immediately; results load afterward
- Processes commands from URL query (e.g. /?q=%2Fhelp)
- Adds `isSlashCommand`, `buildCli`; emits `nip07:auth-change` and updates `LoginButton`
