### PR TITLE
feat: enhance NIP-05 display with root indicators and mobile optimization

### DIFF
--- a/src/components/AuthorBadge.tsx
+++ b/src/components/AuthorBadge.tsx
@@ -1,68 +1,11 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useRouter, useSearchParams, usePathname } from 'next/navigation';
-import { getNip05Domain, isRootNip05 } from '@/lib/nip05';
-import { cleanNip05Display } from '@/lib/utils';
 import { NDKUser } from '@nostr-dev-kit/ndk';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCircleXmark, faCircleExclamation, faUserGroup, faCheckDouble } from '@fortawesome/free-solid-svg-icons';
-import { faIdBadge } from '@fortawesome/free-regular-svg-icons';
-
-type Nip05CheckResult = { isVerified: boolean; value: string | undefined };
-
-function useNip05Status(user: NDKUser): Nip05CheckResult {
-  const nip05Raw = user.profile?.nip05 as
-    | string
-    | { url?: string; verified?: boolean }
-    | undefined;
-  const nip05 = typeof nip05Raw === 'string' ? nip05Raw : nip05Raw?.url;
-  const hintedVerified =
-    typeof nip05Raw === 'object' && nip05Raw !== null && typeof nip05Raw.verified === 'boolean'
-      ? nip05Raw.verified
-      : undefined;
-  const [verified, setVerified] = useState(Boolean(hintedVerified));
-  const pubkey = user.pubkey;
-
-  useEffect(() => {
-    if (typeof hintedVerified === 'boolean') {
-      setVerified(hintedVerified);
-    } else if (!nip05) {
-      setVerified(false);
-    }
-  }, [hintedVerified, nip05]);
-
-  useEffect(() => {
-    let isMounted = true;
-    if (!nip05) {
-      setVerified(false);
-      return () => {
-        isMounted = false;
-      };
-    }
-    (async () => {
-      try {
-        const { checkNip05 } = await import('@/lib/vertex');
-        const result = await checkNip05(pubkey, nip05);
-        if (isMounted) setVerified(Boolean(result));
-      } catch {
-        if (isMounted) setVerified(false);
-      }
-    })();
-    return () => { isMounted = false; };
-  }, [pubkey, nip05]);
-
-  return { isVerified: verified, value: nip05 };
-}
 
 export default function AuthorBadge({ user, onAuthorClick }: { user: NDKUser, onAuthorClick?: (npub: string) => void }) {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const pathname = usePathname();
   const [loaded, setLoaded] = useState(false);
   const [name, setName] = useState('');
-  const { isVerified, value } = useNip05Status(user);
-  // Removed manual revalidation UI; rely on automatic/implicit verification
 
   useEffect(() => {
     let isMounted = true;
@@ -81,102 +24,8 @@ export default function AuthorBadge({ user, onAuthorClick }: { user: NDKUser, on
     return () => { isMounted = false; };
   }, [user]);
 
-  const effectiveVerified = isVerified;
-
-  const nip05Part = value ? (
-    <span className={`inline-flex items-center gap-1 ${effectiveVerified ? 'text-green-400' : 'text-red-400'}`}>
-      <button
-        type="button"
-        onClick={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          if (!value) return;
-          const current = searchParams ? searchParams.toString() : '';
-          const params = new URLSearchParams(current);
-          params.set('q', value);
-          router.push(`/?${params.toString()}`);
-        }}
-        className="hover:opacity-80 transition-opacity"
-        title={`Search for ${value}`}
-      >
-        {effectiveVerified && isRootNip05(value) ? (
-          <>
-            <FontAwesomeIcon icon={faCheckDouble} className="h-4 w-4" />
-            <FontAwesomeIcon icon={faIdBadge} className="h-4 w-4" />
-          </>
-        ) : (
-          <FontAwesomeIcon icon={effectiveVerified ? faIdBadge : faCircleXmark} className="h-4 w-4" />
-        )}
-      </button>
-      <button
-        type="button"
-        onClick={() => onAuthorClick && onAuthorClick(user.npub)}
-        className="hover:underline truncate max-w-[14rem] text-left hidden sm:block"
-        title={cleanNip05Display(value) || undefined}
-      >
-        <span className="truncate max-w-[14rem]">{cleanNip05Display(value) || value}</span>
-      </button>
-      {/* External link removed */}
-      {pathname?.startsWith('/p/') && (
-      <button
-        type="button"
-        className="text-gray-300 hover:text-gray-100"
-        title="Search for profiles by this domain"
-        onClick={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          if (!value) return;
-          const domain = getNip05Domain(value);
-          if (!domain) return;
-          const q = `p:${domain}`;
-          const current = searchParams ? searchParams.toString() : '';
-          const params = new URLSearchParams(current);
-          params.set('q', q);
-          router.push(`/?${params.toString()}`);
-        }}
-      >
-        <FontAwesomeIcon icon={faUserGroup} className="h-3 w-3" />
-      </button>
-      )}
-    </span>
-  ) : (
-    <span className="inline-flex items-center gap-1 text-yellow-400">
-      <button
-        type="button"
-        onClick={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          const current = searchParams ? searchParams.toString() : '';
-          const params = new URLSearchParams(current);
-          params.set('q', 'nip:05');
-          router.push(`/?${params.toString()}`);
-        }}
-        className="hover:opacity-80 transition-opacity"
-        title="Search for NIP-05 specification"
-      >
-        <FontAwesomeIcon icon={faCircleExclamation} className="h-4 w-4" />
-      </button>
-      <button
-        type="button"
-        onClick={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          const current = searchParams ? searchParams.toString() : '';
-          const params = new URLSearchParams(current);
-          params.set('q', 'nip:05');
-          router.push(`/?${params.toString()}`);
-        }}
-        className="text-gray-400 hidden sm:inline hover:underline"
-        title="Search for NIP-05 specification"
-      >
-        no NIP-05
-      </button>
-    </span>
-  );
-
   return (
     <div className="flex items-center gap-2">
-      <span className="text-sm truncate">{nip05Part}</span>
       {loaded ? (
         <button
           type="button"

--- a/src/components/AuthorBadge.tsx
+++ b/src/components/AuthorBadge.tsx
@@ -173,6 +173,7 @@ export default function AuthorBadge({ user, onAuthorClick }: { user: NDKUser, on
 
   return (
     <div className="flex items-center gap-2">
+      <span className="text-sm truncate">{nip05Part}</span>
       {loaded ? (
         <button
           type="button"
@@ -185,7 +186,6 @@ export default function AuthorBadge({ user, onAuthorClick }: { user: NDKUser, on
       ) : (
         <span className="font-medium text-gray-100 truncate max-w-[10rem]">Loading...</span>
       )}
-      <span className="text-sm truncate">{nip05Part}</span>
     </div>
   );
 }

--- a/src/components/AuthorBadge.tsx
+++ b/src/components/AuthorBadge.tsx
@@ -100,7 +100,10 @@ export default function AuthorBadge({ user, onAuthorClick }: { user: NDKUser, on
         title={`Search for ${value}`}
       >
         {effectiveVerified && isRootNip05(value) ? (
-          <FontAwesomeIcon icon={faCheckDouble} className="h-4 w-4" />
+          <>
+            <FontAwesomeIcon icon={faCheckDouble} className="h-4 w-4" />
+            <FontAwesomeIcon icon={faIdBadge} className="h-4 w-4" />
+          </>
         ) : (
           <FontAwesomeIcon icon={effectiveVerified ? faIdBadge : faCircleXmark} className="h-4 w-4" />
         )}

--- a/src/components/AuthorBadge.tsx
+++ b/src/components/AuthorBadge.tsx
@@ -2,11 +2,11 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams, usePathname } from 'next/navigation';
-import { getNip05Domain } from '@/lib/nip05';
+import { getNip05Domain, isRootNip05 } from '@/lib/nip05';
 import { cleanNip05Display } from '@/lib/utils';
 import { NDKUser } from '@nostr-dev-kit/ndk';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCircleXmark, faCircleExclamation, faUserGroup } from '@fortawesome/free-solid-svg-icons';
+import { faCircleXmark, faCircleExclamation, faUserGroup, faCheckDouble } from '@fortawesome/free-solid-svg-icons';
 import { faIdBadge } from '@fortawesome/free-regular-svg-icons';
 
 type Nip05CheckResult = { isVerified: boolean; value: string | undefined };
@@ -99,7 +99,11 @@ export default function AuthorBadge({ user, onAuthorClick }: { user: NDKUser, on
         className="hover:opacity-80 transition-opacity"
         title={`Search for ${value}`}
       >
-        <FontAwesomeIcon icon={effectiveVerified ? faIdBadge : faCircleXmark} className="h-4 w-4" />
+        {effectiveVerified && isRootNip05(value) ? (
+          <FontAwesomeIcon icon={faCheckDouble} className="h-4 w-4" />
+        ) : (
+          <FontAwesomeIcon icon={effectiveVerified ? faIdBadge : faCircleXmark} className="h-4 w-4" />
+        )}
       </button>
       <button
         type="button"

--- a/src/components/Nip05Display.tsx
+++ b/src/components/Nip05Display.tsx
@@ -112,6 +112,15 @@ export default function Nip05Display({ user }: { user: NDKUser }) {
       {/* Mobile view: show only domain part without TLD */}
       <button
         type="button"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          if (!value) return;
+          const current = searchParams ? searchParams.toString() : '';
+          const params = new URLSearchParams(current);
+          params.set('q', value);
+          router.push(`/?${params.toString()}`);
+        }}
         className="hover:underline truncate max-w-[8rem] text-left sm:hidden"
         title={cleanNip05Display(value) || undefined}
       >

--- a/src/components/Nip05Display.tsx
+++ b/src/components/Nip05Display.tsx
@@ -4,6 +4,20 @@ import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams, usePathname } from 'next/navigation';
 import { getNip05Domain, isRootNip05 } from '@/lib/nip05';
 import { cleanNip05Display } from '@/lib/utils';
+
+// Extract domain part without TLD for mobile display
+function getDomainWithoutTld(nip05?: string): string {
+  if (!nip05) return '';
+  const domain = getNip05Domain(nip05);
+  if (!domain) return '';
+  
+  // Split by dots and take everything except the last part (TLD)
+  const parts = domain.split('.');
+  if (parts.length <= 1) return domain;
+  
+  // Return all parts except the last one (TLD)
+  return parts.slice(0, -1).join('.');
+}
 import { NDKUser } from '@nostr-dev-kit/ndk';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleXmark, faCircleExclamation, faUserGroup, faCheckDouble } from '@fortawesome/free-solid-svg-icons';
@@ -95,6 +109,14 @@ export default function Nip05Display({ user }: { user: NDKUser }) {
       >
         <span className="truncate max-w-[14rem]">{cleanNip05Display(value) || value}</span>
       </button>
+      {/* Mobile view: show only domain part without TLD */}
+      <button
+        type="button"
+        className="hover:underline truncate max-w-[8rem] text-left sm:hidden"
+        title={cleanNip05Display(value) || undefined}
+      >
+        <span className="truncate max-w-[8rem]">{getDomainWithoutTld(value)}</span>
+      </button>
       {pathname?.startsWith('/p/') && (
       <button
         type="button"
@@ -145,6 +167,22 @@ export default function Nip05Display({ user }: { user: NDKUser }) {
           router.push(`/?${params.toString()}`);
         }}
         className="text-gray-400 hidden sm:inline hover:underline"
+        title="Search for NIP-05 specification"
+      >
+        no NIP-05
+      </button>
+      {/* Mobile view: show shorter text */}
+      <button
+        type="button"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          const current = searchParams ? searchParams.toString() : '';
+          const params = new URLSearchParams(current);
+          params.set('q', 'nip:05');
+          router.push(`/?${params.toString()}`);
+        }}
+        className="text-gray-400 sm:hidden hover:underline"
         title="Search for NIP-05 specification"
       >
         no NIP-05

--- a/src/components/Nip05Display.tsx
+++ b/src/components/Nip05Display.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams, usePathname } from 'next/navigation';
+import { getNip05Domain, isRootNip05 } from '@/lib/nip05';
+import { cleanNip05Display } from '@/lib/utils';
+import { NDKUser } from '@nostr-dev-kit/ndk';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCircleXmark, faCircleExclamation, faUserGroup, faCheckDouble } from '@fortawesome/free-solid-svg-icons';
+import { faIdBadge } from '@fortawesome/free-regular-svg-icons';
+
+type Nip05CheckResult = { isVerified: boolean; value: string | undefined };
+
+function useNip05Status(user: NDKUser): Nip05CheckResult {
+  const nip05Raw = user.profile?.nip05 as
+    | string
+    | { url?: string; verified?: boolean }
+    | undefined;
+  const nip05 = typeof nip05Raw === 'string' ? nip05Raw : nip05Raw?.url;
+  const hintedVerified =
+    typeof nip05Raw === 'object' && nip05Raw !== null && typeof nip05Raw.verified === 'boolean'
+      ? nip05Raw.verified
+      : undefined;
+  const [verified, setVerified] = useState(Boolean(hintedVerified));
+  const pubkey = user.pubkey;
+
+  useEffect(() => {
+    if (typeof hintedVerified === 'boolean') {
+      setVerified(hintedVerified);
+    } else if (!nip05) {
+      setVerified(false);
+    }
+  }, [hintedVerified, nip05]);
+
+  useEffect(() => {
+    let isMounted = true;
+    if (!nip05) {
+      setVerified(false);
+      return () => {
+        isMounted = false;
+      };
+    }
+    (async () => {
+      try {
+        const { checkNip05 } = await import('@/lib/vertex');
+        const result = await checkNip05(pubkey, nip05);
+        if (isMounted) setVerified(Boolean(result));
+      } catch {
+        if (isMounted) setVerified(false);
+      }
+    })();
+    return () => { isMounted = false; };
+  }, [pubkey, nip05]);
+
+  return { isVerified: verified, value: nip05 };
+}
+
+export default function Nip05Display({ user }: { user: NDKUser }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const { isVerified, value } = useNip05Status(user);
+
+  const effectiveVerified = isVerified;
+
+  const nip05Part = value ? (
+    <span className={`inline-flex items-center gap-1 ${effectiveVerified ? 'text-green-400' : 'text-red-400'}`}>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          if (!value) return;
+          const current = searchParams ? searchParams.toString() : '';
+          const params = new URLSearchParams(current);
+          params.set('q', value);
+          router.push(`/?${params.toString()}`);
+        }}
+        className="hover:opacity-80 transition-opacity"
+        title={`Search for ${value}`}
+      >
+        {effectiveVerified && isRootNip05(value) ? (
+          <>
+            <FontAwesomeIcon icon={faCheckDouble} className="h-4 w-4" />
+            <FontAwesomeIcon icon={faIdBadge} className="h-4 w-4" />
+          </>
+        ) : (
+          <FontAwesomeIcon icon={effectiveVerified ? faIdBadge : faCircleXmark} className="h-4 w-4" />
+        )}
+      </button>
+      <button
+        type="button"
+        className="hover:underline truncate max-w-[14rem] text-left hidden sm:block"
+        title={cleanNip05Display(value) || undefined}
+      >
+        <span className="truncate max-w-[14rem]">{cleanNip05Display(value) || value}</span>
+      </button>
+      {pathname?.startsWith('/p/') && (
+      <button
+        type="button"
+        className="text-gray-300 hover:text-gray-100"
+        title="Search for profiles by this domain"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          if (!value) return;
+          const domain = getNip05Domain(value);
+          if (!domain) return;
+          const q = `p:${domain}`;
+          const current = searchParams ? searchParams.toString() : '';
+          const params = new URLSearchParams(current);
+          params.set('q', q);
+          router.push(`/?${params.toString()}`);
+        }}
+      >
+        <FontAwesomeIcon icon={faUserGroup} className="h-3 w-3" />
+      </button>
+      )}
+    </span>
+  ) : (
+    <span className="inline-flex items-center gap-1 text-yellow-400">
+      <button
+        type="button"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          const current = searchParams ? searchParams.toString() : '';
+          const params = new URLSearchParams(current);
+          params.set('q', 'nip:05');
+          router.push(`/?${params.toString()}`);
+        }}
+        className="hover:opacity-80 transition-opacity"
+        title="Search for NIP-05 specification"
+      >
+        <FontAwesomeIcon icon={faCircleExclamation} className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          const current = searchParams ? searchParams.toString() : '';
+          const params = new URLSearchParams(current);
+          params.set('q', 'nip:05');
+          router.push(`/?${params.toString()}`);
+        }}
+        className="text-gray-400 hidden sm:inline hover:underline"
+        title="Search for NIP-05 specification"
+      >
+        no NIP-05
+      </button>
+    </span>
+  );
+
+  return (
+    <div className="flex items-center gap-2">
+      {nip05Part}
+    </div>
+  );
+}

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -23,6 +23,26 @@ import CardActions from '@/components/CardActions';
 import { formatRelativeTimeAuto } from '@/lib/relativeTime';
 import Nip05Display from '@/components/Nip05Display';
 
+// Clean website URL by removing protocol and www prefix
+function cleanWebsiteUrl(url: string): string {
+  if (!url) return '';
+  
+  try {
+    // Remove protocol (http://, https://)
+    let cleaned = url.replace(/^https?:\/\//, '');
+    
+    // Remove www. prefix
+    cleaned = cleaned.replace(/^www\./, '');
+    
+    // Remove trailing slash
+    cleaned = cleaned.replace(/\/$/, '');
+    
+    return cleaned;
+  } catch {
+    return url;
+  }
+}
+
 function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightning, website, npub, onToggleRaw, showRaw, user }: { pubkey: string; fallbackEventId?: string; fallbackCreatedAt?: number; lightning?: string; website?: string; npub: string; onToggleRaw: () => void; showRaw: boolean; user: NDKUser }) {
   const [updatedAt, setUpdatedAt] = useState<number | null>(null);
   const [updatedEventId, setUpdatedEventId] = useState<string | null>(null);
@@ -105,7 +125,7 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
               title={`Search for ${website}`}
             >
               <FontAwesomeIcon icon={faHouseUser} className="h-4 w-4" />
-              <span className="truncate max-w-[14rem] hidden sm:inline">{website}</span>
+              <span className="truncate max-w-[14rem] hidden sm:inline">{cleanWebsiteUrl(website)}</span>
             </button>
             <a
               href={website}

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -88,7 +88,7 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
             </button>
             <a
               href={`lightning:${lightning}`}
-              className="text-gray-400 hover:text-gray-200 p-1 rounded hover:bg-gray-600"
+              className="text-gray-400 hover:text-gray-200 p-1 rounded hover:bg-gray-600 hidden sm:block"
               title={`Open ${lightning} in Lightning wallet`}
               onClick={(e) => e.stopPropagation()}
             >
@@ -111,7 +111,7 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
               href={website}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-gray-400 hover:text-gray-200 p-1 rounded hover:bg-gray-600"
+              className="text-gray-400 hover:text-gray-200 p-1 rounded hover:bg-gray-600 hidden sm:block"
               title={`Open ${website} externally`}
               onClick={(e) => e.stopPropagation()}
             >

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -21,8 +21,9 @@ import { getIsKindTokens } from '@/lib/search/replacements';
 import RawEventJson from '@/components/RawEventJson';
 import CardActions from '@/components/CardActions';
 import { formatRelativeTimeAuto } from '@/lib/relativeTime';
+import Nip05Display from '@/components/Nip05Display';
 
-function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightning, website, npub, onToggleRaw, showRaw }: { pubkey: string; fallbackEventId?: string; fallbackCreatedAt?: number; lightning?: string; website?: string; npub: string; onToggleRaw: () => void; showRaw: boolean }) {
+function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightning, website, npub, onToggleRaw, showRaw, user }: { pubkey: string; fallbackEventId?: string; fallbackCreatedAt?: number; lightning?: string; website?: string; npub: string; onToggleRaw: () => void; showRaw: boolean; user: any }) {
   const [updatedAt, setUpdatedAt] = useState<number | null>(null);
   const [updatedEventId, setUpdatedEventId] = useState<string | null>(null);
   const [showPortalMenuBottom, setShowPortalMenuBottom] = useState(false);
@@ -73,6 +74,7 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
   return (
     <div className="text-xs text-gray-300 bg-[#2d2d2d] border-t border-[#3d3d3d] px-4 py-2 flex items-center gap-3 flex-wrap">
       <div className="flex items-center gap-2 min-h-[1rem]">
+        {user && <Nip05Display user={user} />}
         {lightning ? (
           <div className="inline-flex items-center gap-1">
             <button
@@ -491,6 +493,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
         npub={event.author.npub}
         onToggleRaw={() => setShowRaw(v => !v)}
         showRaw={showRaw}
+        user={event.author}
       />
       {showPortalMenu && typeof window !== 'undefined' && createPortal(
         <>

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { NDKEvent } from '@nostr-dev-kit/ndk';
+import { NDKEvent, NDKUser } from '@nostr-dev-kit/ndk';
 import AuthorBadge from '@/components/AuthorBadge';
 import { getNewestProfileMetadata, getNewestProfileEvent } from '@/lib/vertex';
 import { isAbsoluteHttpUrl } from '@/lib/urlPatterns';
@@ -23,7 +23,7 @@ import CardActions from '@/components/CardActions';
 import { formatRelativeTimeAuto } from '@/lib/relativeTime';
 import Nip05Display from '@/components/Nip05Display';
 
-function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightning, website, npub, onToggleRaw, showRaw, user }: { pubkey: string; fallbackEventId?: string; fallbackCreatedAt?: number; lightning?: string; website?: string; npub: string; onToggleRaw: () => void; showRaw: boolean; user: any }) {
+function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightning, website, npub, onToggleRaw, showRaw, user }: { pubkey: string; fallbackEventId?: string; fallbackCreatedAt?: number; lightning?: string; website?: string; npub: string; onToggleRaw: () => void; showRaw: boolean; user: NDKUser }) {
   const [updatedAt, setUpdatedAt] = useState<number | null>(null);
   const [updatedEventId, setUpdatedEventId] = useState<string | null>(null);
   const [showPortalMenuBottom, setShowPortalMenuBottom] = useState(false);

--- a/src/lib/nip05.ts
+++ b/src/lib/nip05.ts
@@ -22,6 +22,16 @@ export function getNip05Domain(input: string): string {
   return (parts[1] || '').trim();
 }
 
+export function isRootNip05(nip05?: string): boolean {
+  if (!nip05) return false;
+  const normalized = normalizeNip05String(nip05);
+  if (!normalized) return false;
+  
+  const [localPart] = normalized.split('@');
+  // Root NIP-05 is when local part is '_' or empty (which gets normalized to '_')
+  return localPart === '_';
+}
+
 const nip05Cache = new Map<string, boolean>();
 
 export async function verifyNip05(pubkeyHex: string | undefined, nip05?: string, timeoutMs: number = 4000): Promise<boolean> {

--- a/src/lib/profile/nip05.ts
+++ b/src/lib/profile/nip05.ts
@@ -1,5 +1,5 @@
 import { nip05 as nostrNip05 } from 'nostr-tools';
-import { normalizeNip05String } from '../nip05';
+import { normalizeNip05String, isRootNip05 } from '../nip05';
 import { 
   getCachedNip05Result, 
   setCachedNip05Result, 
@@ -96,3 +96,6 @@ export async function checkNip05(pubkeyHex: string, nip05: string): Promise<bool
 export function invalidateNip05CacheEntry(pubkeyHex: string, nip05: string): void {
   invalidateNip05Cache(pubkeyHex, nip05);
 }
+
+// Re-export isRootNip05 from main nip05 module
+export { isRootNip05 };

--- a/src/lib/profile/search.ts
+++ b/src/lib/profile/search.ts
@@ -7,7 +7,7 @@ import {
   computeMatchScore 
 } from './utils';
 import { queryVertexDVM } from './dvm-core';
-import { verifyNip05 } from './nip05';
+import { verifyNip05, isRootNip05 } from './nip05';
 import { getCachedNip05Result } from './cache';
 
 // Full-text profile search with ranking
@@ -125,6 +125,8 @@ export async function searchProfilesFullText(term: string, limit: number = 50): 
       : (row.pubkey && row.nip05 ? (getCachedNip05Result(row.pubkey, row.nip05) ?? false) : false);
     let score = row.baseScore;
     if (verified) score += 100;
+    // Additional bonus for verified root NIP-05s (double checkmark)
+    if (verified && row.nip05 && isRootNip05(row.nip05)) score += 50;
     if (row.isFriend) score += 50;
     row.finalScore = score;
     row.verified = verified;


### PR DESCRIPTION
This PR enhances NIP-05 display and profile ranking with special indicators for verified root identifiers, improves mobile UX, and moves NIP-05 elements to profile card footers for better organization.

- Add special double-checkmark indicator for verified root NIP-05s (domain-only identifiers like `dergigi.com`)
- Move NIP-05 display to profile card footer for both individual profiles and profile lists
- Add +50 point scoring bonus for verified root NIP-05s in profile ranking system
- Optimize mobile view with domain-only display (showing `dergigi` instead of `dergigi.com`)
- Clean website URL display by removing `http/https` and `www` prefixes
- Hide external link icons on mobile to reduce visual clutter
