### PR TITLE
fix: strip nostr prefixes in search

### DIFF
--- a/public/replacements.txt
+++ b/public/replacements.txt
@@ -156,3 +156,5 @@ nip:EE => nips/blob/master/EE.md
 nip:A0 => nips/blob/master/A0.md
 nip:C7 => nips/blob/master/C7.md
 nip:7D => nips/blob/master/7D.md
+
+nostr: => 


### PR DESCRIPTION
This PR teaches the client to strip `nostr:` prefixes during search preprocessing by leveraging a new rule in `public/replacements.txt` and the updated matcher in `applySimpleReplacements`.

- allow prefix-only replacements to drop leading tokens like `nostr:`
- reuse the same rule table for prefix stripping and existing site alias expansion
