### PR TITLE
feat: highlight nutzap activity in profiles

### DIFF
--- a/public/replacements.txt
+++ b/public/replacements.txt
@@ -45,6 +45,7 @@ is:patch => kind:1617
 is:issue => kind:1621
 is:report => kind:1984
 is:zap => kind:9735
+is:nutzap => kind:9321
 is:muted => kind:10000
 is:pin => kind:10001
 is:bookmark => kind:10003

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -56,12 +56,12 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
   const pathname = usePathname();
   const hasSentZap = useHasSentZap(pubkey);
   const hasSentNutzap = useHasSentNutzap(pubkey);
-  const lightningButtonAccent = hasSentNutzap ? 'text-purple-300' : hasSentZap ? 'text-yellow-300' : '';
-  const lightningIconAccent = hasSentNutzap ? 'text-purple-300' : hasSentZap ? 'text-yellow-400' : '';
+  const lightningButtonAccent = hasSentNutzap ? 'text-purple-300' : hasSentZap ? 'text-yellow-200' : '';
+  const lightningIconAccent = hasSentNutzap ? 'text-purple-300' : hasSentZap ? 'text-yellow-200' : '';
   const lightningAnchorAccent = hasSentNutzap
     ? 'text-purple-300 hover:text-purple-200'
     : hasSentZap
-      ? 'text-yellow-300 hover:text-yellow-200'
+      ? 'text-yellow-200 hover:text-yellow-100'
       : 'text-gray-400 hover:text-gray-200';
 
   const handleLightningSearch = (e: React.MouseEvent) => {

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -56,10 +56,10 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
   const pathname = usePathname();
   const hasSentZap = useHasSentZap(pubkey);
   const hasSentNutzap = useHasSentNutzap(pubkey);
-  const lightningButtonAccent = hasSentNutzap ? 'text-purple-300' : hasSentZap ? 'text-yellow-200' : '';
-  const lightningIconAccent = hasSentNutzap ? 'text-purple-300' : hasSentZap ? 'text-yellow-200' : '';
+  const lightningButtonAccent = hasSentNutzap ? 'text-purple-400' : hasSentZap ? 'text-yellow-200' : '';
+  const lightningIconAccent = hasSentNutzap ? 'text-purple-400' : hasSentZap ? 'text-yellow-200' : '';
   const lightningAnchorAccent = hasSentNutzap
-    ? 'text-purple-300 hover:text-purple-200'
+    ? 'text-purple-400 hover:text-purple-300'
     : hasSentZap
       ? 'text-yellow-200 hover:text-yellow-100'
       : 'text-gray-400 hover:text-gray-200';

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -22,7 +22,7 @@ import RawEventJson from '@/components/RawEventJson';
 import CardActions from '@/components/CardActions';
 import { formatRelativeTimeAuto } from '@/lib/relativeTime';
 import Nip05Display from '@/components/Nip05Display';
-import { useHasSentZap } from '@/hooks/useHasSentZap';
+import { useHasSentZap, useHasSentNutzap } from '@/hooks/useHasSentZap';
 
 // Clean website URL by removing protocol and www prefix
 function cleanWebsiteUrl(url: string): string {
@@ -55,6 +55,14 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
   const router = useRouter();
   const pathname = usePathname();
   const hasSentZap = useHasSentZap(pubkey);
+  const hasSentNutzap = useHasSentNutzap(pubkey);
+  const lightningButtonAccent = hasSentNutzap ? 'text-purple-300' : hasSentZap ? 'text-yellow-300' : '';
+  const lightningIconAccent = hasSentNutzap ? 'text-purple-300' : hasSentZap ? 'text-yellow-400' : '';
+  const lightningAnchorAccent = hasSentNutzap
+    ? 'text-purple-300 hover:text-purple-200'
+    : hasSentZap
+      ? 'text-yellow-300 hover:text-yellow-200'
+      : 'text-gray-400 hover:text-gray-200';
 
   const handleLightningSearch = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -102,19 +110,19 @@ function ProfileCreatedAt({ pubkey, fallbackEventId, fallbackCreatedAt, lightnin
             <button
               type="button"
               onClick={handleLightningSearch}
-              className={`inline-flex items-center gap-1 hover:underline p-1 rounded ${hasSentZap ? 'text-yellow-300' : ''}`.trim()}
+              className={`inline-flex items-center gap-1 hover:underline p-1 rounded ${lightningButtonAccent}`.trim()}
               title={`Search for ${lightning}`}
             >
-              <FontAwesomeIcon icon={faBoltLightning} className={`h-4 w-4 ${hasSentZap ? 'text-yellow-400' : ''}`.trim()} />
+              <FontAwesomeIcon icon={faBoltLightning} className={`h-4 w-4 ${lightningIconAccent}`.trim()} />
               <span className="truncate max-w-[14rem] hidden sm:inline">{lightning}</span>
             </button>
             <a
               href={`lightning:${lightning}`}
-              className={`p-1 rounded hover:bg-gray-600 hidden sm:block ${hasSentZap ? 'text-yellow-300 hover:text-yellow-200' : 'text-gray-400 hover:text-gray-200'}`.trim()}
+              className={`p-1 rounded hover:bg-gray-600 hidden sm:block ${lightningAnchorAccent}`.trim()}
               title={`Open ${lightning} in Lightning wallet`}
               onClick={(e) => e.stopPropagation()}
             >
-              <FontAwesomeIcon icon={faExternalLink} className={`h-4 w-4 ${hasSentZap ? 'text-yellow-400' : ''}`.trim()} />
+              <FontAwesomeIcon icon={faExternalLink} className={`h-4 w-4 ${lightningIconAccent}`.trim()} />
             </a>
           </div>
         ) : null}

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -25,7 +25,7 @@ import ClientFilters, { FilterSettings } from '@/components/ClientFilters';
 import CopyButton from '@/components/CopyButton';
 import { nip19 } from 'nostr-tools';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { shortenNevent, shortenNpub } from '@/lib/utils';
+import { shortenNevent, shortenNpub, shortenString } from '@/lib/utils';
 import emojiRegex from 'emoji-regex';
 import { faMagnifyingGlass, faImage, faExternalLink, faUser, faEye, faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
 import { setPrefetchedProfile, prepareProfileEventForPrefetch } from '@/lib/profile/prefetch';
@@ -1640,10 +1640,20 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
       const barClasses = `text-xs text-gray-300 bg-[#1f1f1f] border border-[#3d3d3d] px-4 py-2 hover:bg-[#262626] ${
         isTop ? 'rounded-t-lg' : 'rounded-none border-t-0'
       } rounded-b-none border-b-0`;
+      const parentLabel = (() => {
+        if (!parentId) return 'Unknown parent';
+        const normalized = parentId.trim();
+        if (/^[0-9a-f]{64}$/i.test(normalized)) {
+          try {
+            return shortenNevent(nip19.neventEncode({ id: normalized }));
+          } catch {}
+        }
+        return shortenString(normalized, 10, 6);
+      })();
       return (
         <div className={barClasses}>
           <button type="button" onClick={handleToggle} className="w-full text-left">
-            {isLoading ? 'Loading parent…' : `Replying to: ${shortenNevent(nip19.neventEncode({ id: parentId }))}`}
+            {isLoading ? 'Loading parent…' : `Replying to: ${parentLabel}`}
           </button>
         </div>
       );


### PR DESCRIPTION
Profiles now highlight lightning details in purple once a user has sent a `kind:9321` nutzap, while zap-only users keep a muted yellow accent; search also gains an `is:nutzap` shortcut and parent-chain previews are hardened against invalid ids.
- reuse lightning history hook for both zap and nutzap checks with caching
- update `ProfileCard` accents to use deeper purple and softened yellow tones
- add `is:nutzap` replacement and guard `nip19.neventEncode` calls in parent chains
