### PR TITLE
feat: embed naddr pointers inline

### DIFF
--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -468,9 +468,9 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
           <RawEventJson event={rawProfileEvent || event} loading={rawLoading} parseContent={true} />
         </div>
       ) : event.author?.profile?.about ? (
-        <p className="mt-4 text-gray-300 break-words">
+        <div className="mt-4 text-gray-300 break-words">
           {renderBioWithHashtags(event.author?.profile?.about)}
-        </p>
+        </div>
       ) : null}
       </div>
       <ProfileCreatedAt

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -1365,6 +1365,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
         const nostrSplit = options?.disableNevent ? [chunk] : chunk.split(new RegExp(`(${combinedSource})`, 'gi'));
         const combinedRegex = new RegExp(`^nostr:(?:nevent1|naddr1)[0-9a-z]+[),.;]*$`, 'i');
         nostrSplit.forEach((sub, subIdx) => {
+          if (!sub) return;
           const isNostrToken = combinedRegex.test(sub);
           if (!options?.disableNevent && isNostrToken) {
             const match = sub.match(/^(nostr:(nevent1|naddr1)[0-9a-z]+)([),.;]*)$/i);
@@ -1389,7 +1390,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
           }
 
           // Process hashtags and emojis within the remaining text
-          const parts = sub.split(/(#\w+)/g);
+          const parts = (sub || '').split(/(#\w+)/g);
           parts.forEach((part, index) => {
             if (part.startsWith('#')) {
               finalNodes.push(


### PR DESCRIPTION
Adds inline rendering for `nostr:naddr` references using the same `EventCard` variant as existing note embeds, reusing the shared content renderer while keeping the UI consistent.

- Decode `nostr:naddr` pointers alongside `nostr:nevent` and fetch events with relay hints
- Reuse the inline `EventCard` path to display embedded references with the shared styling
- Guard token splitting to tolerate empty segments produced by regex captures
