### PR TITLE
Remove custom URL protocol stripping and add lud06 Lightning address support

### DIFF
--- a/public/replacements.txt
+++ b/public/replacements.txt
@@ -158,3 +158,8 @@ nip:C7 => nips/blob/master/C7.md
 nip:7D => nips/blob/master/7D.md
 
 nostr: => 
+http://www. => 
+https://www. =>
+http:// => 
+https:// =>
+ftp:// =>

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -251,7 +251,7 @@ type ProfileCardProps = {
 
 export default function ProfileCard({ event, onAuthorClick, onHashtagClick, showBanner = false }: ProfileCardProps) {
   const noteCardClasses = 'relative bg-[#2d2d2d] border border-[#3d3d3d] rounded-lg overflow-hidden';
-  type ProfileLike = { banner?: string; cover?: string; header?: string; lud16?: string; website?: string; url?: string } | undefined;
+  type ProfileLike = { banner?: string; cover?: string; header?: string; lud16?: string; lud06?: string; website?: string; url?: string } | undefined;
   const profile = (event.author?.profile as ProfileLike);
   const bannerUrl = profile?.banner || profile?.cover || profile?.header;
   const safeBannerUrl = isAbsoluteHttpUrl(bannerUrl) ? bannerUrl : undefined;
@@ -529,7 +529,7 @@ export default function ProfileCard({ event, onAuthorClick, onHashtagClick, show
         pubkey={event.author.pubkey}
         fallbackEventId={event.id}
         fallbackCreatedAt={event.created_at}
-        lightning={profile?.lud16}
+        lightning={profile?.lud16 || profile?.lud06}
         website={(profile?.website || profile?.url) as string | undefined}
         npub={event.author.npub}
         onToggleRaw={() => setShowRaw(v => !v)}

--- a/src/lib/profile/prefetch.ts
+++ b/src/lib/profile/prefetch.ts
@@ -110,6 +110,8 @@ export function prepareProfileEventForPrefetch(event: NDKEvent): NDKEvent {
         // Keep banner/cover/header as-is; UI already checks these keys
         // Ensure nip05 is preserved
         if (typeof parsed?.nip05 === 'string') normalized.nip05 = parsed.nip05;
+        // Ensure lud06 is preserved (alternative to lud16 for Lightning addresses)
+        if (typeof parsed?.lud06 === 'string') normalized.lud06 = parsed.lud06;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (author as any).profile = normalized;
       } catch {}

--- a/src/lib/search/urlSearch.ts
+++ b/src/lib/search/urlSearch.ts
@@ -26,9 +26,8 @@ export async function searchUrlEvents(
   chosenRelaySet: NDKRelaySet,
   abortSignal?: AbortSignal
 ): Promise<NDKEvent[]> {
-  // Strip protocol and search for the domain and path content
-  const urlWithoutProtocol = cleanedQuery.replace(/^https?:\/\//, '');
-  const searchQuery = buildSearchQueryWithExtensions(`"${urlWithoutProtocol}"`, nip50Extensions);
+  // Search for the URL content (protocol stripping now handled by replacement rules)
+  const searchQuery = buildSearchQueryWithExtensions(`"${cleanedQuery}"`, nip50Extensions);
   
   const results = isStreaming 
     ? await subscribeAndStream({


### PR DESCRIPTION
This PR removes custom URL protocol stripping logic and adds support for `lud06` Lightning addresses alongside existing `lud16` support.

The main changes include removing hardcoded `https?://` protocol stripping from `urlSearch.ts` and replacing it with centralized replacement rules in `replacements.txt`. This improves maintainability by consolidating URL normalization logic in one place. Additionally, the ProfileCard component now supports both `lud16` and `lud06` Lightning address fields, with `lud16` taking precedence when both are present.

- Remove custom URL protocol stripping from search functionality
- Add `lud06` support for Lightning addresses in profile metadata
- Centralize URL normalization through replacement rules system
