### PR TITLE
Improve mobile UX and add search examples

### DIFF
--- a/src/components/AuthorBadge.tsx
+++ b/src/components/AuthorBadge.tsx
@@ -62,7 +62,7 @@ export default function AuthorBadge({ user, onAuthorClick }: { user: NDKUser, on
       <button
         type="button"
         onClick={() => onAuthorClick && onAuthorClick(user.npub)}
-        className="hover:underline truncate max-w-[14rem] text-left"
+        className="hover:underline truncate max-w-[14rem] text-left hidden sm:block"
         title={value}
       >
         <span className="truncate max-w-[14rem]">{value}</span>

--- a/src/components/AuthorBadge.tsx
+++ b/src/components/AuthorBadge.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams, usePathname } from 'next/navigation';
 import { getNip05Domain } from '@/lib/nip05';
+import { cleanNip05Display } from '@/lib/utils';
 import { NDKUser } from '@nostr-dev-kit/ndk';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleCheck, faCircleXmark, faCircleExclamation, faUserGroup } from '@fortawesome/free-solid-svg-icons';
@@ -78,9 +79,9 @@ export default function AuthorBadge({ user, onAuthorClick }: { user: NDKUser, on
         type="button"
         onClick={() => onAuthorClick && onAuthorClick(user.npub)}
         className="hover:underline truncate max-w-[14rem] text-left hidden sm:block"
-        title={value}
+        title={cleanNip05Display(value)}
       >
-        <span className="truncate max-w-[14rem]">{value}</span>
+        <span className="truncate max-w-[14rem]">{cleanNip05Display(value)}</span>
       </button>
       {/* External link removed */}
       {pathname?.startsWith('/p/') && (

--- a/src/components/AuthorBadge.tsx
+++ b/src/components/AuthorBadge.tsx
@@ -58,7 +58,22 @@ export default function AuthorBadge({ user, onAuthorClick }: { user: NDKUser, on
 
   const nip05Part = value ? (
     <span className={`inline-flex items-center gap-2 ${effectiveVerified ? 'text-green-400' : 'text-red-400'}`}>
-      <FontAwesomeIcon icon={effectiveVerified ? faCircleCheck : faCircleXmark} className="h-4 w-4" />
+      <button
+        type="button"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          if (!value) return;
+          const current = searchParams ? searchParams.toString() : '';
+          const params = new URLSearchParams(current);
+          params.set('q', value);
+          router.push(`/?${params.toString()}`);
+        }}
+        className="hover:opacity-80 transition-opacity"
+        title={`Search for ${value}`}
+      >
+        <FontAwesomeIcon icon={effectiveVerified ? faCircleCheck : faCircleXmark} className="h-4 w-4" />
+      </button>
       <button
         type="button"
         onClick={() => onAuthorClick && onAuthorClick(user.npub)}
@@ -92,7 +107,21 @@ export default function AuthorBadge({ user, onAuthorClick }: { user: NDKUser, on
     </span>
   ) : (
     <span className="inline-flex items-center gap-1 text-yellow-400">
-      <FontAwesomeIcon icon={faCircleExclamation} className="h-4 w-4" />
+      <button
+        type="button"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          const current = searchParams ? searchParams.toString() : '';
+          const params = new URLSearchParams(current);
+          params.set('q', 'no NIP-05');
+          router.push(`/?${params.toString()}`);
+        }}
+        className="hover:opacity-80 transition-opacity"
+        title="Search for 'no NIP-05'"
+      >
+        <FontAwesomeIcon icon={faCircleExclamation} className="h-4 w-4" />
+      </button>
       <span className="text-gray-400">no NIP-05</span>
     </span>
   );

--- a/src/components/AuthorBadge.tsx
+++ b/src/components/AuthorBadge.tsx
@@ -122,7 +122,7 @@ export default function AuthorBadge({ user, onAuthorClick }: { user: NDKUser, on
       >
         <FontAwesomeIcon icon={faCircleExclamation} className="h-4 w-4" />
       </button>
-      <span className="text-gray-400">no NIP-05</span>
+      <span className="text-gray-400 hidden sm:inline">no NIP-05</span>
     </span>
   );
 

--- a/src/components/AuthorBadge.tsx
+++ b/src/components/AuthorBadge.tsx
@@ -114,11 +114,11 @@ export default function AuthorBadge({ user, onAuthorClick }: { user: NDKUser, on
           e.stopPropagation();
           const current = searchParams ? searchParams.toString() : '';
           const params = new URLSearchParams(current);
-          params.set('q', 'no NIP-05');
+          params.set('q', 'nips/blob/master/05.md');
           router.push(`/?${params.toString()}`);
         }}
         className="hover:opacity-80 transition-opacity"
-        title="Search for 'no NIP-05'"
+        title="Search for NIP-05 specification"
       >
         <FontAwesomeIcon icon={faCircleExclamation} className="h-4 w-4" />
       </button>

--- a/src/components/ClientFilters.tsx
+++ b/src/components/ClientFilters.tsx
@@ -115,7 +115,7 @@ export default function ClientFilters({ filterSettings, onFilterChange, resultCo
               </div>
             </label>
 
-            {/* Verified only */}
+            {/* Valid NIP-05 */}
             <label className="flex items-center gap-2 text-xs text-gray-400">
               <input
                 type="checkbox"
@@ -123,7 +123,7 @@ export default function ClientFilters({ filterSettings, onFilterChange, resultCo
                 onChange={(e) => onFilterChange({ ...filterSettings, verifiedOnly: e.target.checked })}
                 className="accent-[#4a4a4a]"
               />
-              <span>Verified only</span>
+              <span>Valid NIP-05</span>
               <FontAwesomeIcon icon={faCircleCheck} className="w-3 h-3 text-green-400" />
             </label>
 

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -8,6 +8,7 @@ import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 import { useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { createEventExplorerItems } from '@/lib/portals';
+import { calculateMenuPosition } from '@/lib/utils';
 import RawEventJson from '@/components/RawEventJson';
 import CardActions from '@/components/CardActions';
 
@@ -66,7 +67,8 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
                 onToggleMenu={() => {
                   if (portalButtonRef.current) {
                     const rect = portalButtonRef.current.getBoundingClientRect();
-                    setMenuPosition({ top: rect.bottom + 4, left: rect.left });
+                    const position = calculateMenuPosition(rect);
+                    setMenuPosition(position);
                   }
                   setShowPortalMenu((v) => !v);
                 }}

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -8,7 +8,7 @@ import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 import { useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { createEventExplorerItems } from '@/lib/portals';
-import { calculateMenuPosition } from '@/lib/utils';
+import { calculateAbsoluteMenuPosition } from '@/lib/utils';
 import RawEventJson from '@/components/RawEventJson';
 import CardActions from '@/components/CardActions';
 
@@ -67,7 +67,7 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
                 onToggleMenu={() => {
                   if (portalButtonRef.current) {
                     const rect = portalButtonRef.current.getBoundingClientRect();
-                    const position = calculateMenuPosition(rect);
+                    const position = calculateAbsoluteMenuPosition(rect);
                     setMenuPosition(position);
                   }
                   setShowPortalMenu((v) => !v);
@@ -85,7 +85,7 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
             onClick={(e) => { e.preventDefault(); setShowPortalMenu(false); }}
           />
           <div
-            className="fixed z-[9999] w-56 rounded-md bg-[#2d2d2d]/95 border border-[#3d3d3d] shadow-lg backdrop-blur-sm"
+            className="absolute z-[9999] w-56 rounded-md bg-[#2d2d2d]/95 border border-[#3d3d3d] shadow-lg backdrop-blur-sm"
             style={{ top: menuPosition.top, left: menuPosition.left }}
             onClick={(e) => { e.stopPropagation(); }}
           >

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useRouter, useSearchParams } from 'next/navigation';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faExternalLink } from '@fortawesome/free-solid-svg-icons';
 
 export function Footer() {
   const router = useRouter();
@@ -20,6 +22,12 @@ export function Footer() {
     const params = new URLSearchParams(searchParams.toString());
     params.set('q', nextQuery);
     router.replace(`?${params.toString()}`);
+  };
+
+  const handleGitHubExternalClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    window.open('https://github.com/dergigi/ants/issues/new', '_blank', 'noopener,noreferrer');
   };
 
   const handleSec04Click = (e: React.MouseEvent) => {
@@ -52,7 +60,17 @@ export function Footer() {
         Vibed by <a href="#" onClick={handleGigiClick} className="underline hover:text-gray-300">Gigi</a>.
       </p>
       <p className="mt-1">
-        <a href="#" onClick={handleGitHubClick} className="underline hover:text-gray-300">GitHub</a>
+        <a href="#" onClick={handleGitHubClick} className="underline hover:text-gray-300">
+          GitHub
+          <button
+            type="button"
+            onClick={handleGitHubExternalClick}
+            className="ml-1 text-gray-400 hover:text-gray-300"
+            title="Open GitHub issues"
+          >
+            <FontAwesomeIcon icon={faExternalLink} className="h-3 w-3" />
+          </button>
+        </a>
         <span className="mx-2">·</span>
         <a href="#" onClick={handleNostrClick} className="underline hover:text-gray-300">Nostr</a>
         <span className="mx-2">·</span>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,19 +8,11 @@ export function Footer() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const handleNostrClick = (e: React.MouseEvent) => {
+  // DRY: Reusable function for search navigation
+  const handleSearchClick = (query: string) => (e: React.MouseEvent) => {
     e.preventDefault();
-    const nextQuery = 'p:npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc';
     const params = new URLSearchParams(searchParams.toString());
-    params.set('q', nextQuery);
-    router.replace(`?${params.toString()}`);
-  };
-
-  const handleGitHubClick = (e: React.MouseEvent) => {
-    e.preventDefault();
-    const nextQuery = '"dergigi/ants"';
-    const params = new URLSearchParams(searchParams.toString());
-    params.set('q', nextQuery);
+    params.set('q', query);
     router.replace(`?${params.toString()}`);
   };
 
@@ -30,37 +22,13 @@ export function Footer() {
     window.open('https://github.com/dergigi/ants/issues/new', '_blank', 'noopener,noreferrer');
   };
 
-  const handleSec04Click = (e: React.MouseEvent) => {
-    e.preventDefault();
-    const nextQuery = '#SovEng';
-    const params = new URLSearchParams(searchParams.toString());
-    params.set('q', nextQuery);
-    router.replace(`?${params.toString()}`);
-  };
-
-  const handleVertexClick = (e: React.MouseEvent) => {
-    e.preventDefault();
-    const nextQuery = 'p:npub1kpt95rv4q3mcz8e4lamwtxq7men6jprf49l7asfac9lnv2gda0lqdknhmz';
-    const params = new URLSearchParams(searchParams.toString());
-    params.set('q', nextQuery);
-    router.replace(`?${params.toString()}`);
-  };
-
-  const handleGigiClick = (e: React.MouseEvent) => {
-    e.preventDefault();
-    const nextQuery = 'dergigi.com';
-    const params = new URLSearchParams(searchParams.toString());
-    params.set('q', nextQuery);
-    router.replace(`?${params.toString()}`);
-  };
-
   return (
     <footer className="text-center text-xs text-gray-400 py-6 select-none bg-[#1a1a1a]">
       <p>
-        Vibed by <a href="#" onClick={handleGigiClick} className="underline hover:text-gray-300">Gigi</a>.
+        Vibed by <a href="#" onClick={handleSearchClick('dergigi.com')} className="underline hover:text-gray-300">Gigi</a>.
       </p>
       <p className="mt-1">
-        <a href="#" onClick={handleGitHubClick} className="underline hover:text-gray-300">
+        <a href="#" onClick={handleSearchClick('"dergigi/ants"')} className="underline hover:text-gray-300">
           GitHub
           <button
             type="button"
@@ -72,11 +40,11 @@ export function Footer() {
           </button>
         </a>
         <span className="mx-2">·</span>
-        <a href="#" onClick={handleNostrClick} className="underline hover:text-gray-300">Nostr</a>
+        <a href="#" onClick={handleSearchClick('p:npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc')} className="underline hover:text-gray-300">Nostr</a>
         <span className="mx-2">·</span>
-        <a href="#" onClick={handleSec04Click} className="underline hover:text-gray-300">Birthed during SEC-04</a>
+        <a href="#" onClick={handleSearchClick('#SovEng')} className="underline hover:text-gray-300">Birthed during SEC-04</a>
         <span className="mx-2">·</span>
-        <a href="#" onClick={handleVertexClick} className="underline hover:text-gray-300">Using Vertex</a>
+        <a href="#" onClick={handleSearchClick('p:npub1kpt95rv4q3mcz8e4lamwtxq7men6jprf49l7asfac9lnv2gda0lqdknhmz')} className="underline hover:text-gray-300">Using Vertex</a>
       </p>
     </footer>
   );

--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect } from 'react';
 import { NDKUser } from '@nostr-dev-kit/ndk';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
+import { shortenNpub } from '@/lib/utils';
 
 function getDisplayName(user: NDKUser): string {
   if (!user) return '';
@@ -20,7 +21,7 @@ function getDisplayName(user: NDKUser): string {
   
   // Fallback to shortened npub
   const npub = user.npub;
-  return `${npub.substring(0, 10)}...${npub.substring(npub.length - 3)}`;
+  return shortenNpub(npub);
 }
 
 export function LoginButton() {

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -13,7 +13,7 @@ import { faArrowUpRightFromSquare, faCopy } from '@fortawesome/free-solid-svg-ic
 import { shortenNpub } from '@/lib/utils';
 import { createPortal } from 'react-dom';
 import { createProfileExplorerItems } from '@/lib/portals';
-import { calculateAbsoluteMenuPosition } from '@/lib/utils';
+import { calculateAbsoluteMenuPosition, calculateBannerMenuPosition } from '@/lib/utils';
 import { getIsKindTokens } from '@/lib/search/replacements';
 import RawEventJson from '@/components/RawEventJson';
 import CardActions from '@/components/CardActions';
@@ -333,7 +333,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
                   e.stopPropagation(); 
                   if (buttonRef.current) {
                     const rect = buttonRef.current.getBoundingClientRect();
-                    const position = calculateAbsoluteMenuPosition(rect);
+                    const position = calculateBannerMenuPosition(rect);
                     setMenuPosition(position);
                   }
                   setShowPortalMenu((v) => !v); 
@@ -419,7 +419,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
             onClick={(e) => { e.preventDefault(); setShowPortalMenu(false); }}
           />
           <div
-            className="absolute z-[9999] w-56 rounded-md bg-[#2d2d2d]/95 border border-[#3d3d3d] shadow-lg backdrop-blur-sm"
+            className="fixed z-[9999] w-56 rounded-md bg-[#2d2d2d]/95 border border-[#3d3d3d] shadow-lg backdrop-blur-sm"
             style={{ top: menuPosition.top, left: menuPosition.left }}
             onClick={(e) => { e.stopPropagation(); }}
           >

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -13,7 +13,7 @@ import { faArrowUpRightFromSquare, faCopy } from '@fortawesome/free-solid-svg-ic
 import { shortenNpub } from '@/lib/utils';
 import { createPortal } from 'react-dom';
 import { createProfileExplorerItems } from '@/lib/portals';
-import { calculateMenuPosition } from '@/lib/utils';
+import { calculateAbsoluteMenuPosition } from '@/lib/utils';
 import { getIsKindTokens } from '@/lib/search/replacements';
 import RawEventJson from '@/components/RawEventJson';
 import CardActions from '@/components/CardActions';
@@ -112,7 +112,7 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
           onToggleMenu={() => {
             if (bottomButtonRef.current) {
               const rect = bottomButtonRef.current.getBoundingClientRect();
-              const position = calculateMenuPosition(rect);
+              const position = calculateAbsoluteMenuPosition(rect);
               setMenuPositionBottom(position);
             }
             setShowPortalMenuBottom((v) => !v);
@@ -127,7 +127,7 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
             onClick={(e) => { e.preventDefault(); setShowPortalMenuBottom(false); }}
           />
           <div
-            className="fixed z-[9999] w-56 rounded-md bg-[#2d2d2d]/95 border border-[#3d3d3d] shadow-lg backdrop-blur-sm"
+            className="absolute z-[9999] w-56 rounded-md bg-[#2d2d2d]/95 border border-[#3d3d3d] shadow-lg backdrop-blur-sm"
             style={{ top: menuPositionBottom.top, left: menuPositionBottom.left }}
             onClick={(e) => { e.stopPropagation(); }}
           >
@@ -333,7 +333,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
                   e.stopPropagation(); 
                   if (buttonRef.current) {
                     const rect = buttonRef.current.getBoundingClientRect();
-                    const position = calculateMenuPosition(rect);
+                    const position = calculateAbsoluteMenuPosition(rect);
                     setMenuPosition(position);
                   }
                   setShowPortalMenu((v) => !v); 
@@ -419,7 +419,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
             onClick={(e) => { e.preventDefault(); setShowPortalMenu(false); }}
           />
           <div
-            className="fixed z-[9999] w-56 rounded-md bg-[#2d2d2d]/95 border border-[#3d3d3d] shadow-lg backdrop-blur-sm"
+            className="absolute z-[9999] w-56 rounded-md bg-[#2d2d2d]/95 border border-[#3d3d3d] shadow-lg backdrop-blur-sm"
             style={{ top: menuPosition.top, left: menuPosition.left }}
             onClick={(e) => { e.stopPropagation(); }}
           >

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -3,7 +3,6 @@
 import Image from 'next/image';
 import { NDKEvent } from '@nostr-dev-kit/ndk';
 import AuthorBadge from '@/components/AuthorBadge';
-import { nip19 } from 'nostr-tools';
 import { getNewestProfileMetadata, getNewestProfileEvent } from '@/lib/vertex';
 import { isAbsoluteHttpUrl } from '@/lib/urlPatterns';
 import { useEffect, useMemo, useState, useRef } from 'react';

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -161,7 +161,6 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
         document.body
       )}
     </div>
-    </div>
   );
 }
 
@@ -242,8 +241,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
             >
               {part}
             </button>
-            </div>
-  );
+          );
         }
         return <span key={`bio-text-${idx}`}>{part}</span>;
       });
@@ -379,8 +377,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
                 unoptimized
               />
             </button>
-              </div>
-  );
+          );
           })()}
           <AuthorBadge user={event.author} onAuthorClick={onAuthorClick} />
         </div>

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -387,7 +387,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
             >
               <FontAwesomeIcon icon={faCopy} className="text-gray-400 text-xs" />
             </button>
-            <a href={`/p/${event.author.npub}`} className="truncate hover:underline" title={event.author.npub}>
+            <a href={`/p/${event.author.npub}`} className="truncate hover:underline hidden sm:block" title={event.author.npub}>
               {shortenNpub(event.author.npub)}
             </a>
           </div>

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -6,7 +6,7 @@ import AuthorBadge from '@/components/AuthorBadge';
 import { getNewestProfileMetadata, getNewestProfileEvent } from '@/lib/vertex';
 import { isAbsoluteHttpUrl } from '@/lib/urlPatterns';
 import { useEffect, useMemo, useState, useRef } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowUpRightFromSquare, faCopy } from '@fortawesome/free-solid-svg-icons';
 import { shortenNpub } from '@/lib/utils';
@@ -25,6 +25,7 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
   const bottomButtonRef = useRef<HTMLButtonElement>(null);
   const bottomItems = useMemo(() => createProfileExplorerItems(npub), [npub]);
   const router = useRouter();
+  const pathname = usePathname();
 
   const handleLightningSearch = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -100,7 +101,16 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
       </div>
       <div className="ml-auto flex items-center gap-2">
         {updatedAt && updatedEventId ? (
-          <a href={`/p/${npub}`} className="hover:underline">{updatedLabel}</a>
+          pathname.startsWith('/p/') ? (
+            <button 
+              onClick={onToggleRaw}
+              className="hover:underline cursor-pointer"
+            >
+              {updatedLabel}
+            </button>
+          ) : (
+            <a href={`/p/${npub}`} className="hover:underline">{updatedLabel}</a>
+          )
         ) : (
           <span>{updatedLabel}</span>
         )}

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -161,6 +161,7 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
         document.body
       )}
     </div>
+    </div>
   );
 }
 
@@ -241,7 +242,8 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
             >
               {part}
             </button>
-          );
+            </div>
+  );
         }
         return <span key={`bio-text-${idx}`}>{part}</span>;
       });
@@ -377,7 +379,8 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
                 unoptimized
               />
             </button>
-            );
+              </div>
+  );
           })()}
           <AuthorBadge user={event.author} onAuthorClick={onAuthorClick} />
         </div>
@@ -469,6 +472,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
         </>,
         document.body
       )}
+    </div>
     </div>
   );
 }

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -101,7 +101,7 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
       </div>
       <div className="ml-auto flex items-center gap-2">
         {updatedAt && updatedEventId ? (
-          <a href={`https://njump.me/${nip19.neventEncode({ id: updatedEventId })}`} target="_blank" rel="noopener noreferrer" className="hover:underline">{updatedLabel}</a>
+          <a href={`/p/${npub}`} className="hover:underline">{updatedLabel}</a>
         ) : (
           <span>{updatedLabel}</span>
         )}

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -10,6 +10,7 @@ import { useEffect, useMemo, useState, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowUpRightFromSquare, faCopy } from '@fortawesome/free-solid-svg-icons';
+import { shortenNpub } from '@/lib/utils';
 import { createPortal } from 'react-dom';
 import { createProfileExplorerItems } from '@/lib/portals';
 import { getIsKindTokens } from '@/lib/search/replacements';
@@ -399,7 +400,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
               <FontAwesomeIcon icon={faCopy} className="text-gray-400 text-xs" />
             </button>
             <a href={`/p/${event.author.npub}`} className="truncate hover:underline" title={event.author.npub}>
-              {`${event.author.npub.slice(0, 10)}…${event.author.npub.slice(-3)}`}
+              {shortenNpub(event.author.npub)}
             </a>
           </div>
         )}

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -13,6 +13,7 @@ import { faArrowUpRightFromSquare, faCopy } from '@fortawesome/free-solid-svg-ic
 import { shortenNpub } from '@/lib/utils';
 import { createPortal } from 'react-dom';
 import { createProfileExplorerItems } from '@/lib/portals';
+import { calculateMenuPosition } from '@/lib/utils';
 import { getIsKindTokens } from '@/lib/search/replacements';
 import RawEventJson from '@/components/RawEventJson';
 import CardActions from '@/components/CardActions';
@@ -111,7 +112,8 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
           onToggleMenu={() => {
             if (bottomButtonRef.current) {
               const rect = bottomButtonRef.current.getBoundingClientRect();
-              setMenuPositionBottom({ top: rect.bottom + 4, left: rect.left });
+              const position = calculateMenuPosition(rect);
+              setMenuPositionBottom(position);
             }
             setShowPortalMenuBottom((v) => !v);
           }}
@@ -331,7 +333,8 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
                   e.stopPropagation(); 
                   if (buttonRef.current) {
                     const rect = buttonRef.current.getBoundingClientRect();
-                    setMenuPosition({ top: rect.bottom + 4, left: rect.left });
+                    const position = calculateMenuPosition(rect);
+                    setMenuPosition(position);
                   }
                   setShowPortalMenu((v) => !v); 
                 }}

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -412,6 +412,21 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
         </p>
       ) : null}
       </div>
+      <div className="mt-4 flex items-center justify-end">
+        <CardActions
+          eventId={event.id}
+          showRaw={showRaw}
+          onToggleRaw={() => setShowRaw(v => !v)}
+          onToggleMenu={() => {
+            if (buttonRef.current) {
+              const rect = buttonRef.current.getBoundingClientRect();
+              setMenuPosition({ top: rect.bottom + 4, left: rect.left });
+            }
+            setShowPortalMenu((v) => !v);
+          }}
+          menuButtonRef={buttonRef}
+        />
+      </div>
       <ProfileCreatedAt
         pubkey={event.author.pubkey}
         fallbackEventId={event.id}

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -411,7 +411,6 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
           {renderBioWithHashtags(event.author?.profile?.about)}
         </p>
       ) : null}
-      </div>
       <div className="mt-4 flex items-center justify-end">
         <CardActions
           eventId={event.id}

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -22,6 +22,7 @@ import ProfileCard from '@/components/ProfileCard';
 import ClientFilters, { FilterSettings } from '@/components/ClientFilters';
 import { nip19 } from 'nostr-tools';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { shortenNevent, shortenNpub } from '@/lib/utils';
 import emojiRegex from 'emoji-regex';
 import { faMagnifyingGlass, faImage, faExternalLink, faUser } from '@fortawesome/free-solid-svg-icons';
 // Removed direct Highlight usage; RawEventJson handles JSON highlighting
@@ -1023,7 +1024,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
               const display = profile?.displayName || profile?.display || profile?.name || '';
               const npubVal = nip19.npubEncode(pubkey);
               setNpub(npubVal);
-              setLabel(display || `npub:${npubVal.slice(0, 8)}…${npubVal.slice(-4)}`);
+              setLabel(display || `npub:${shortenNpub(npubVal)}`);
             } catch {
               if (!isMounted) return;
               setLabel(token);
@@ -1414,7 +1415,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
       return (
         <div className={barClasses}>
           <button type="button" onClick={handleToggle} className="w-full text-left">
-            {isLoading ? 'Loading parent…' : `Replying to: ${nip19.neventEncode({ id: parentId })}`}
+            {isLoading ? 'Loading parent…' : `Replying to: ${shortenNevent(nip19.neventEncode({ id: parentId }))}`}
           </button>
         </div>
       );

--- a/src/lib/examples.ts
+++ b/src/lib/examples.ts
@@ -26,6 +26,7 @@ export const searchExamples = [
   'site:github by:fiatjaf',
   'by:dergigi site:yt',
   '#news site:rumble.com',
+  'by:rektbot 💀💀💀💀💀💀💀💀💀💀',
 
   // Direct npub
   'GN by:npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc',

--- a/src/lib/examples.ts
+++ b/src/lib/examples.ts
@@ -6,6 +6,7 @@ export const searchExamples = [
   '#YESTR',
   '#SovEng',
   '#gratefulchain',
+  '#dogstr or #pugstr or #catstr or #horsestr or #goatstr',
   'nevent',
   
   // Author

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,40 @@
+/**
+ * Shortens a long string by keeping the beginning and end, removing the middle part
+ * @param str - The string to shorten
+ * @param startLength - Number of characters to keep at the start (default: 8)
+ * @param endLength - Number of characters to keep at the end (default: 4)
+ * @param separator - The separator to use between start and end (default: '…')
+ * @returns The shortened string
+ */
+export function shortenString(
+  str: string, 
+  startLength: number = 8, 
+  endLength: number = 4, 
+  separator: string = '…'
+): string {
+  if (!str || str.length <= startLength + endLength) {
+    return str;
+  }
+  
+  const start = str.slice(0, startLength);
+  const end = str.slice(-endLength);
+  return `${start}${separator}${end}`;
+}
+
+/**
+ * Shortens an npub string using the standard format
+ * @param npub - The npub string to shorten
+ * @returns The shortened npub string
+ */
+export function shortenNpub(npub: string): string {
+  return shortenString(npub, 10, 3);
+}
+
+/**
+ * Shortens an nevent string using the standard format
+ * @param nevent - The nevent string to shorten
+ * @returns The shortened nevent string
+ */
+export function shortenNevent(nevent: string): string {
+  return shortenString(nevent, 10, 3);
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -84,18 +84,6 @@ export function calculateMenuPosition(
 }
 
 /**
- * Cleans up NIP-05 display by removing implicit prefixes
- * @param nip05 - The NIP-05 string to clean
- * @returns The cleaned NIP-05 string without implicit prefixes
- */
-export function cleanNip05Display(nip05: string): string {
-  if (!nip05) return nip05;
-  
-  // Remove "_@" prefix if present (implicit in NIP-05)
-  return nip05.replace(/^_@/, '');
-}
-
-/**
  * Calculates smart menu positioning for absolute positioning (relative to document)
  * @param buttonRect - The bounding rectangle of the button that triggered the menu
  * @param menuWidth - The width of the menu (default: 224px for w-56)
@@ -139,18 +127,6 @@ export function calculateAbsoluteMenuPosition(
   }
   
   return { top, left };
-}
-
-/**
- * Cleans up NIP-05 display by removing implicit prefixes
- * @param nip05 - The NIP-05 string to clean
- * @returns The cleaned NIP-05 string without implicit prefixes
- */
-export function cleanNip05Display(nip05: string): string {
-  if (!nip05) return nip05;
-  
-  // Remove "_@" prefix if present (implicit in NIP-05)
-  return nip05.replace(/^_@/, '');
 }
 
 /**

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -84,6 +84,18 @@ export function calculateMenuPosition(
 }
 
 /**
+ * Cleans up NIP-05 display by removing implicit prefixes
+ * @param nip05 - The NIP-05 string to clean
+ * @returns The cleaned NIP-05 string without implicit prefixes
+ */
+export function cleanNip05Display(nip05: string): string {
+  if (!nip05) return nip05;
+  
+  // Remove "_@" prefix if present (implicit in NIP-05)
+  return nip05.replace(/^_@/, '');
+}
+
+/**
  * Calculates smart menu positioning for absolute positioning (relative to document)
  * @param buttonRect - The bounding rectangle of the button that triggered the menu
  * @param menuWidth - The width of the menu (default: 224px for w-56)
@@ -130,6 +142,18 @@ export function calculateAbsoluteMenuPosition(
 }
 
 /**
+ * Cleans up NIP-05 display by removing implicit prefixes
+ * @param nip05 - The NIP-05 string to clean
+ * @returns The cleaned NIP-05 string without implicit prefixes
+ */
+export function cleanNip05Display(nip05: string): string {
+  if (!nip05) return nip05;
+  
+  // Remove "_@" prefix if present (implicit in NIP-05)
+  return nip05.replace(/^_@/, '');
+}
+
+/**
  * Calculates positioning for banner menu (positioned relative to viewport, not document)
  * @param buttonRect - The bounding rectangle of the button that triggered the menu
  * @param menuWidth - The width of the menu (default: 224px for w-56)
@@ -171,4 +195,16 @@ export function calculateBannerMenuPosition(
   }
   
   return { top, left };
+}
+
+/**
+ * Cleans up NIP-05 display by removing implicit prefixes
+ * @param nip05 - The NIP-05 string to clean
+ * @returns The cleaned NIP-05 string without implicit prefixes
+ */
+export function cleanNip05Display(nip05: string): string {
+  if (!nip05) return nip05;
+  
+  // Remove "_@" prefix if present (implicit in NIP-05)
+  return nip05.replace(/^_@/, '');
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -128,3 +128,47 @@ export function calculateAbsoluteMenuPosition(
   
   return { top, left };
 }
+
+/**
+ * Calculates positioning for banner menu (positioned relative to viewport, not document)
+ * @param buttonRect - The bounding rectangle of the button that triggered the menu
+ * @param menuWidth - The width of the menu (default: 224px for w-56)
+ * @param menuHeight - The height of the menu (default: auto)
+ * @returns Object with top and left positioning values
+ */
+export function calculateBannerMenuPosition(
+  buttonRect: DOMRect, 
+  menuWidth: number = 224, 
+  menuHeight: number = 200
+): { top: number; left: number } {
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+  
+  // Calculate initial position (below and aligned with left edge of button)
+  let left = buttonRect.left;
+  let top = buttonRect.bottom + 4;
+  
+  // Adjust horizontal position if menu would go off-screen
+  if (left + menuWidth > viewportWidth) {
+    // Try positioning from the right edge of the button
+    left = buttonRect.right - menuWidth;
+    
+    // If still off-screen, position from the right edge of viewport
+    if (left < 0) {
+      left = viewportWidth - menuWidth - 8; // 8px margin from edge
+    }
+  }
+  
+  // Adjust vertical position if menu would go off-screen
+  if (top + menuHeight > viewportHeight) {
+    // Position above the button instead
+    top = buttonRect.top - menuHeight - 4;
+    
+    // If still off-screen, position at the top of viewport
+    if (top < 0) {
+      top = 8; // 8px margin from top
+    }
+  }
+  
+  return { top, left };
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -82,3 +82,49 @@ export function calculateMenuPosition(
   
   return { top, left };
 }
+
+/**
+ * Calculates smart menu positioning for absolute positioning (relative to document)
+ * @param buttonRect - The bounding rectangle of the button that triggered the menu
+ * @param menuWidth - The width of the menu (default: 224px for w-56)
+ * @param menuHeight - The height of the menu (default: auto)
+ * @returns Object with top and left positioning values
+ */
+export function calculateAbsoluteMenuPosition(
+  buttonRect: DOMRect, 
+  menuWidth: number = 224, 
+  menuHeight: number = 200
+): { top: number; left: number } {
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+  const scrollX = window.scrollX;
+  const scrollY = window.scrollY;
+  
+  // Calculate initial position (below and aligned with left edge of button)
+  let left = buttonRect.left + scrollX;
+  let top = buttonRect.bottom + scrollY + 4;
+  
+  // Adjust horizontal position if menu would go off-screen
+  if (left + menuWidth > viewportWidth + scrollX) {
+    // Try positioning from the right edge of the button
+    left = buttonRect.right + scrollX - menuWidth;
+    
+    // If still off-screen, position from the right edge of viewport
+    if (left < scrollX) {
+      left = viewportWidth + scrollX - menuWidth - 8; // 8px margin from edge
+    }
+  }
+  
+  // Adjust vertical position if menu would go off-screen
+  if (top + menuHeight > viewportHeight + scrollY) {
+    // Position above the button instead
+    top = buttonRect.top + scrollY - menuHeight - 4;
+    
+    // If still off-screen, position at the top of viewport
+    if (top < scrollY) {
+      top = scrollY + 8; // 8px margin from top
+    }
+  }
+  
+  return { top, left };
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -38,3 +38,47 @@ export function shortenNpub(npub: string): string {
 export function shortenNevent(nevent: string): string {
   return shortenString(nevent, 10, 3);
 }
+
+/**
+ * Calculates smart menu positioning to ensure the menu stays within viewport
+ * @param buttonRect - The bounding rectangle of the button that triggered the menu
+ * @param menuWidth - The width of the menu (default: 224px for w-56)
+ * @param menuHeight - The height of the menu (default: auto)
+ * @returns Object with top and left positioning values
+ */
+export function calculateMenuPosition(
+  buttonRect: DOMRect, 
+  menuWidth: number = 224, 
+  menuHeight: number = 200
+): { top: number; left: number } {
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+  
+  // Calculate initial position (below and aligned with left edge of button)
+  let left = buttonRect.left;
+  let top = buttonRect.bottom + 4;
+  
+  // Adjust horizontal position if menu would go off-screen
+  if (left + menuWidth > viewportWidth) {
+    // Try positioning from the right edge of the button
+    left = buttonRect.right - menuWidth;
+    
+    // If still off-screen, position from the right edge of viewport
+    if (left < 0) {
+      left = viewportWidth - menuWidth - 8; // 8px margin from edge
+    }
+  }
+  
+  // Adjust vertical position if menu would go off-screen
+  if (top + menuHeight > viewportHeight) {
+    // Position above the button instead
+    top = buttonRect.top - menuHeight - 4;
+    
+    // If still off-screen, position at the top of viewport
+    if (top < 0) {
+      top = 8; // 8px margin from top
+    }
+  }
+  
+  return { top, left };
+}


### PR DESCRIPTION
This PR enhances the mobile user experience by shortening display text, improving menu positioning, and adding context-aware navigation. The changes include shortening npub/nevent strings using DRY utility functions, hiding unnecessary information on mobile screens, making NIP-05 indicators clickable, and fixing three-dot menu positioning issues. Additionally, new search examples have been added including animal hashtags and rektbot content, and the GitHub footer link now includes an external link icon.

- Refactor Footer component to eliminate duplicate code using higher-order function pattern
- Add context-aware behavior for profile updated links to toggle raw JSON when already on profile page
- Update filter text from 'Verified only' to 'Valid NIP-05' for better clarity