### PR TITLE
Add profile actions to /p page

### DIFF
--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -23,7 +23,7 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
   const [showPortalMenuBottom, setShowPortalMenuBottom] = useState(false);
   const [menuPositionBottom, setMenuPositionBottom] = useState({ top: 0, left: 0 });
   const bottomButtonRef = useRef<HTMLButtonElement>(null);
-  const bottomItems = useMemo(() => createProfileExplorerItems(npub), [npub]);
+  const bottomItems = useMemo(() => createProfileExplorerItems(npub, pubkey), [npub, pubkey]);
   const router = useRouter();
   const pathname = usePathname();
 
@@ -71,7 +71,7 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
   };
 
   const updatedLabel = updatedAt ? `Updated ${relative(updatedAt)}.` : 'Updated unknown.';
-  // footer-specific state only
+  const explorerItems = bottomItems;
 
   return (
     <div className="text-xs text-gray-300 bg-[#2d2d2d] border-t border-[#3d3d3d] px-4 py-2 flex items-center gap-3 flex-wrap">
@@ -100,34 +100,46 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
         {/* NIP-05 controls moved to AuthorBadge next to the name */}
       </div>
       <div className="ml-auto flex items-center gap-2">
-        {updatedAt && updatedEventId ? (
-          pathname.startsWith('/p/') ? (
-            <button 
-              onClick={onToggleRaw}
-              className="hover:underline cursor-pointer"
-            >
-              {updatedLabel}
-            </button>
+        <div className="flex items-center gap-2">
+          {updatedAt && updatedEventId ? (
+            pathname.startsWith('/p/') ? (
+              <button
+                onClick={onToggleRaw}
+                className="hover:underline cursor-pointer"
+              >
+                {updatedLabel}
+              </button>
+            ) : (
+              <a href={`/p/${npub}`} className="hover:underline">{updatedLabel}</a>
+            )
           ) : (
-            <a href={`/p/${npub}`} className="hover:underline">{updatedLabel}</a>
-          )
-        ) : (
-          <span>{updatedLabel}</span>
-        )}
-        <CardActions
-          eventId={fallbackEventId}
-          showRaw={showRaw}
-          onToggleRaw={onToggleRaw}
-          onToggleMenu={() => {
-            if (bottomButtonRef.current) {
-              const rect = bottomButtonRef.current.getBoundingClientRect();
-              const position = calculateAbsoluteMenuPosition(rect);
-              setMenuPositionBottom(position);
-            }
-            setShowPortalMenuBottom((v) => !v);
-          }}
-          menuButtonRef={bottomButtonRef}
-        />
+            <span>{updatedLabel}</span>
+          )}
+          <CardActions
+            eventId={fallbackEventId}
+            showRaw={showRaw}
+            onToggleRaw={onToggleRaw}
+            onToggleMenu={() => {
+              if (bottomButtonRef.current) {
+                const rect = bottomButtonRef.current.getBoundingClientRect();
+                const position = calculateAbsoluteMenuPosition(rect);
+                setMenuPositionBottom(position);
+              }
+              setShowPortalMenuBottom((v) => !v);
+            }}
+            menuButtonRef={bottomButtonRef}
+            externalHref={bottomItems[0]?.href}
+            externalTitle={`Open ${bottomItems[0]?.name}`}
+            externalTarget={bottomItems[0]?.href?.startsWith('http') ? '_blank' : undefined}
+            externalRel={bottomItems[0]?.href?.startsWith('http') ? 'noopener noreferrer' : undefined}
+            onExternalClick={(e) => {
+              if (!bottomItems.length) return;
+              if (bottomItems[0]?.href?.startsWith('http')) return;
+              e.preventDefault();
+              router.push(bottomItems[0]?.href || '#');
+            }}
+          />
+        </div>
       </div>
       {showPortalMenuBottom && typeof window !== 'undefined' && createPortal(
         <>

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -24,6 +24,7 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
   const [menuPositionBottom, setMenuPositionBottom] = useState({ top: 0, left: 0 });
   const bottomButtonRef = useRef<HTMLButtonElement>(null);
   const bottomItems = useMemo(() => createProfileExplorerItems(npub, pubkey), [npub, pubkey]);
+  const nativeAppHref = useMemo(() => bottomItems.find((item) => item.name === 'Native App')?.href, [bottomItems]);
   const router = useRouter();
   const pathname = usePathname();
 
@@ -71,7 +72,6 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
   };
 
   const updatedLabel = updatedAt ? `Updated ${relative(updatedAt)}.` : 'Updated unknown.';
-  const explorerItems = bottomItems;
 
   return (
     <div className="text-xs text-gray-300 bg-[#2d2d2d] border-t border-[#3d3d3d] px-4 py-2 flex items-center gap-3 flex-wrap">
@@ -128,15 +128,16 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
               setShowPortalMenuBottom((v) => !v);
             }}
             menuButtonRef={bottomButtonRef}
-            externalHref={bottomItems[0]?.href}
-            externalTitle={`Open ${bottomItems[0]?.name}`}
-            externalTarget={bottomItems[0]?.href?.startsWith('http') ? '_blank' : undefined}
-            externalRel={bottomItems[0]?.href?.startsWith('http') ? 'noopener noreferrer' : undefined}
+            externalHref={nativeAppHref}
+            externalTitle="Open in native app"
+            externalTarget={nativeAppHref?.startsWith('http') ? '_blank' : undefined}
+            externalRel={nativeAppHref?.startsWith('http') ? 'noopener noreferrer' : undefined}
             onExternalClick={(e) => {
-              if (!bottomItems.length) return;
-              if (bottomItems[0]?.href?.startsWith('http')) return;
-              e.preventDefault();
-              router.push(bottomItems[0]?.href || '#');
+              if (!nativeAppHref) return;
+              if (nativeAppHref.startsWith('/')) {
+                e.preventDefault();
+                router.push(nativeAppHref);
+              }
             }}
           />
         </div>


### PR DESCRIPTION
Adds the missing controls to the `/p` profile header so the JSON toggle, portals menu, and native `nostr:` link match what we ship elsewhere.

- share the profile via the three-dot menu using `createProfileExplorerItems`
- show the JSON toggle inline next to the `Updated` timestamp
- ensure the external button calls the `Native App` `nostr:` URI