### PR TITLE
Reorder buttons and implement DRY refactoring

### DIFF
--- a/src/components/CardActions.tsx
+++ b/src/components/CardActions.tsx
@@ -2,9 +2,10 @@
 
 import React, { forwardRef } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCode, faArrowUpRightFromSquare, faCopy } from '@fortawesome/free-solid-svg-icons';
+import { faCode, faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 import { nip19 } from 'nostr-tools';
 import IconButton from '@/components/IconButton';
+import CopyButton from '@/components/CopyButton';
 
 type Props = {
   eventId?: string;
@@ -58,21 +59,17 @@ const CardActions = forwardRef<HTMLDivElement, Props>(function CardActions(
         <FontAwesomeIcon icon={faCode} className="text-xs" />
       </IconButton>
       {nprofile ? (
-        <IconButton
+        <CopyButton
+          text={`nostr:${nprofile}`}
           title="Copy nprofile"
-          ariaLabel="Copy nprofile"
-          onClick={(e) => { e.preventDefault(); e.stopPropagation(); try { void navigator.clipboard.writeText(`nostr:${nprofile}`); } catch {} }}
-        >
-          <FontAwesomeIcon icon={faCopy} className="text-xs" />
-        </IconButton>
+          className="w-5 h-5 rounded-md text-gray-300 hover:bg-[#3a3a3a] flex items-center justify-center text-[12px] leading-none"
+        />
       ) : eventId ? (
-        <IconButton
+        <CopyButton
+          text={String(neventHref)}
           title="Copy nevent"
-          ariaLabel="Copy nevent"
-          onClick={(e) => { e.preventDefault(); e.stopPropagation(); try { void navigator.clipboard.writeText(String(neventHref)); } catch {} }}
-        >
-          <FontAwesomeIcon icon={faCopy} className="text-xs" />
-        </IconButton>
+          className="w-5 h-5 rounded-md text-gray-300 hover:bg-[#3a3a3a] flex items-center justify-center text-[12px] leading-none"
+        />
       ) : null}
       {href ? (
         <a

--- a/src/components/CardActions.tsx
+++ b/src/components/CardActions.tsx
@@ -57,20 +57,6 @@ const CardActions = forwardRef<HTMLDivElement, Props>(function CardActions(
       >
         <FontAwesomeIcon icon={faCode} className="text-xs" />
       </IconButton>
-      {isMenuVisible ? (
-        <IconButton
-          ref={menuButtonRef}
-          title="Open in portals"
-          ariaLabel="Open in portals"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            onToggleMenu();
-          }}
-        >
-          ⋯
-        </IconButton>
-      ) : null}
       {nprofile ? (
         <IconButton
           title="Copy nprofile"
@@ -103,6 +89,20 @@ const CardActions = forwardRef<HTMLDivElement, Props>(function CardActions(
         >
           <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-xs" />
         </a>
+      ) : null}
+      {isMenuVisible ? (
+        <IconButton
+          ref={menuButtonRef}
+          title="Open in portals"
+          ariaLabel="Open in portals"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onToggleMenu();
+          }}
+        >
+          ⋯
+        </IconButton>
       ) : null}
     </div>
   );

--- a/src/components/CardActions.tsx
+++ b/src/components/CardActions.tsx
@@ -65,8 +65,7 @@ const CardActions = forwardRef<HTMLDivElement, Props>(function CardActions(
         >
           <FontAwesomeIcon icon={faCopy} className="text-xs" />
         </IconButton>
-      ) : null}
-      {eventId ? (
+      ) : eventId ? (
         <IconButton
           title="Copy nevent"
           ariaLabel="Copy nevent"

--- a/src/components/CardActions.tsx
+++ b/src/components/CardActions.tsx
@@ -62,13 +62,13 @@ const CardActions = forwardRef<HTMLDivElement, Props>(function CardActions(
         <CopyButton
           text={`nostr:${nprofile}`}
           title="Copy nprofile"
-          className="w-5 h-5 rounded-md text-gray-300 hover:bg-[#3a3a3a] flex items-center justify-center text-[12px] leading-none"
+          className="w-5 h-5 rounded-md border-0 text-gray-300 hover:bg-[#3a3a3a] flex items-center justify-center text-[12px] leading-none"
         />
       ) : eventId ? (
         <CopyButton
           text={String(neventHref)}
           title="Copy nevent"
-          className="w-5 h-5 rounded-md text-gray-300 hover:bg-[#3a3a3a] flex items-center justify-center text-[12px] leading-none"
+          className="w-5 h-5 rounded-md border-0 text-gray-300 hover:bg-[#3a3a3a] flex items-center justify-center text-[12px] leading-none"
         />
       ) : null}
       {href ? (

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -9,6 +9,7 @@ import { useEffect, useMemo, useState, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowUpRightFromSquare, faCopy, faExternalLink, faArrowLeft } from '@fortawesome/free-solid-svg-icons';
+import TitleBarButton from '@/components/TitleBarButton';
 import { shortenNpub } from '@/lib/utils';
 import { createPortal } from 'react-dom';
 import { nip19 } from 'nostr-tools';
@@ -322,71 +323,50 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
               <Image src={safeBannerUrl} alt="Banner" fill className="object-cover" unoptimized />
             </div>
             <div className="absolute top-1 left-1 z-50 flex gap-1">
-              <button
-                type="button"
-                aria-label="Go back"
-                onClick={(e) => { 
-                  e.preventDefault(); 
-                  e.stopPropagation(); 
-                  router.back();
-                }}
-                className="w-5 h-5 rounded-md bg-[#2a2a2a]/70 text-gray-200 border border-[#4a4a4a]/70 shadow-sm flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]/80 hover:border-[#5a5a5a]/80 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-[#5a5a5a]/40"
-              >
-                <FontAwesomeIcon icon={faArrowLeft} className="text-xs" />
-              </button>
-              <button
+              <TitleBarButton
+                icon={faArrowLeft}
+                title="Go back"
+                onClick={() => router.back()}
+              />
+              <TitleBarButton
                 ref={buttonRef}
-                type="button"
-                aria-label="Open portals menu"
-                onClick={(e) => { 
-                  e.preventDefault(); 
-                  e.stopPropagation(); 
+                title="Open portals menu"
+                onClick={() => {
                   if (buttonRef.current) {
                     const rect = buttonRef.current.getBoundingClientRect();
                     const position = calculateAbsoluteMenuPosition(rect);
                     setMenuPosition(position);
                   }
-                  setShowPortalMenu((v) => !v); 
+                  setShowPortalMenu((v) => !v);
                 }}
-                className="w-5 h-5 rounded-md bg-[#2a2a2a]/70 text-gray-200 border border-[#4a4a4a]/70 shadow-sm flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]/80 hover:border-[#5a5a5a]/80 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-[#5a5a5a]/40"
               >
                 ⋯
-              </button>
+              </TitleBarButton>
             </div>
             <div className="absolute top-1 right-1 flex gap-1">
-              <button
-                type="button"
-                aria-label="Minimize"
-                onClick={(e) => { e.preventDefault(); e.stopPropagation(); setBannerExpanded(false); }}
-                className="w-5 h-5 rounded-md bg-[#2a2a2a]/70 text-gray-200 border border-[#4a4a4a]/70 shadow-sm flex items-center justify-center text-[10px] leading-none hover:bg-[#3a3a3a]/80 hover:border-[#5a5a5a]/80 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-[#5a5a5a]/40"
+              <TitleBarButton
+                title="Minimize"
+                textSize="text-[10px]"
+                onClick={() => setBannerExpanded(false)}
               >
                 –
-              </button>
-              <button
-                type="button"
-                aria-label="Maximize"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
+              </TitleBarButton>
+              <TitleBarButton
+                title="Maximize"
+                textSize="text-[10px]"
+                onClick={() => {
                   if (safeBannerUrl) window.open(safeBannerUrl, '_blank', 'noopener,noreferrer');
                 }}
-                className="w-5 h-5 rounded-md bg-[#2a2a2a]/70 text-gray-200 border border-[#4a4a4a]/70 shadow-sm flex items-center justify-center text-[10px] leading-none hover:bg-[#3a3a3a]/80 hover:border-[#5a5a5a]/80 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-[#5a5a5a]/40"
               >
                 ▢
-              </button>
-              <button
-                type="button"
-                aria-label="Close"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  // Clear search by navigating to landing page
-                  router.push('/');
-                }}
-                className="w-5 h-5 rounded-md bg-[#2a2a2a]/70 text-gray-200 border border-[#4a4a4a]/70 shadow-sm flex items-center justify-center text-[10px] leading-none hover:bg-[#3a3a3a]/80 hover:border-[#5a5a5a]/80 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-[#5a5a5a]/40"
+              </TitleBarButton>
+              <TitleBarButton
+                title="Close"
+                textSize="text-[10px]"
+                onClick={() => router.push('/')}
               >
                 ×
-              </button>
+              </TitleBarButton>
             </div>
           </div>
         </div>
@@ -394,36 +374,25 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
       {showBanner && !bannerUrl && (
         <div className="relative w-full border-b border-[#3d3d3d] bg-[#2d2d2d]" style={{ height: 32 }}>
           <div className="absolute top-1 left-1 z-50 flex gap-1">
-            <button
-              type="button"
-              aria-label="Go back"
-              onClick={(e) => { 
-                e.preventDefault(); 
-                e.stopPropagation(); 
-                router.back();
-              }}
-              className="w-5 h-5 rounded-md bg-[#2a2a2a]/70 text-gray-200 border border-[#4a4a4a]/70 shadow-sm flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]/80 hover:border-[#5a5a5a]/80 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-[#5a5a5a]/40"
-            >
-              <FontAwesomeIcon icon={faArrowLeft} className="text-xs" />
-            </button>
-            <button
+            <TitleBarButton
+              icon={faArrowLeft}
+              title="Go back"
+              onClick={() => router.back()}
+            />
+            <TitleBarButton
               ref={buttonRef}
-              type="button"
-              aria-label="Open portals menu"
-              onClick={(e) => { 
-                e.preventDefault(); 
-                e.stopPropagation(); 
+              title="Open portals menu"
+              onClick={() => {
                 if (buttonRef.current) {
                   const rect = buttonRef.current.getBoundingClientRect();
                   const position = calculateBannerMenuPosition(rect);
                   setMenuPosition(position);
                 }
-                setShowPortalMenu((v) => !v); 
+                setShowPortalMenu((v) => !v);
               }}
-              className="w-5 h-5 rounded-md bg-[#2a2a2a]/70 text-gray-200 border border-[#4a4a4a]/70 shadow-sm flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]/80 hover:border-[#5a5a5a]/80 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-[#5a5a5a]/40"
             >
               ⋯
-            </button>
+            </TitleBarButton>
           </div>
         </div>
       )}

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -472,7 +472,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
             <CopyButton
               text={event.author.npub}
               title="Copy npub"
-              className="p-1 rounded hover:bg-[#3a3a3a]"
+              className="p-1 rounded border-0 hover:bg-[#3a3a3a]"
             />
           </div>
         )}

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -321,27 +321,6 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
             <div className="absolute inset-0 overflow-hidden">
               <Image src={safeBannerUrl} alt="Banner" fill className="object-cover" unoptimized />
             </div>
-            <div className="absolute top-1 left-1 z-50">
-              <div className="relative">
-                <button
-                  ref={buttonRef}
-                  type="button"
-                  aria-label="Open portals menu"
-                  onClick={(e) => { 
-                    e.preventDefault(); 
-                    e.stopPropagation(); 
-                    if (buttonRef.current) {
-                      const rect = buttonRef.current.getBoundingClientRect();
-                      setMenuPosition({ top: rect.bottom + 4, left: rect.left });
-                    }
-                    setShowPortalMenu((v) => !v); 
-                  }}
-                  className="w-5 h-5 rounded-md bg-[#2a2a2a]/70 text-gray-200 border border-[#4a4a4a]/70 shadow-sm flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]/80 hover:border-[#5a5a5a]/80 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-[#5a5a5a]/40"
-                >
-                  ⋯
-                </button>
-              </div>
-            </div>
             <div className="absolute top-1 right-1 flex gap-1">
               <button
                 type="button"
@@ -376,15 +355,8 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
               >
                 ×
               </button>
-            </div>
-          </div>
-        </div>
-      )}
-      {showBanner && !bannerUrl && (
-        <div className="relative w-full border-b border-[#3d3d3d] bg-[#2d2d2d]" style={{ height: 32 }}>
-          <div className="absolute top-1 left-1 z-50">
-            <div className="relative">
               <button
+                ref={buttonRef}
                 type="button"
                 aria-label="Open portals menu"
                 onClick={(e) => { 
@@ -392,7 +364,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
                   e.stopPropagation(); 
                   if (buttonRef.current) {
                     const rect = buttonRef.current.getBoundingClientRect();
-                    const position = calculateBannerMenuPosition(rect);
+                    const position = calculateAbsoluteMenuPosition(rect);
                     setMenuPosition(position);
                   }
                   setShowPortalMenu((v) => !v); 
@@ -402,6 +374,30 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
                 ⋯
               </button>
             </div>
+          </div>
+        </div>
+      )}
+      {showBanner && !bannerUrl && (
+        <div className="relative w-full border-b border-[#3d3d3d] bg-[#2d2d2d]" style={{ height: 32 }}>
+          <div className="absolute top-1 right-1 z-50">
+            <button
+              ref={buttonRef}
+              type="button"
+              aria-label="Open portals menu"
+              onClick={(e) => { 
+                e.preventDefault(); 
+                e.stopPropagation(); 
+                if (buttonRef.current) {
+                  const rect = buttonRef.current.getBoundingClientRect();
+                  const position = calculateBannerMenuPosition(rect);
+                  setMenuPosition(position);
+                }
+                setShowPortalMenu((v) => !v); 
+              }}
+              className="w-5 h-5 rounded-md bg-[#2a2a2a]/70 text-gray-200 border border-[#4a4a4a]/70 shadow-sm flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]/80 hover:border-[#5a5a5a]/80 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-[#5a5a5a]/40"
+            >
+              ⋯
+            </button>
           </div>
         </div>
       )}

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -10,6 +10,7 @@ import { useRouter, usePathname } from 'next/navigation';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowUpRightFromSquare, faCopy, faExternalLink, faArrowLeft } from '@fortawesome/free-solid-svg-icons';
 import TitleBarButton from '@/components/TitleBarButton';
+import CopyButton from '@/components/CopyButton';
 import { shortenNpub } from '@/lib/utils';
 import { createPortal } from 'react-dom';
 import { nip19 } from 'nostr-tools';
@@ -453,19 +454,6 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
         </div>
         {event.author?.npub && (
           <div className="flex items-center gap-2 max-w-[50%] text-right text-sm text-gray-400">
-            <button
-              type="button"
-              aria-label="Copy npub"
-              title="Copy npub"
-              onClick={async (e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                try { await navigator.clipboard.writeText(event.author.npub); } catch {}
-              }}
-              className="p-1 rounded hover:bg-[#3a3a3a]"
-            >
-              <FontAwesomeIcon icon={faCopy} className="text-gray-400 text-xs" />
-            </button>
             <a
               href={`/p/${event.author.npub}`}
               className="truncate hover:underline hidden sm:block"
@@ -481,6 +469,11 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
             >
               {shortenNpub(event.author.npub)}
             </a>
+            <CopyButton
+              text={event.author.npub}
+              title="Copy npub"
+              className="p-1 rounded hover:bg-[#3a3a3a]"
+            />
           </div>
         )}
       </div>

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -8,7 +8,7 @@ import { isAbsoluteHttpUrl } from '@/lib/urlPatterns';
 import { useEffect, useMemo, useState, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faArrowUpRightFromSquare, faCopy, faExternalLink } from '@fortawesome/free-solid-svg-icons';
+import { faArrowUpRightFromSquare, faCopy, faExternalLink, faArrowLeft } from '@fortawesome/free-solid-svg-icons';
 import { shortenNpub } from '@/lib/utils';
 import { createPortal } from 'react-dom';
 import { nip19 } from 'nostr-tools';
@@ -321,7 +321,19 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
             <div className="absolute inset-0 overflow-hidden">
               <Image src={safeBannerUrl} alt="Banner" fill className="object-cover" unoptimized />
             </div>
-            <div className="absolute top-1 left-1 z-50">
+            <div className="absolute top-1 left-1 z-50 flex gap-1">
+              <button
+                type="button"
+                aria-label="Go back"
+                onClick={(e) => { 
+                  e.preventDefault(); 
+                  e.stopPropagation(); 
+                  router.back();
+                }}
+                className="w-5 h-5 rounded-md bg-[#2a2a2a]/70 text-gray-200 border border-[#4a4a4a]/70 shadow-sm flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]/80 hover:border-[#5a5a5a]/80 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-[#5a5a5a]/40"
+              >
+                <FontAwesomeIcon icon={faArrowLeft} className="text-xs" />
+              </button>
               <button
                 ref={buttonRef}
                 type="button"
@@ -381,7 +393,19 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
       )}
       {showBanner && !bannerUrl && (
         <div className="relative w-full border-b border-[#3d3d3d] bg-[#2d2d2d]" style={{ height: 32 }}>
-          <div className="absolute top-1 left-1 z-50">
+          <div className="absolute top-1 left-1 z-50 flex gap-1">
+            <button
+              type="button"
+              aria-label="Go back"
+              onClick={(e) => { 
+                e.preventDefault(); 
+                e.stopPropagation(); 
+                router.back();
+              }}
+              className="w-5 h-5 rounded-md bg-[#2a2a2a]/70 text-gray-200 border border-[#4a4a4a]/70 shadow-sm flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]/80 hover:border-[#5a5a5a]/80 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-[#5a5a5a]/40"
+            >
+              <FontAwesomeIcon icon={faArrowLeft} className="text-xs" />
+            </button>
             <button
               ref={buttonRef}
               type="button"

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -321,6 +321,26 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
             <div className="absolute inset-0 overflow-hidden">
               <Image src={safeBannerUrl} alt="Banner" fill className="object-cover" unoptimized />
             </div>
+            <div className="absolute top-1 left-1 z-50">
+              <button
+                ref={buttonRef}
+                type="button"
+                aria-label="Open portals menu"
+                onClick={(e) => { 
+                  e.preventDefault(); 
+                  e.stopPropagation(); 
+                  if (buttonRef.current) {
+                    const rect = buttonRef.current.getBoundingClientRect();
+                    const position = calculateAbsoluteMenuPosition(rect);
+                    setMenuPosition(position);
+                  }
+                  setShowPortalMenu((v) => !v); 
+                }}
+                className="w-5 h-5 rounded-md bg-[#2a2a2a]/70 text-gray-200 border border-[#4a4a4a]/70 shadow-sm flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]/80 hover:border-[#5a5a5a]/80 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-[#5a5a5a]/40"
+              >
+                ⋯
+              </button>
+            </div>
             <div className="absolute top-1 right-1 flex gap-1">
               <button
                 type="button"
@@ -355,31 +375,13 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
               >
                 ×
               </button>
-              <button
-                ref={buttonRef}
-                type="button"
-                aria-label="Open portals menu"
-                onClick={(e) => { 
-                  e.preventDefault(); 
-                  e.stopPropagation(); 
-                  if (buttonRef.current) {
-                    const rect = buttonRef.current.getBoundingClientRect();
-                    const position = calculateAbsoluteMenuPosition(rect);
-                    setMenuPosition(position);
-                  }
-                  setShowPortalMenu((v) => !v); 
-                }}
-                className="w-5 h-5 rounded-md bg-[#2a2a2a]/70 text-gray-200 border border-[#4a4a4a]/70 shadow-sm flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]/80 hover:border-[#5a5a5a]/80 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-[#5a5a5a]/40"
-              >
-                ⋯
-              </button>
             </div>
           </div>
         </div>
       )}
       {showBanner && !bannerUrl && (
         <div className="relative w-full border-b border-[#3d3d3d] bg-[#2d2d2d]" style={{ height: 32 }}>
-          <div className="absolute top-1 right-1 z-50">
+          <div className="absolute top-1 left-1 z-50">
             <button
               ref={buttonRef}
               type="button"

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -8,7 +8,7 @@ import { isAbsoluteHttpUrl } from '@/lib/urlPatterns';
 import { useEffect, useMemo, useState, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faArrowUpRightFromSquare, faCopy, faExternalLink, faArrowLeft } from '@fortawesome/free-solid-svg-icons';
+import { faArrowUpRightFromSquare, faExternalLink, faArrowLeft } from '@fortawesome/free-solid-svg-icons';
 import TitleBarButton from '@/components/TitleBarButton';
 import CopyButton from '@/components/CopyButton';
 import { shortenNpub } from '@/lib/utils';

--- a/src/components/TitleBarButton.tsx
+++ b/src/components/TitleBarButton.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import React, { forwardRef } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+
+type Props = {
+  icon?: IconDefinition;
+  children?: React.ReactNode;
+  title: string;
+  ariaLabel?: string;
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  className?: string;
+  textSize?: 'text-[10px]' | 'text-[12px]';
+};
+
+const TitleBarButton = forwardRef<HTMLButtonElement, Props>(function TitleBarButton(
+  { icon, children, title, ariaLabel, onClick, className, textSize = 'text-[12px]' },
+  ref
+) {
+  const baseClasses = 'w-5 h-5 rounded-md bg-[#2a2a2a]/70 text-gray-200 border border-[#4a4a4a]/70 shadow-sm flex items-center justify-center leading-none hover:bg-[#3a3a3a]/80 hover:border-[#5a5a5a]/80 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-[#5a5a5a]/40';
+  
+  return (
+    <button
+      ref={ref}
+      type="button"
+      aria-label={ariaLabel || title}
+      title={title}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        onClick(e);
+      }}
+      className={`${baseClasses} ${textSize} ${className || ''}`.trim()}
+    >
+      {icon ? <FontAwesomeIcon icon={icon} className="text-xs" /> : children}
+    </button>
+  );
+});
+
+export default TitleBarButton;


### PR DESCRIPTION
This PR reorders buttons across the application to improve UX consistency and implements DRY refactoring to reduce code duplication.

The main changes include moving three-dot buttons to the rightmost position in footer bars, adding a back button to profile pages, and creating reusable components to eliminate repeated button styling code. All copy buttons now use the same `CopyButton` component with consistent checkmark feedback animation.

• Reorder buttons so three-dot menu appears at the very right in all footer bars
• Add back button to profile page title bar for better navigation
• Create `TitleBarButton` component to eliminate ~100 lines of repeated button styling
• Refactor npub copy button to use `CopyButton` component with checkmark feedback
• Remove borders from copy buttons in footer context for cleaner appearance
