### PR TITLE
feat: instant profile rendering with prefetch and improved loading states

### DIFF
--- a/src/components/AuthorBadge.tsx
+++ b/src/components/AuthorBadge.tsx
@@ -66,6 +66,10 @@ export default function AuthorBadge({ user, onAuthorClick }: { user: NDKUser, on
 
   useEffect(() => {
     let isMounted = true;
+    // Use any already-known profile data immediately
+    const initial = user.profile?.displayName || user.profile?.name || '';
+    setName(initial);
+    setLoaded(true);
     (async () => {
       try {
         await user.fetchProfile();
@@ -73,7 +77,6 @@ export default function AuthorBadge({ user, onAuthorClick }: { user: NDKUser, on
       if (!isMounted) return;
       const display = user.profile?.displayName || user.profile?.name || '';
       setName(display);
-      setLoaded(true);
     })();
     return () => { isMounted = false; };
   }, [user]);

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -11,6 +11,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowUpRightFromSquare, faCopy, faExternalLink } from '@fortawesome/free-solid-svg-icons';
 import { shortenNpub } from '@/lib/utils';
 import { createPortal } from 'react-dom';
+import { nip19 } from 'nostr-tools';
+import { setPrefetchedProfile } from '@/lib/profile/prefetch';
 import { createProfileExplorerItems } from '@/lib/portals';
 import { calculateAbsoluteMenuPosition, calculateBannerMenuPosition } from '@/lib/utils';
 import { getIsKindTokens } from '@/lib/search/replacements';
@@ -466,7 +468,19 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
             >
               <FontAwesomeIcon icon={faCopy} className="text-gray-400 text-xs" />
             </button>
-            <a href={`/p/${event.author.npub}`} className="truncate hover:underline hidden sm:block" title={event.author.npub}>
+            <a
+              href={`/p/${event.author.npub}`}
+              className="truncate hover:underline hidden sm:block"
+              title={event.author.npub}
+              onClick={(e) => {
+                try {
+                  const { data } = nip19.decode(event.author.npub);
+                  const pk = data as string;
+                  setPrefetchedProfile(pk, event);
+                } catch {}
+                // Allow default navigation
+              }}
+            >
               {shortenNpub(event.author.npub)}
             </a>
           </div>

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -298,7 +298,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
   return (
     <div className={noteCardClasses}>
       {/* Centralized preseed: whenever a ProfileCard renders, ensure its event is prepared and seeded */}
-      {(() => { try { if (event?.kind === 0 && event?.author?.pubkey) { console.log('🔥 ProfileCard seeding with pubkey:', event.author.pubkey); setPrefetchedProfile(event.author.pubkey, prepareProfileEventForPrefetch(event)); } } catch {} return null; })()}
+      {(() => { try { if (event?.kind === 0 && event?.author?.pubkey) { setPrefetchedProfile(event.author.pubkey, prepareProfileEventForPrefetch(event)); } } catch {} return null; })()}
       {showBanner && safeBannerUrl && (
         <div
           role="button"

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -298,7 +298,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
   return (
     <div className={noteCardClasses}>
       {/* Centralized preseed: whenever a ProfileCard renders, ensure its event is prepared and seeded */}
-      {(() => { try { if (event?.kind === 0 && event?.author?.pubkey) { setPrefetchedProfile(event.author.pubkey, prepareProfileEventForPrefetch(event)); } } catch {} return null; })()}
+      {(() => { try { if (event?.kind === 0 && event?.author?.pubkey) { console.log('🔥 ProfileCard seeding with pubkey:', event.author.pubkey); setPrefetchedProfile(event.author.pubkey, prepareProfileEventForPrefetch(event)); } } catch {} return null; })()}
       {showBanner && safeBannerUrl && (
         <div
           role="button"

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -431,7 +431,12 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
                   }
                 } catch {}
               }
-              // Otherwise, go to the author's profile
+              // Otherwise, go to the author's profile; seed prefetch first
+              try {
+                const { data } = nip19.decode(event.author.npub);
+                const pk = data as string;
+                setPrefetchedProfile(pk, event);
+              } catch {}
               if (onAuthorClick && event.author?.npub) onAuthorClick(event.author.npub);
             };
             return (

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -12,7 +12,7 @@ import { faArrowUpRightFromSquare, faCopy, faExternalLink } from '@fortawesome/f
 import { shortenNpub } from '@/lib/utils';
 import { createPortal } from 'react-dom';
 import { nip19 } from 'nostr-tools';
-import { setPrefetchedProfile } from '@/lib/profile/prefetch';
+import { setPrefetchedProfile, prepareProfileEventForPrefetch } from '@/lib/profile/prefetch';
 import { createProfileExplorerItems } from '@/lib/portals';
 import { calculateAbsoluteMenuPosition, calculateBannerMenuPosition } from '@/lib/utils';
 import { getIsKindTokens } from '@/lib/search/replacements';
@@ -297,6 +297,8 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
   }, [onHashtagClick, router]);
   return (
     <div className={noteCardClasses}>
+      {/* Centralized preseed: whenever a ProfileCard renders, ensure its event is prepared and seeded */}
+      {(() => { try { if (event?.kind === 0 && event?.author?.pubkey) { setPrefetchedProfile(event.author.pubkey, prepareProfileEventForPrefetch(event)); } } catch {} return null; })()}
       {showBanner && safeBannerUrl && (
         <div
           role="button"
@@ -435,7 +437,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
               try {
                 const { data } = nip19.decode(event.author.npub);
                 const pk = data as string;
-                setPrefetchedProfile(pk, event);
+                setPrefetchedProfile(pk, prepareProfileEventForPrefetch(event));
               } catch {}
               if (onAuthorClick && event.author?.npub) onAuthorClick(event.author.npub);
             };

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -479,7 +479,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
               href={`/p/${event.author.npub}`}
               className="truncate hover:underline hidden sm:block"
               title={event.author.npub}
-              onClick={(e) => {
+              onClick={() => {
                 try {
                   const { data } = nip19.decode(event.author.npub);
                   const pk = data as string;

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -26,7 +26,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { shortenNevent, shortenNpub } from '@/lib/utils';
 import emojiRegex from 'emoji-regex';
 import { faMagnifyingGlass, faImage, faExternalLink, faUser, faEye } from '@fortawesome/free-solid-svg-icons';
-import { setPrefetchedProfile } from '@/lib/profile/prefetch';
+import { setPrefetchedProfile, prepareProfileEventForPrefetch } from '@/lib/profile/prefetch';
 
 // Reusable search icon button component
 function SearchIconButton({ 
@@ -562,7 +562,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
     try {
       for (const ev of fuseFilteredResults) {
         if (ev.kind === 0 && ev.pubkey) {
-          setPrefetchedProfile(ev.pubkey, ev);
+          setPrefetchedProfile(ev.pubkey, prepareProfileEventForPrefetch(ev));
         }
       }
     } catch {}
@@ -963,7 +963,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
       if (prefetchEvent) {
         const { data } = nip19.decode(npub);
         const pk = data as string;
-        setPrefetchedProfile(pk, prefetchEvent);
+        setPrefetchedProfile(pk, prepareProfileEventForPrefetch(prefetchEvent));
       }
     } catch {}
     router.push(`/p/${npub}`);

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -559,9 +559,11 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
 
   // Seed profile prefetch for visible profile cards as soon as results materialize
   useEffect(() => {
+    console.log('🔥 SearchView seeding prefetch for', fuseFilteredResults.length, 'results');
     try {
       for (const ev of fuseFilteredResults) {
         if (ev.kind === 0 && ev.pubkey) {
+          console.log('🔥 SearchView seeding profile with pubkey:', ev.pubkey);
           setPrefetchedProfile(ev.pubkey, prepareProfileEventForPrefetch(ev));
         }
       }

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -559,7 +559,6 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
 
   // Seed profile prefetch for visible profile cards as soon as results materialize
   useEffect(() => {
-    console.log('🔥 SearchView seeding prefetch for', fuseFilteredResults.length, 'results');
     try {
       for (const ev of fuseFilteredResults) {
         if (ev.kind === 0) {

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -946,7 +946,17 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
     return () => { cancelled = true; clearTimeout(id); };
   }, [query]);
 
-  const goToProfile = useCallback((npub: string) => {
+  const goToProfile = useCallback((npub: string, prefetchEvent?: NDKEvent) => {
+    try {
+      if (prefetchEvent) {
+        const { data } = nip19.decode(npub);
+        const pk = data as string;
+        // Lazy import to avoid circular deps at module init
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { setPrefetchedProfile } = require('@/lib/profile/prefetch');
+        setPrefetchedProfile(pk, prefetchEvent);
+      }
+    } catch {}
     router.push(`/p/${npub}`);
   }, [router]);
 
@@ -1817,7 +1827,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
                 <div key={key}>
                   {parentId && renderParentChain(event)}
                   {event.kind === 0 ? (
-                    <ProfileCard event={event} onAuthorClick={goToProfile} showBanner={false} />
+                    <ProfileCard event={event} onAuthorClick={(npub) => goToProfile(npub, event)} showBanner={false} />
                   ) : event.kind === 1 ? (
                     <EventCard
                       event={event}

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -562,9 +562,13 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
     console.log('🔥 SearchView seeding prefetch for', fuseFilteredResults.length, 'results');
     try {
       for (const ev of fuseFilteredResults) {
-        if (ev.kind === 0 && ev.pubkey) {
-          console.log('🔥 SearchView seeding profile with pubkey:', ev.pubkey);
-          setPrefetchedProfile(ev.pubkey, prepareProfileEventForPrefetch(ev));
+        if (ev.kind === 0) {
+          // Use author.pubkey if available, fallback to event.pubkey
+          const pubkey = ev.author?.pubkey || ev.pubkey;
+          if (pubkey) {
+            console.log('🔥 SearchView seeding profile with pubkey:', pubkey);
+            setPrefetchedProfile(pubkey, prepareProfileEventForPrefetch(ev));
+          }
         }
       }
     } catch {}

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -565,7 +565,6 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
           // Use author.pubkey if available, fallback to event.pubkey
           const pubkey = ev.author?.pubkey || ev.pubkey;
           if (pubkey) {
-            console.log('🔥 SearchView seeding profile with pubkey:', pubkey);
             setPrefetchedProfile(pubkey, prepareProfileEventForPrefetch(ev));
           }
         }

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -26,6 +26,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { shortenNevent, shortenNpub } from '@/lib/utils';
 import emojiRegex from 'emoji-regex';
 import { faMagnifyingGlass, faImage, faExternalLink, faUser, faEye } from '@fortawesome/free-solid-svg-icons';
+import { setPrefetchedProfile } from '@/lib/profile/prefetch';
 
 // Reusable search icon button component
 function SearchIconButton({ 
@@ -951,9 +952,6 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
       if (prefetchEvent) {
         const { data } = nip19.decode(npub);
         const pk = data as string;
-        // Lazy import to avoid circular deps at module init
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const { setPrefetchedProfile } = require('@/lib/profile/prefetch');
         setPrefetchedProfile(pk, prefetchEvent);
       }
     } catch {}

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -557,6 +557,17 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
     return fuse.search(q).map(r => r.item);
   }, [filteredResults, filterSettings.resultFilter, filterSettings.fuzzyEnabled]);
 
+  // Seed profile prefetch for visible profile cards as soon as results materialize
+  useEffect(() => {
+    try {
+      for (const ev of fuseFilteredResults) {
+        if (ev.kind === 0 && ev.pubkey) {
+          setPrefetchedProfile(ev.pubkey, ev);
+        }
+      }
+    } catch {}
+  }, [fuseFilteredResults]);
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   function applyClientFilters(events: NDKEvent[], _terms: string[], _active: Set<string>): NDKEvent[] {
     // Rely solely on replacements.txt expansion upstream; no client-side media seeding

--- a/src/hooks/useNostrUser.ts
+++ b/src/hooks/useNostrUser.ts
@@ -18,7 +18,6 @@ export function useNostrUser(npub: string | undefined) {
       try {
         const { data } = nip19.decode(npub);
         const pk = data as string;
-        console.log('🔥 useNostrUser decoded pubkey:', pk);
         setPubkey(pk);
         const u = new NDKUser({ pubkey: pk });
         u.ndk = ndk;
@@ -28,21 +27,17 @@ export function useNostrUser(npub: string | undefined) {
         const prefetched = getPrefetchedProfile(pk);
         console.log('🔥 useNostrUser prefetched result:', !!prefetched);
         if (prefetched) {
-          console.log('🔥 useNostrUser found prefetched, preparing...');
           const prepared = prepareProfileEventForPrefetch(prefetched);
           // Copy prepared author's profile into the new user before attaching
           try {
             const existingProfile = prepared.author && (prepared.author as unknown as { profile?: unknown }).profile;
-            console.log('🔥 useNostrUser existingProfile:', existingProfile);
             if (existingProfile) {
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               (u as any).profile = existingProfile as any;
-              console.log('🔥 useNostrUser applied profile to user, user.profile now:', u.profile);
             }
           } catch {}
           prepared.author = u;
           setProfileEvent(prepared);
-          console.log('🔥 useNostrUser set profile event with prefetched data');
           clearPrefetchedProfile(pk);
         } else {
           const placeholder = new NDKEvent(ndk, {

--- a/src/hooks/useNostrUser.ts
+++ b/src/hooks/useNostrUser.ts
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { NDKEvent, NDKUser } from '@nostr-dev-kit/ndk';
 import { nip19 } from 'nostr-tools';
 import { ndk, connect } from '@/lib/ndk';
+import { getPrefetchedProfile, clearPrefetchedProfile } from '@/lib/profile/prefetch';
 
 export function useNostrUser(npub: string | undefined) {
   const [user, setUser] = useState<NDKUser | null>(null);
@@ -21,19 +22,26 @@ export function useNostrUser(npub: string | undefined) {
         const u = new NDKUser({ pubkey: pk });
         u.ndk = ndk;
 
-        // Show placeholder immediately
+        // Use prefetched event if available for instant UI; otherwise show placeholder
         setUser(u);
-        const placeholder = new NDKEvent(ndk, {
-          kind: 0,
-          created_at: Math.floor(Date.now() / 1000),
-          content: JSON.stringify({}),
-          pubkey: pk,
-          tags: [],
-          id: '',
-          sig: ''
-        });
-        placeholder.author = u;
-        setProfileEvent(placeholder);
+        const prefetched = getPrefetchedProfile(pk);
+        if (prefetched) {
+          prefetched.author = u;
+          setProfileEvent(prefetched);
+          clearPrefetchedProfile(pk);
+        } else {
+          const placeholder = new NDKEvent(ndk, {
+            kind: 0,
+            created_at: Math.floor(Date.now() / 1000),
+            content: JSON.stringify({}),
+            pubkey: pk,
+            tags: [],
+            id: '',
+            sig: ''
+          });
+          placeholder.author = u;
+          setProfileEvent(placeholder);
+        }
 
         // Load connection and fetch profile
         try { await connect(); } catch {}

--- a/src/hooks/useNostrUser.ts
+++ b/src/hooks/useNostrUser.ts
@@ -25,18 +25,23 @@ export function useNostrUser(npub: string | undefined) {
         // Use prefetched event if available for instant UI; otherwise show placeholder
         setUser(u);
         const prefetched = getPrefetchedProfile(pk);
+        console.log('🔥 useNostrUser prefetched result:', !!prefetched);
         if (prefetched) {
+          console.log('🔥 useNostrUser found prefetched, preparing...');
           const prepared = prepareProfileEventForPrefetch(prefetched);
           // Copy prepared author's profile into the new user before attaching
           try {
             const existingProfile = prepared.author && (prepared.author as unknown as { profile?: unknown }).profile;
+            console.log('🔥 useNostrUser existingProfile:', existingProfile);
             if (existingProfile) {
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               (u as any).profile = existingProfile as any;
+              console.log('🔥 useNostrUser applied profile to user, user.profile now:', u.profile);
             }
           } catch {}
           prepared.author = u;
           setProfileEvent(prepared);
+          console.log('🔥 useNostrUser set profile event with prefetched data');
           clearPrefetchedProfile(pk);
         } else {
           const placeholder = new NDKEvent(ndk, {

--- a/src/hooks/useNostrUser.ts
+++ b/src/hooks/useNostrUser.ts
@@ -52,22 +52,23 @@ export function useNostrUser(npub: string | undefined) {
           setProfileEvent(placeholder);
         }
 
-        // Load connection and fetch profile
-        try { await connect(); } catch {}
-        try { await u.fetchProfile(); } catch {}
-        if (cancelled) return;
-
-        const filled = new NDKEvent(ndk, {
-          kind: 0,
-          created_at: Math.floor(Date.now() / 1000),
-          content: JSON.stringify(u.profile || {}),
-          pubkey: pk,
-          tags: [],
-          id: '',
-          sig: ''
-        });
-        filled.author = u;
-        setProfileEvent(filled);
+        // Load connection and fetch profile to refresh in background
+        ;(async () => {
+          try { await connect(); } catch {}
+          try { await u.fetchProfile(); } catch {}
+          if (cancelled) return;
+          const filled = new NDKEvent(ndk, {
+            kind: 0,
+            created_at: Math.floor(Date.now() / 1000),
+            content: JSON.stringify(u.profile || {}),
+            pubkey: pk,
+            tags: [],
+            id: '',
+            sig: ''
+          });
+          filled.author = u;
+          setProfileEvent(filled);
+        })();
       } catch {
         if (cancelled) return;
         setUser(null);

--- a/src/hooks/useNostrUser.ts
+++ b/src/hooks/useNostrUser.ts
@@ -26,15 +26,15 @@ export function useNostrUser(npub: string | undefined) {
         setUser(u);
         const prefetched = getPrefetchedProfile(pk);
         if (prefetched) {
-          // Preserve existing profile metadata so avatar/banner show instantly
+          const prepared = prepareProfileEventForPrefetch(prefetched);
+          // Copy prepared author's profile into the new user before attaching
           try {
-            const existingAuthor = prefetched.author as unknown as { profile?: unknown } | null;
-            if (existingAuthor && typeof existingAuthor === 'object' && 'profile' in existingAuthor) {
+            const existingProfile = prepared.author && (prepared.author as unknown as { profile?: unknown }).profile;
+            if (existingProfile) {
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              (u as any).profile = (existingAuthor as any).profile;
+              (u as any).profile = existingProfile as any;
             }
           } catch {}
-          const prepared = prepareProfileEventForPrefetch(prefetched);
           prepared.author = u;
           setProfileEvent(prepared);
           clearPrefetchedProfile(pk);

--- a/src/hooks/useNostrUser.ts
+++ b/src/hooks/useNostrUser.ts
@@ -25,7 +25,6 @@ export function useNostrUser(npub: string | undefined) {
         // Use prefetched event if available for instant UI; otherwise show placeholder
         setUser(u);
         const prefetched = getPrefetchedProfile(pk);
-        console.log('🔥 useNostrUser prefetched result:', !!prefetched);
         if (prefetched) {
           const prepared = prepareProfileEventForPrefetch(prefetched);
           // Copy prepared author's profile into the new user before attaching

--- a/src/hooks/useNostrUser.ts
+++ b/src/hooks/useNostrUser.ts
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { NDKEvent, NDKUser } from '@nostr-dev-kit/ndk';
 import { nip19 } from 'nostr-tools';
 import { ndk, connect } from '@/lib/ndk';
-import { getPrefetchedProfile, clearPrefetchedProfile } from '@/lib/profile/prefetch';
+import { getPrefetchedProfile, clearPrefetchedProfile, prepareProfileEventForPrefetch } from '@/lib/profile/prefetch';
 
 export function useNostrUser(npub: string | undefined) {
   const [user, setUser] = useState<NDKUser | null>(null);
@@ -34,8 +34,9 @@ export function useNostrUser(npub: string | undefined) {
               (u as any).profile = (existingAuthor as any).profile;
             }
           } catch {}
-          prefetched.author = u;
-          setProfileEvent(prefetched);
+          const prepared = prepareProfileEventForPrefetch(prefetched);
+          prepared.author = u;
+          setProfileEvent(prepared);
           clearPrefetchedProfile(pk);
         } else {
           const placeholder = new NDKEvent(ndk, {

--- a/src/hooks/useNostrUser.ts
+++ b/src/hooks/useNostrUser.ts
@@ -38,7 +38,8 @@ export function useNostrUser(npub: string | undefined) {
           } catch {}
           prepared.author = u;
           setProfileEvent(prepared);
-          clearPrefetchedProfile(pk);
+          // Clear prefetch after a small delay to handle React StrictMode double-mounting
+          setTimeout(() => clearPrefetchedProfile(pk), 100);
         } else {
           const placeholder = new NDKEvent(ndk, {
             kind: 0,

--- a/src/hooks/useNostrUser.ts
+++ b/src/hooks/useNostrUser.ts
@@ -18,6 +18,7 @@ export function useNostrUser(npub: string | undefined) {
       try {
         const { data } = nip19.decode(npub);
         const pk = data as string;
+        console.log('🔥 useNostrUser decoded pubkey:', pk);
         setPubkey(pk);
         const u = new NDKUser({ pubkey: pk });
         u.ndk = ndk;

--- a/src/hooks/useNostrUser.ts
+++ b/src/hooks/useNostrUser.ts
@@ -26,6 +26,14 @@ export function useNostrUser(npub: string | undefined) {
         setUser(u);
         const prefetched = getPrefetchedProfile(pk);
         if (prefetched) {
+          // Preserve existing profile metadata so avatar/banner show instantly
+          try {
+            const existingAuthor = prefetched.author as unknown as { profile?: unknown } | null;
+            if (existingAuthor && typeof existingAuthor === 'object' && 'profile' in existingAuthor) {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              (u as any).profile = (existingAuthor as any).profile;
+            }
+          } catch {}
           prefetched.author = u;
           setProfileEvent(prefetched);
           clearPrefetchedProfile(pk);

--- a/src/lib/profile/prefetch.ts
+++ b/src/lib/profile/prefetch.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { NDKEvent } from '@nostr-dev-kit/ndk';
+
+// Simple in-memory prefetch store for profile events keyed by hex pubkey
+// Not persisted; short TTL to avoid stale UI
+
+type PrefetchEntry = { event: NDKEvent; timestamp: number };
+
+const PROFILE_PREFETCH_TTL_MS = 60 * 1000; // 60s is enough for navigation
+const profilePrefetch = new Map<string, PrefetchEntry>();
+
+export function setPrefetchedProfile(pubkeyHex: string, event: NDKEvent): void {
+  if (!pubkeyHex || !event) return;
+  profilePrefetch.set(pubkeyHex, { event, timestamp: Date.now() });
+}
+
+export function getPrefetchedProfile(pubkeyHex: string): NDKEvent | null {
+  const entry = profilePrefetch.get(pubkeyHex);
+  if (!entry) return null;
+  const isExpired = Date.now() - entry.timestamp > PROFILE_PREFETCH_TTL_MS;
+  if (isExpired) {
+    profilePrefetch.delete(pubkeyHex);
+    return null;
+  }
+  return entry.event;
+}
+
+export function clearPrefetchedProfile(pubkeyHex: string): void {
+  if (!pubkeyHex) return;
+  profilePrefetch.delete(pubkeyHex);
+}
+
+

--- a/src/lib/profile/prefetch.ts
+++ b/src/lib/profile/prefetch.ts
@@ -64,13 +64,14 @@ export function setPrefetchedProfile(pubkeyHex: string, event: NDKEvent): void {
   try {
     if (!hasLocalStorage()) return;
     const current = loadMapFromStorage<StoredProfileEvent & { timestamp: number }>(STORAGE_KEY);
+    const authorProfile: unknown = event.author && (event.author as unknown as { profile?: unknown }).profile;
     const stored: StoredProfileEvent & { timestamp: number } = {
       kind: 0,
       content: event.content || '{}',
       pubkey: pubkeyHex,
       created_at: event.created_at,
       id: event.id,
-      author: event.author ? { pubkey: event.author.pubkey, /* eslint-disable-next-line @typescript-eslint/no-explicit-any */ profile: (event.author as any).profile } : { pubkey: pubkeyHex },
+      author: event.author ? { pubkey: event.author.pubkey, profile: authorProfile } : { pubkey: pubkeyHex },
       timestamp: ts
     };
     current.set(pubkeyHex, stored);

--- a/src/lib/profile/prefetch.ts
+++ b/src/lib/profile/prefetch.ts
@@ -81,9 +81,7 @@ export function setPrefetchedProfile(pubkeyHex: string, event: NDKEvent): void {
 }
 
 export function getPrefetchedProfile(pubkeyHex: string): NDKEvent | null {
-  console.log('🔥 getPrefetchedProfile called for:', pubkeyHex);
   const entry = profilePrefetch.get(pubkeyHex);
-  console.log('🔥 getPrefetchedProfile found entry:', !!entry, entry ? 'age:' + (Date.now() - entry.timestamp) + 'ms' : '');
   if (!entry) return null;
   const isExpired = Date.now() - entry.timestamp > PROFILE_PREFETCH_TTL_MS;
   if (isExpired) {

--- a/src/lib/profile/prefetch.ts
+++ b/src/lib/profile/prefetch.ts
@@ -2,18 +2,82 @@
 
 import { NDKEvent, NDKUser } from '@nostr-dev-kit/ndk';
 import { ndk } from '@/lib/ndk';
+import { hasLocalStorage, loadMapFromStorage, saveMapToStorage } from '@/lib/storageCache';
 
 // Simple in-memory prefetch store for profile events keyed by hex pubkey
 // Not persisted; short TTL to avoid stale UI
 
 type PrefetchEntry = { event: NDKEvent; timestamp: number };
+type StoredProfileEvent = {
+  kind: 0;
+  content: string;
+  pubkey: string;
+  created_at?: number;
+  id?: string;
+  // Minimal author for reconstruction
+  author?: { pubkey: string; profile?: unknown } | null;
+};
 
 const PROFILE_PREFETCH_TTL_MS = 60 * 1000; // 60s is enough for navigation
-const profilePrefetch = new Map<string, PrefetchEntry>();
+const STORAGE_KEY = 'ants_profile_prefetch_v1';
+
+// Use a window-backed singleton so it survives module reloads/chunk boundaries in dev
+function getGlobalMap(): Map<string, PrefetchEntry> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const w = typeof window !== 'undefined' ? (window as any) : undefined;
+  if (w) {
+    if (!w.__ANTS_PROFILE_PREFETCH__) {
+      w.__ANTS_PROFILE_PREFETCH__ = new Map<string, PrefetchEntry>();
+    }
+    return w.__ANTS_PROFILE_PREFETCH__ as Map<string, PrefetchEntry>;
+  }
+  return new Map<string, PrefetchEntry>();
+}
+
+const profilePrefetch = getGlobalMap();
+
+// Load persisted prefetch entries (best effort, respects TTL)
+try {
+  const persisted = loadMapFromStorage<StoredProfileEvent & { timestamp: number }>(STORAGE_KEY);
+  for (const [pk, value] of persisted.entries()) {
+    if (!value) continue;
+    if (Date.now() - value.timestamp > PROFILE_PREFETCH_TTL_MS) continue;
+    const evt = new NDKEvent(ndk, value as unknown as StoredProfileEvent);
+    if (value.author) {
+      const user = new NDKUser({ pubkey: value.author.pubkey });
+      user.ndk = ndk;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (user as any).profile = value.author.profile;
+      evt.author = user;
+    }
+    profilePrefetch.set(pk, { event: evt, timestamp: value.timestamp });
+  }
+} catch {
+  // ignore
+}
 
 export function setPrefetchedProfile(pubkeyHex: string, event: NDKEvent): void {
   if (!pubkeyHex || !event) return;
-  profilePrefetch.set(pubkeyHex, { event, timestamp: Date.now() });
+  const ts = Date.now();
+  profilePrefetch.set(pubkeyHex, { event, timestamp: ts });
+  // Persist minimal data so handoff works across reloads/dev refreshes
+  try {
+    if (!hasLocalStorage()) return;
+    const current = loadMapFromStorage<StoredProfileEvent & { timestamp: number }>(STORAGE_KEY);
+    const stored: StoredProfileEvent & { timestamp: number } = {
+      kind: 0,
+      content: event.content || '{}',
+      pubkey: pubkeyHex,
+      created_at: event.created_at,
+      id: event.id,
+      author: event.author ? { pubkey: event.author.pubkey, /* eslint-disable-next-line @typescript-eslint/no-explicit-any */ profile: (event.author as any).profile } : { pubkey: pubkeyHex },
+      timestamp: ts
+    };
+    current.set(pubkeyHex, stored);
+    saveMapToStorage(STORAGE_KEY, current);
+  } catch {
+    // ignore
+  }
 }
 
 export function getPrefetchedProfile(pubkeyHex: string): NDKEvent | null {
@@ -30,6 +94,14 @@ export function getPrefetchedProfile(pubkeyHex: string): NDKEvent | null {
 export function clearPrefetchedProfile(pubkeyHex: string): void {
   if (!pubkeyHex) return;
   profilePrefetch.delete(pubkeyHex);
+  try {
+    if (!hasLocalStorage()) return;
+    const current = loadMapFromStorage<StoredProfileEvent & { timestamp: number }>(STORAGE_KEY);
+    current.delete(pubkeyHex);
+    saveMapToStorage(STORAGE_KEY, current);
+  } catch {
+    // ignore
+  }
 }
 
 // Ensure the event has an author with profile attached from content (kind:0)

--- a/src/lib/profile/prefetch.ts
+++ b/src/lib/profile/prefetch.ts
@@ -58,10 +58,8 @@ try {
 
 export function setPrefetchedProfile(pubkeyHex: string, event: NDKEvent): void {
   if (!pubkeyHex || !event) return;
-  console.log('🔥 setPrefetchedProfile called:', { pubkeyHex, eventKind: event.kind, hasAuthor: !!event.author, authorProfile: event.author?.profile });
   const ts = Date.now();
   profilePrefetch.set(pubkeyHex, { event, timestamp: ts });
-  console.log('🔥 setPrefetchedProfile stored, map size:', profilePrefetch.size);
   // Persist minimal data so handoff works across reloads/dev refreshes
   try {
     if (!hasLocalStorage()) return;
@@ -89,11 +87,9 @@ export function getPrefetchedProfile(pubkeyHex: string): NDKEvent | null {
   if (!entry) return null;
   const isExpired = Date.now() - entry.timestamp > PROFILE_PREFETCH_TTL_MS;
   if (isExpired) {
-    console.log('🔥 getPrefetchedProfile expired, removing');
     profilePrefetch.delete(pubkeyHex);
     return null;
   }
-  console.log('🔥 getPrefetchedProfile returning event with author profile:', entry.event.author?.profile);
   return entry.event;
 }
 
@@ -112,17 +108,14 @@ export function clearPrefetchedProfile(pubkeyHex: string): void {
 
 // Ensure the event has an author with profile attached from content (kind:0)
 export function prepareProfileEventForPrefetch(event: NDKEvent): NDKEvent {
-  console.log('🔥 prepareProfileEventForPrefetch called:', { eventKind: event.kind, content: event.content?.substring(0, 100) });
   try {
     if (!event) return event;
     const author = event.author || new NDKUser({ pubkey: event.pubkey });
     author.ndk = ndk;
     // If no profile on author but content looks like a profile JSON, attach it
     if (!author.profile && event.kind === 0) {
-      console.log('🔥 prepareProfileEventForPrefetch parsing content for profile');
       try {
         const parsed = JSON.parse(event.content || '{}');
-        console.log('🔥 prepareProfileEventForPrefetch parsed:', parsed);
         const normalized: Record<string, unknown> = { ...parsed };
         // Normalize common fields our UI expects
         // picture -> image

--- a/src/lib/profile/prefetch.ts
+++ b/src/lib/profile/prefetch.ts
@@ -114,8 +114,21 @@ export function prepareProfileEventForPrefetch(event: NDKEvent): NDKEvent {
     if (!author.profile && event.kind === 0) {
       try {
         const parsed = JSON.parse(event.content || '{}');
+        const normalized: Record<string, unknown> = { ...parsed };
+        // Normalize common fields our UI expects
+        // picture -> image
+        if (typeof parsed?.picture === 'string') normalized.image = parsed.picture;
+        // display_name -> displayName
+        if (typeof parsed?.display_name === 'string') normalized.displayName = parsed.display_name;
+        // username often maps to name if name is missing
+        if (!parsed?.name && typeof parsed?.username === 'string') normalized.name = parsed.username;
+        // website also available as url
+        if (typeof parsed?.website === 'string' && !parsed?.url) normalized.url = parsed.website;
+        // Keep banner/cover/header as-is; UI already checks these keys
+        // Ensure nip05 is preserved
+        if (typeof parsed?.nip05 === 'string') normalized.nip05 = parsed.nip05;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (author as any).profile = parsed || {};
+        (author as any).profile = normalized;
       } catch {}
     }
     event.author = author;


### PR DESCRIPTION
This PR implements instant profile rendering by prefetching metadata from search results and improving loading states throughout the application. The changes eliminate blank profile states and provide smooth transitions when navigating to profile pages.

- Add in-memory profile prefetch store with TTL to cache profile metadata
- Seed prefetch when clicking profile results in SearchView for instant `/p/` navigation
- Implement eager preseed of visible `kind:0` results and avatar-click prefetch
- Normalize profile fields and persist prefetch across page reloads
