### PR TITLE
Add text truncation with link-aware character counting and global constants

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -12,6 +12,7 @@ import { calculateAbsoluteMenuPosition } from '@/lib/utils';
 import RawEventJson from '@/components/RawEventJson';
 import CardActions from '@/components/CardActions';
 
+
 type Props = {
   event: NDKEvent;
   onAuthorClick?: (npub: string) => void;

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -381,6 +381,15 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
               ⋯
             </TitleBarButton>
           </div>
+          <div className="absolute top-1 right-1 flex gap-1">
+            <TitleBarButton
+              title="Close"
+              textSize="text-[10px]"
+              onClick={() => router.push('/')}
+            >
+              ×
+            </TitleBarButton>
+          </div>
         </div>
       )}
       <div className="p-4">

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -29,7 +29,7 @@ import { faMagnifyingGlass, faImage, faExternalLink, faUser, faEye, faChevronDow
 import { setPrefetchedProfile, prepareProfileEventForPrefetch } from '@/lib/profile/prefetch';
 import { formatRelativeTimeAuto } from '@/lib/relativeTime';
 import { formatEventTimestamp } from '@/lib/utils/eventHelpers';
-import { TEXT_MAX_LENGTH } from '@/lib/constants';
+import { TEXT_MAX_LENGTH, TEXT_LINK_CHAR_COUNT } from '@/lib/constants';
 
 // Reusable search icon button component
 function SearchIconButton({ 
@@ -80,16 +80,16 @@ function TruncatedText({
     
     let effectiveLength = text.length;
     
-    // Replace URLs with 10 character placeholder
+    // Replace URLs with configured character count
     const urls = text.match(urlPattern) || [];
     urls.forEach(url => {
-      effectiveLength = effectiveLength - url.length + 10;
+      effectiveLength = effectiveLength - url.length + TEXT_LINK_CHAR_COUNT;
     });
     
-    // Replace nostr-native links with 10 character placeholder
+    // Replace nostr-native links with configured character count
     const nostrLinks = text.match(nostrPattern) || [];
     nostrLinks.forEach(link => {
-      effectiveLength = effectiveLength - link.length + 10;
+      effectiveLength = effectiveLength - link.length + TEXT_LINK_CHAR_COUNT;
     });
     
     return effectiveLength;

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -55,6 +55,41 @@ function SearchIconButton({
   );
 }
 
+// Component for truncating long text with show more/less functionality
+function TruncatedText({ 
+  content, 
+  maxLength = 500, 
+  className = '',
+  renderContentWithClickableHashtags
+}: { 
+  content: string; 
+  maxLength?: number; 
+  className?: string;
+  renderContentWithClickableHashtags: (content: string) => React.ReactNode;
+}) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  
+  if (!content) return null;
+  
+  const shouldTruncate = content.length > maxLength;
+  const displayText = isExpanded || !shouldTruncate ? content : content.slice(0, maxLength);
+  
+  return (
+    <div className={className}>
+      {renderContentWithClickableHashtags(displayText)}
+      {shouldTruncate && (
+        <button
+          type="button"
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="ml-2 text-blue-400 hover:text-blue-300 underline text-sm"
+        >
+          {isExpanded ? 'show less' : 'show more'}
+        </button>
+      )}
+    </div>
+  );
+}
+
 // Reusable reverse image search button component
 function ReverseImageSearchButton({ 
   imageUrl, 
@@ -1316,9 +1351,12 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
               event={embedded}
               onAuthorClick={goToProfile}
               renderContent={(text) => (
-                <div className="text-gray-100 whitespace-pre-wrap break-words">
-                  {renderContentWithClickableHashtags(text, { disableNevent: true })}
-                </div>
+                <TruncatedText 
+                  content={text} 
+                  maxLength={500}
+                  className="text-gray-100 whitespace-pre-wrap break-words"
+                  renderContentWithClickableHashtags={(content) => renderContentWithClickableHashtags(content, { disableNevent: true })}
+                />
               )}
               variant="inline"
               footerRight={createdAt ? (
@@ -1619,7 +1657,12 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
             event={parentEvent}
             onAuthorClick={goToProfile}
             renderContent={(text) => (
-              <div className="text-gray-100 whitespace-pre-wrap break-words">{renderContentWithClickableHashtags(text)}</div>
+              <TruncatedText 
+                content={text} 
+                maxLength={500}
+                className="text-gray-100 whitespace-pre-wrap break-words"
+                renderContentWithClickableHashtags={renderContentWithClickableHashtags}
+              />
             )}
             mediaRenderer={renderNoteMedia}
             className="p-0 border-0 bg-transparent"
@@ -1889,7 +1932,12 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
                       event={event}
                       onAuthorClick={goToProfile}
                       renderContent={(text) => (
-                        <div className="text-gray-100 whitespace-pre-wrap break-words">{renderContentWithClickableHashtags(text)}</div>
+                        <TruncatedText 
+                          content={text} 
+                          maxLength={500}
+                          className="text-gray-100 whitespace-pre-wrap break-words"
+                          renderContentWithClickableHashtags={renderContentWithClickableHashtags}
+                        />
                       )}
                       mediaRenderer={renderNoteMedia}
                       footerRight={(

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -25,7 +25,7 @@ import { nip19 } from 'nostr-tools';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { shortenNevent, shortenNpub } from '@/lib/utils';
 import emojiRegex from 'emoji-regex';
-import { faMagnifyingGlass, faImage, faExternalLink, faUser, faEye } from '@fortawesome/free-solid-svg-icons';
+import { faMagnifyingGlass, faImage, faExternalLink, faUser, faEye, faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
 import { setPrefetchedProfile, prepareProfileEventForPrefetch } from '@/lib/profile/prefetch';
 import { formatRelativeTimeAuto } from '@/lib/relativeTime';
 import { formatEventTimestamp } from '@/lib/utils/eventHelpers';
@@ -56,7 +56,7 @@ function SearchIconButton({
   );
 }
 
-// Component for truncating long text with show more/less functionality
+// Component for truncating long text with fade effect and expand arrow
 function TruncatedText({ 
   content, 
   maxLength = TEXT_MAX_LENGTH, 
@@ -76,16 +76,27 @@ function TruncatedText({
   const displayText = isExpanded || !shouldTruncate ? content : content.slice(0, maxLength);
   
   return (
-    <div className={className}>
-      {renderContentWithClickableHashtags(displayText)}
+    <div className={`relative ${className}`}>
+      <div className={shouldTruncate && !isExpanded ? 'relative' : ''}>
+        {renderContentWithClickableHashtags(displayText)}
+        {shouldTruncate && !isExpanded && (
+          <div className="absolute bottom-0 left-0 right-0 h-16 bg-gradient-to-t from-[#2d2d2d] to-transparent pointer-events-none" />
+        )}
+      </div>
       {shouldTruncate && (
-        <button
-          type="button"
-          onClick={() => setIsExpanded(!isExpanded)}
-          className="ml-2 text-blue-400 hover:text-blue-300 underline text-sm"
-        >
-          {isExpanded ? 'show less' : 'show more'}
-        </button>
+        <div className="flex justify-center mt-2">
+          <button
+            type="button"
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="flex items-center gap-1 text-gray-400 hover:text-gray-200 transition-colors text-sm"
+          >
+            <FontAwesomeIcon 
+              icon={isExpanded ? faChevronUp : faChevronDown} 
+              className="w-3 h-3" 
+            />
+            <span>{isExpanded ? 'Show less' : 'Show more'}</span>
+          </button>
+        </div>
       )}
     </div>
   );

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -425,7 +425,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
     if (cmd === 'help') {
       const lines = ['Available commands:', ...SLASH_COMMANDS.map(c => `  ${c.label.padEnd(12)} ${c.description}`)];
       setTopCommandText(buildCli('--help', lines));
-      setTopExamples(null);
+      setTopExamples(SLASH_COMMANDS.map(c => c.label));
       return;
     }
     if (cmd === 'examples') {

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -72,7 +72,33 @@ function TruncatedText({
   
   if (!content) return null;
   
-  const shouldTruncate = content.length > maxLength;
+  // Calculate effective length considering links as 10 characters each
+  const calculateEffectiveLength = (text: string): number => {
+    // Regex patterns for different types of links
+    const urlPattern = /https?:\/\/[^\s]+/g;
+    const nostrPattern = /(nevent|naddr|nprofile|npub|nsec|note)1[a-z0-9]+/g;
+    
+    let effectiveLength = text.length;
+    
+    // Replace URLs with 10 character placeholder
+    const urls = text.match(urlPattern) || [];
+    urls.forEach(url => {
+      effectiveLength = effectiveLength - url.length + 10;
+    });
+    
+    // Replace nostr-native links with 10 character placeholder
+    const nostrLinks = text.match(nostrPattern) || [];
+    nostrLinks.forEach(link => {
+      effectiveLength = effectiveLength - link.length + 10;
+    });
+    
+    return effectiveLength;
+  };
+  
+  const effectiveLength = calculateEffectiveLength(content);
+  const shouldTruncate = effectiveLength > maxLength;
+  
+  // For display, we still need to truncate the actual text
   const displayText = isExpanded || !shouldTruncate ? content : content.slice(0, maxLength);
   
   return (

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -29,6 +29,7 @@ import { faMagnifyingGlass, faImage, faExternalLink, faUser, faEye } from '@fort
 import { setPrefetchedProfile, prepareProfileEventForPrefetch } from '@/lib/profile/prefetch';
 import { formatRelativeTimeAuto } from '@/lib/relativeTime';
 import { formatEventTimestamp } from '@/lib/utils/eventHelpers';
+import { TEXT_MAX_LENGTH } from '@/lib/constants';
 
 // Reusable search icon button component
 function SearchIconButton({ 
@@ -58,7 +59,7 @@ function SearchIconButton({
 // Component for truncating long text with show more/less functionality
 function TruncatedText({ 
   content, 
-  maxLength = 500, 
+  maxLength = TEXT_MAX_LENGTH, 
   className = '',
   renderContentWithClickableHashtags
 }: { 
@@ -1353,7 +1354,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
               renderContent={(text) => (
                 <TruncatedText 
                   content={text} 
-                  maxLength={500}
+                  maxLength={TEXT_MAX_LENGTH}
                   className="text-gray-100 whitespace-pre-wrap break-words"
                   renderContentWithClickableHashtags={(content) => renderContentWithClickableHashtags(content, { disableNevent: true })}
                 />
@@ -1659,7 +1660,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
             renderContent={(text) => (
               <TruncatedText 
                 content={text} 
-                maxLength={500}
+                maxLength={TEXT_MAX_LENGTH}
                 className="text-gray-100 whitespace-pre-wrap break-words"
                 renderContentWithClickableHashtags={renderContentWithClickableHashtags}
               />
@@ -1934,7 +1935,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
                       renderContent={(text) => (
                         <TruncatedText 
                           content={text} 
-                          maxLength={500}
+                          maxLength={TEXT_MAX_LENGTH}
                           className="text-gray-100 whitespace-pre-wrap break-words"
                           renderContentWithClickableHashtags={renderContentWithClickableHashtags}
                         />

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -84,11 +84,11 @@ function TruncatedText({
         )}
       </div>
       {shouldTruncate && (
-        <div className="flex justify-center mt-1">
+        <div className="mt-0.5">
           <button
             type="button"
             onClick={() => setIsExpanded(!isExpanded)}
-            className="text-gray-400 hover:text-gray-200 transition-colors"
+            className="w-full flex items-center justify-center text-gray-400 hover:text-gray-200 transition-colors"
           >
             <FontAwesomeIcon 
               icon={isExpanded ? faChevronUp : faChevronDown} 

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -84,17 +84,16 @@ function TruncatedText({
         )}
       </div>
       {shouldTruncate && (
-        <div className="flex justify-center mt-2">
+        <div className="flex justify-center mt-1">
           <button
             type="button"
             onClick={() => setIsExpanded(!isExpanded)}
-            className="flex items-center gap-1 text-gray-400 hover:text-gray-200 transition-colors text-sm"
+            className="text-gray-400 hover:text-gray-200 transition-colors"
           >
             <FontAwesomeIcon 
               icon={isExpanded ? faChevronUp : faChevronDown} 
               className="w-3 h-3" 
             />
-            <span>{isExpanded ? 'Show less' : 'Show more'}</span>
           </button>
         </div>
       )}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -9,7 +9,10 @@ export const UI_CONFIG = {
     MAX_LENGTH_INLINE: 300,
     
     // Maximum length for profile descriptions
-    MAX_LENGTH_PROFILE: 200
+    MAX_LENGTH_PROFILE: 200,
+    
+    // Character count for links in truncation calculation
+    LINK_CHAR_COUNT: 10
   },
   
   // Search result settings
@@ -57,6 +60,7 @@ export const UI_CONFIG = {
 export const TEXT_MAX_LENGTH = UI_CONFIG.TEXT_TRUNCATION.MAX_LENGTH;
 export const TEXT_MAX_LENGTH_INLINE = UI_CONFIG.TEXT_TRUNCATION.MAX_LENGTH_INLINE;
 export const TEXT_MAX_LENGTH_PROFILE = UI_CONFIG.TEXT_TRUNCATION.MAX_LENGTH_PROFILE;
+export const TEXT_LINK_CHAR_COUNT = UI_CONFIG.TEXT_TRUNCATION.LINK_CHAR_COUNT;
 
 // Search constants
 export const SEARCH_MAX_RESULTS = UI_CONFIG.SEARCH.MAX_RESULTS;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -29,6 +29,27 @@ export const UI_CONFIG = {
     
     // Maximum video duration in seconds
     MAX_VIDEO_DURATION: 300
+  },
+  
+  // Search & Results settings
+  SEARCH: {
+    // Maximum number of results to return
+    MAX_RESULTS: 1000,
+    
+    // Maximum results for streaming queries
+    MAX_RESULTS_STREAMING: 200,
+    
+    // Default search timeout in milliseconds
+    DEFAULT_TIMEOUT: 30000,
+    
+    // Timeout for hinted relay queries
+    HINTED_TIMEOUT: 5000,
+    
+    // Timeout for fallback relay queries
+    FALLBACK_TIMEOUT: 8000,
+    
+    // NIP-05 resolution timeout
+    NIP05_TIMEOUT: 4000
   }
 } as const;
 
@@ -36,3 +57,11 @@ export const UI_CONFIG = {
 export const TEXT_MAX_LENGTH = UI_CONFIG.TEXT_TRUNCATION.MAX_LENGTH;
 export const TEXT_MAX_LENGTH_INLINE = UI_CONFIG.TEXT_TRUNCATION.MAX_LENGTH_INLINE;
 export const TEXT_MAX_LENGTH_PROFILE = UI_CONFIG.TEXT_TRUNCATION.MAX_LENGTH_PROFILE;
+
+// Search constants
+export const SEARCH_MAX_RESULTS = UI_CONFIG.SEARCH.MAX_RESULTS;
+export const SEARCH_MAX_RESULTS_STREAMING = UI_CONFIG.SEARCH.MAX_RESULTS_STREAMING;
+export const SEARCH_DEFAULT_TIMEOUT = UI_CONFIG.SEARCH.DEFAULT_TIMEOUT;
+export const SEARCH_HINTED_TIMEOUT = UI_CONFIG.SEARCH.HINTED_TIMEOUT;
+export const SEARCH_FALLBACK_TIMEOUT = UI_CONFIG.SEARCH.FALLBACK_TIMEOUT;
+export const SEARCH_NIP05_TIMEOUT = UI_CONFIG.SEARCH.NIP05_TIMEOUT;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,38 @@
+// UI Configuration Constants
+export const UI_CONFIG = {
+  // Text truncation settings
+  TEXT_TRUNCATION: {
+    // Maximum character length before showing "show more" button
+    MAX_LENGTH: 500,
+    
+    // Alternative shorter length for inline content
+    MAX_LENGTH_INLINE: 300,
+    
+    // Maximum length for profile descriptions
+    MAX_LENGTH_PROFILE: 200
+  },
+  
+  // Search result settings
+  SEARCH_RESULTS: {
+    // Maximum number of results to show initially
+    MAX_INITIAL_RESULTS: 50,
+    
+    // Number of results to load per page
+    RESULTS_PER_PAGE: 20
+  },
+  
+  // Media settings
+  MEDIA: {
+    // Maximum image dimensions
+    MAX_IMAGE_WIDTH: 800,
+    MAX_IMAGE_HEIGHT: 600,
+    
+    // Maximum video duration in seconds
+    MAX_VIDEO_DURATION: 300
+  }
+} as const;
+
+// Export individual constants for easier importing
+export const TEXT_MAX_LENGTH = UI_CONFIG.TEXT_TRUNCATION.MAX_LENGTH;
+export const TEXT_MAX_LENGTH_INLINE = UI_CONFIG.TEXT_TRUNCATION.MAX_LENGTH_INLINE;
+export const TEXT_MAX_LENGTH_PROFILE = UI_CONFIG.TEXT_TRUNCATION.MAX_LENGTH_PROFILE;


### PR DESCRIPTION
This PR implements text truncation functionality with link-aware character counting and adds comprehensive global constants for better maintainability. The main changes include a new `TruncatedText` component that prevents search result cards from becoming excessively tall by truncating long content with a fade effect and expandable chevron button. Links and nostr-native links (nevent, naddr, nprofile, etc.) are counted as only 10 characters regardless of their actual length to prevent unnecessary truncation. The PR also centralizes configuration by adding a global constants file with text truncation limits, search timeouts, and result limits that can be easily modified from a single location.

- Add `TruncatedText` component with fade effect and full-width chevron button
- Implement link-aware truncation that counts URLs and nostr links as 10 characters
- Create global constants file for centralized configuration management
