### PR TITLE
feat: refresh footer copy

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -29,7 +29,8 @@ export function Footer() {
         <a href="#" onClick={handleSearchClick('dergigi.com')} className="underline hover:text-gray-300">
           Gigi
         </a>
-        . Birthed during{' '}
+        <span className="mx-2">·</span>
+        Birthed during{' '}
         <a
           href="#"
           onClick={handleSearchClick('(#SovEng OR by:sovereignengineering.io)')}
@@ -37,11 +38,11 @@ export function Footer() {
         >
           SEC-04
         </a>
-        . Using{' '}
+        <span className="mx-2">·</span>
+        Using{' '}
         <a href="#" onClick={handleSearchClick('p:npub1kpt95rv4q3mcz8e4lamwtxq7men6jprf49l7asfac9lnv2gda0lqdknhmz')} className="underline hover:text-gray-300">
           Vertex
         </a>
-        .
       </p>
       <p className="mt-1">
         <a href="#" onClick={handleSearchClick('"dergigi/ants"')} className="underline hover:text-gray-300">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -55,7 +55,7 @@ export function Footer() {
             <FontAwesomeIcon icon={faExternalLink} className="h-3 w-3" />
           </button>
         </a>
-        {'   '}
+        <span className="mx-2">·</span>
         <a href="#" onClick={handleSearchClick('p:npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc')} className="underline hover:text-gray-300">
           Nostr
         </a>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -25,7 +25,23 @@ export function Footer() {
   return (
     <footer className="text-center text-xs text-gray-400 py-6 select-none bg-[#1a1a1a]">
       <p>
-        Vibed by <a href="#" onClick={handleSearchClick('dergigi.com')} className="underline hover:text-gray-300">Gigi</a>.
+        Vibed by{' '}
+        <a href="#" onClick={handleSearchClick('dergigi.com')} className="underline hover:text-gray-300">
+          Gigi
+        </a>
+        . Birthed during{' '}
+        <a
+          href="#"
+          onClick={handleSearchClick('(#SovEng OR by:sovereignengineering.io)')}
+          className="underline hover:text-gray-300"
+        >
+          SEC-04
+        </a>
+        . Using{' '}
+        <a href="#" onClick={handleSearchClick('p:npub1kpt95rv4q3mcz8e4lamwtxq7men6jprf49l7asfac9lnv2gda0lqdknhmz')} className="underline hover:text-gray-300">
+          Vertex
+        </a>
+        .
       </p>
       <p className="mt-1">
         <a href="#" onClick={handleSearchClick('"dergigi/ants"')} className="underline hover:text-gray-300">
@@ -39,18 +55,10 @@ export function Footer() {
             <FontAwesomeIcon icon={faExternalLink} className="h-3 w-3" />
           </button>
         </a>
-        <span className="mx-2">·</span>
-        <a href="#" onClick={handleSearchClick('p:npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc')} className="underline hover:text-gray-300">Nostr</a>
-        <span className="mx-2">·</span>
-        <a
-          href="#"
-          onClick={handleSearchClick('(#SovEng OR by:sovereignengineering.io)')}
-          className="underline hover:text-gray-300"
-        >
-          Birthed during SEC-04
+        {'   '}
+        <a href="#" onClick={handleSearchClick('p:npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc')} className="underline hover:text-gray-300">
+          Nostr
         </a>
-        <span className="mx-2">·</span>
-        <a href="#" onClick={handleSearchClick('p:npub1kpt95rv4q3mcz8e4lamwtxq7men6jprf49l7asfac9lnv2gda0lqdknhmz')} className="underline hover:text-gray-300">Using Vertex</a>
       </p>
     </footer>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -42,7 +42,13 @@ export function Footer() {
         <span className="mx-2">·</span>
         <a href="#" onClick={handleSearchClick('p:npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc')} className="underline hover:text-gray-300">Nostr</a>
         <span className="mx-2">·</span>
-        <a href="#" onClick={handleSearchClick('#SovEng')} className="underline hover:text-gray-300">Birthed during SEC-04</a>
+        <a
+          href="#"
+          onClick={handleSearchClick('(#SovEng OR by:sovereignengineering.io)')}
+          className="underline hover:text-gray-300"
+        >
+          Birthed during SEC-04
+        </a>
         <span className="mx-2">·</span>
         <a href="#" onClick={handleSearchClick('p:npub1kpt95rv4q3mcz8e4lamwtxq7men6jprf49l7asfac9lnv2gda0lqdknhmz')} className="underline hover:text-gray-300">Using Vertex</a>
       </p>


### PR DESCRIPTION
Updates the footer to keep the project credits in a single line with middot separators while preserving all existing link targets and expanding the `SEC-04` search query to include `by:sovereignengineering.io`