### PR TITLE
Highlight zap senders in profile lightning UI

### DIFF
--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -22,6 +22,7 @@ import RawEventJson from '@/components/RawEventJson';
 import CardActions from '@/components/CardActions';
 import { formatRelativeTimeAuto } from '@/lib/relativeTime';
 import Nip05Display from '@/components/Nip05Display';
+import { useHasSentZap } from '@/hooks/useHasSentZap';
 
 // Clean website URL by removing protocol and www prefix
 function cleanWebsiteUrl(url: string): string {
@@ -53,6 +54,7 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
   const nativeAppHref = useMemo(() => bottomItems.find((item) => item.name === 'Native App')?.href, [bottomItems]);
   const router = useRouter();
   const pathname = usePathname();
+  const hasSentZap = useHasSentZap(pubkey);
 
   const handleLightningSearch = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -100,19 +102,19 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
             <button
               type="button"
               onClick={handleLightningSearch}
-              className="inline-flex items-center gap-1 hover:underline p-1 rounded"
+              className={`inline-flex items-center gap-1 hover:underline p-1 rounded ${hasSentZap ? 'text-yellow-300' : ''}`.trim()}
               title={`Search for ${lightning}`}
             >
-              <FontAwesomeIcon icon={faBoltLightning} className="h-4 w-4" />
+              <FontAwesomeIcon icon={faBoltLightning} className={`h-4 w-4 ${hasSentZap ? 'text-yellow-400' : ''}`.trim()} />
               <span className="truncate max-w-[14rem] hidden sm:inline">{lightning}</span>
             </button>
             <a
               href={`lightning:${lightning}`}
-              className="text-gray-400 hover:text-gray-200 p-1 rounded hover:bg-gray-600 hidden sm:block"
+              className={`p-1 rounded hover:bg-gray-600 hidden sm:block ${hasSentZap ? 'text-yellow-300 hover:text-yellow-200' : 'text-gray-400 hover:text-gray-200'}`.trim()}
               title={`Open ${lightning} in Lightning wallet`}
               onClick={(e) => e.stopPropagation()}
             >
-              <FontAwesomeIcon icon={faExternalLink} className="h-4 w-4" />
+              <FontAwesomeIcon icon={faExternalLink} className={`h-4 w-4 ${hasSentZap ? 'text-yellow-400' : ''}`.trim()} />
             </a>
           </div>
         ) : null}

--- a/src/hooks/useHasSentZap.ts
+++ b/src/hooks/useHasSentZap.ts
@@ -1,0 +1,84 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { NDKFilter, NDKSubscription } from '@nostr-dev-kit/ndk';
+import { NDKSubscriptionCacheUsage } from '@nostr-dev-kit/ndk';
+import { safeSubscribe } from '@/lib/ndk';
+import { relaySets } from '@/lib/relays';
+
+const ZAP_RECEIPT_KIND = 9735;
+const zapSenderCache = new Map<string, boolean>();
+
+export function useHasSentZap(pubkey?: string | null): boolean {
+  const [hasSentZap, setHasSentZap] = useState(() => (pubkey ? zapSenderCache.get(pubkey) ?? false : false));
+
+  useEffect(() => {
+    if (!pubkey) {
+      setHasSentZap(false);
+      return;
+    }
+
+    const cachedValue = zapSenderCache.get(pubkey);
+    if (cachedValue !== undefined) {
+      setHasSentZap(cachedValue);
+      return;
+    }
+
+    let cancelled = false;
+    let settled = false;
+    let subscription: NDKSubscription | null = null;
+
+    const finish = (value: boolean) => {
+      if (settled) return;
+      settled = true;
+      zapSenderCache.set(pubkey, value);
+      if (!cancelled) {
+        setHasSentZap(value);
+      }
+      try {
+        subscription?.stop();
+      } catch {}
+    };
+
+    setHasSentZap(false);
+
+    (async () => {
+      try {
+        const relaySet = await relaySets.default();
+        const filter: NDKFilter = {
+          kinds: [ZAP_RECEIPT_KIND],
+          limit: 1,
+          ['#P']: [pubkey]
+        };
+
+        subscription = safeSubscribe([filter], {
+          closeOnEose: true,
+          relaySet,
+          cacheUsage: NDKSubscriptionCacheUsage.ONLY_RELAY
+        });
+
+        if (!subscription) {
+          finish(false);
+          return;
+        }
+
+        subscription.on('event', () => finish(true));
+        subscription.on('eose', () => finish(false));
+        subscription.start();
+      } catch {
+        finish(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      try {
+        subscription?.stop();
+      } catch {}
+    };
+  }, [pubkey]);
+
+  return hasSentZap;
+}
+
+


### PR DESCRIPTION
This PR highlights the lightning bolt and lightning address in `ProfileCard` when a profile pubkey has previously sent a zap, using a new `useHasSentZap` hook that queries zap receipts.

- add zap sender detection via kind `9735` lookup
- cache zap lookups for repeated profile renders
- update lightning UI to show yellow state for zap senders
