### PR TITLE
Add hashtag-specific URL paths with /t/[hashtags] route

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,32 @@ A simple search interface for Nostr events.
 - [`@dergigi.com`](https://search.dergigi.com/?q=%40dergigi.com) - Resolve NIP-05
 - [`/p/npub1...`](https://search.dergigi.com/?q=/p/npub1...) - Direct profile page URL
 
+## URL Paths
+
+The application supports several direct URL paths for quick access:
+
+### Profile Pages
+
+- `/p/[id]` - View a specific profile and their latest notes
+  - `/p/npub1...` - Direct profile by npub
+  - `/p/@username.com` - Profile by NIP-05 identifier
+  - `/p/username` - Profile search by username
+
+### Event Pages
+
+- `/e/[id]` - View a specific event
+  - `/e/nevent1...` - Event by nevent identifier
+  - `/e/note1...` - Event by note identifier
+  - `/e/[hex-id]` - Event by 64-character hex ID
+
+### Hashtag Pages
+
+- `/t/[hashtags]` - Search multiple hashtags
+  - `/t/bitcoin` - Search for #bitcoin
+  - `/t/bitcoin,lightning` - Search for #bitcoin OR #lightning
+  - `/t/bitcoin+lightning` - Alternative syntax for multiple hashtags
+  - `/t/bitcoin lightning` - Space-separated hashtags
+
 ## Features
 
 - Search for nostr posts (kind 1)

--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ The application supports several direct URL paths for quick access:
 ### Hashtag Pages
 
 - `/t/[hashtags]` - Search multiple hashtags
-  - `/t/bitcoin` - Search for #bitcoin
-  - `/t/bitcoin,lightning` - Search for #bitcoin OR #lightning
-  - `/t/bitcoin+lightning` - Alternative syntax for multiple hashtags
-  - `/t/bitcoin lightning` - Space-separated hashtags
+  - `/t/pugstr` - Search for #pugstr
+  - `/t/pugstr,dogstr,goatstr` - Search for #pugstr OR #dogstr OR #goatstr
+  - `/t/pugstr+dogstr+goatstr` - Alternative syntax for multiple hashtags
+  - `/t/pugstr dogstr goatstr` - Space-separated hashtags
 
 ## Features
 

--- a/src/app/e/[id]/page.tsx
+++ b/src/app/e/[id]/page.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useMemo } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { nip19 } from 'nostr-tools';
+import { decodeMaybe } from '@/lib/utils';
+import { LoadingLayout } from '@/components/LoadingLayout';
 
 export default function EidRedirectPage() {
   const params = useParams<{ id: string }>();
@@ -10,9 +12,6 @@ export default function EidRedirectPage() {
   const rawId = params?.id || '';
 
   const normalizedQuery = useMemo(() => {
-    const decodeMaybe = (s: string): string => {
-      try { return decodeURIComponent(s); } catch { return s; }
-    };
     let token = decodeMaybe(rawId).trim();
     if (!token) return '';
     if (/^nostr:/i.test(token)) token = token.replace(/^nostr:/i, '');
@@ -43,13 +42,7 @@ export default function EidRedirectPage() {
     router.replace(`/?q=${encodeURIComponent(normalizedQuery)}`);
   }, [normalizedQuery, router]);
 
-  return (
-    <main className="min-h-screen bg-[#1a1a1a] text-gray-100">
-      <div className="max-w-2xl mx-auto px-4 pt-6 space-y-4">
-        <div className="text-sm text-gray-400">Redirecting to search…</div>
-      </div>
-    </main>
-  );
+  return <LoadingLayout message="Redirecting to search…" />;
 }
 
 

--- a/src/app/p/[id]/page.tsx
+++ b/src/app/p/[id]/page.tsx
@@ -7,6 +7,8 @@ import SearchView from '@/components/SearchView';
 import ProfileCard from '@/components/ProfileCard';
 import { resolveNip05ToPubkey } from '@/lib/vertex';
 import { useNostrUser } from '@/hooks/useNostrUser';
+import { decodeMaybe } from '@/lib/utils';
+import { LoadingLayout } from '@/components/LoadingLayout';
 
 // shared hook imported from '@/hooks/useNostrUser'
 
@@ -18,9 +20,6 @@ export default function PidPage() {
   const q = searchParams?.get('q') || '';
 
   const id = useMemo(() => {
-    const decodeMaybe = (s: string): string => {
-      try { return decodeURIComponent(s); } catch { return s; }
-    };
     let token = decodeMaybe(rawId).trim();
     if (!token) return '';
     if (/^nostr:/i.test(token)) token = token.replace(/^nostr:/i, '');
@@ -84,13 +83,7 @@ export default function PidPage() {
   const { profileEvent } = useNostrUser(npub || undefined);
 
   if (mode === 'checking') {
-    return (
-      <main className="min-h-screen bg-[#1a1a1a] text-gray-100">
-        <div className="max-w-2xl mx-auto px-4 pt-6 space-y-4">
-          <div className="text-sm text-gray-400">Trying to resolve NIP-05...</div>
-        </div>
-      </main>
-    );
+    return <LoadingLayout message="Trying to resolve NIP-05..." />;
   }
 
   if (mode === 'profile' && npub) {

--- a/src/app/t/[hashtags]/page.tsx
+++ b/src/app/t/[hashtags]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react';
 import { useParams } from 'next/navigation';
-import { decodeMaybe } from '@/lib/utils';
+import { decodeMaybe, processHashtagInput } from '@/lib/utils';
 import SearchView from '@/components/SearchView';
 
 export default function HashtagsPage() {
@@ -10,27 +10,8 @@ export default function HashtagsPage() {
   const rawHashtags = params?.hashtags || '';
 
   const normalizedQuery = useMemo(() => {
-    const hashtags = decodeMaybe(rawHashtags).trim();
-    if (!hashtags) return '';
-    
-    // Split by comma, space, or plus sign to handle multiple hashtags
-    const hashtagList = hashtags
-      .split(/[,+\s]+/)
-      .map(tag => tag.trim())
-      .filter(tag => tag.length > 0)
-      .map(tag => {
-        // Ensure hashtag starts with # if not already present
-        return tag.startsWith('#') ? tag : `#${tag}`;
-      });
-    
-    if (hashtagList.length === 0) return '';
-    
-    // If multiple hashtags, join with OR operator
-    if (hashtagList.length === 1) {
-      return hashtagList[0];
-    } else {
-      return hashtagList.join(' OR ');
-    }
+    const hashtags = decodeMaybe(rawHashtags);
+    return processHashtagInput(hashtags);
   }, [rawHashtags]);
 
   return (

--- a/src/app/t/[hashtags]/page.tsx
+++ b/src/app/t/[hashtags]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useCallback } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { decodeMaybe, processHashtagInput, isHashtagOnlyQuery, hashtagQueryToUrl } from '@/lib/utils';
 import SearchView from '@/components/SearchView';
@@ -16,7 +16,7 @@ export default function HashtagsPage() {
   }, [rawHashtags]);
 
   // Custom URL management for hashtag pages
-  const handleUrlUpdate = (query: string) => {
+  const handleUrlUpdate = useCallback((query: string) => {
     if (isHashtagOnlyQuery(query)) {
       // If it's hashtag-only, update to /t/ path
       const hashtagUrl = hashtagQueryToUrl(query);
@@ -27,7 +27,7 @@ export default function HashtagsPage() {
       // If it's not hashtag-only, redirect to main search
       router.replace(`/?q=${encodeURIComponent(query)}`);
     }
-  };
+  }, [router]);
 
   return (
     <main className="min-h-screen bg-[#1a1a1a] text-gray-100">

--- a/src/app/t/[hashtags]/page.tsx
+++ b/src/app/t/[hashtags]/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import SearchView from '@/components/SearchView';
 
 export default function HashtagsPage() {
   const params = useParams<{ hashtags: string }>();
@@ -14,7 +13,7 @@ export default function HashtagsPage() {
       try { return decodeURIComponent(s); } catch { return s; }
     };
     
-    let hashtags = decodeMaybe(rawHashtags).trim();
+    const hashtags = decodeMaybe(rawHashtags).trim();
     if (!hashtags) return '';
     
     // Split by comma, space, or plus sign to handle multiple hashtags

--- a/src/app/t/[hashtags]/page.tsx
+++ b/src/app/t/[hashtags]/page.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useMemo } from 'react';
 import { useParams, useRouter } from 'next/navigation';
+import { decodeMaybe } from '@/lib/utils';
+import { LoadingLayout } from '@/components/LoadingLayout';
 
 export default function HashtagsPage() {
   const params = useParams<{ hashtags: string }>();
@@ -9,10 +11,6 @@ export default function HashtagsPage() {
   const rawHashtags = params?.hashtags || '';
 
   const normalizedQuery = useMemo(() => {
-    const decodeMaybe = (s: string): string => {
-      try { return decodeURIComponent(s); } catch { return s; }
-    };
-    
     const hashtags = decodeMaybe(rawHashtags).trim();
     if (!hashtags) return '';
     
@@ -41,11 +39,5 @@ export default function HashtagsPage() {
     router.replace(`/?q=${encodeURIComponent(normalizedQuery)}`);
   }, [normalizedQuery, router]);
 
-  return (
-    <main className="min-h-screen bg-[#1a1a1a] text-gray-100">
-      <div className="max-w-2xl mx-auto px-4 pt-6 space-y-4">
-        <div className="text-sm text-gray-400">Searching hashtags: {rawHashtags}</div>
-      </div>
-    </main>
-  );
+  return <LoadingLayout message={`Searching hashtags: ${rawHashtags}`} />;
 }

--- a/src/app/t/[hashtags]/page.tsx
+++ b/src/app/t/[hashtags]/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect, useMemo } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import SearchView from '@/components/SearchView';
+
+export default function HashtagsPage() {
+  const params = useParams<{ hashtags: string }>();
+  const router = useRouter();
+  const rawHashtags = params?.hashtags || '';
+
+  const normalizedQuery = useMemo(() => {
+    const decodeMaybe = (s: string): string => {
+      try { return decodeURIComponent(s); } catch { return s; }
+    };
+    
+    let hashtags = decodeMaybe(rawHashtags).trim();
+    if (!hashtags) return '';
+    
+    // Split by comma, space, or plus sign to handle multiple hashtags
+    const hashtagList = hashtags
+      .split(/[,+\s]+/)
+      .map(tag => tag.trim())
+      .filter(tag => tag.length > 0)
+      .map(tag => {
+        // Ensure hashtag starts with # if not already present
+        return tag.startsWith('#') ? tag : `#${tag}`;
+      });
+    
+    if (hashtagList.length === 0) return '';
+    
+    // If multiple hashtags, join with OR operator
+    if (hashtagList.length === 1) {
+      return hashtagList[0];
+    } else {
+      return hashtagList.join(' OR ');
+    }
+  }, [rawHashtags]);
+
+  useEffect(() => {
+    if (!normalizedQuery) return;
+    router.replace(`/?q=${encodeURIComponent(normalizedQuery)}`);
+  }, [normalizedQuery, router]);
+
+  return (
+    <main className="min-h-screen bg-[#1a1a1a] text-gray-100">
+      <div className="max-w-2xl mx-auto px-4 pt-6 space-y-4">
+        <div className="text-sm text-gray-400">Searching hashtags: {rawHashtags}</div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/t/[hashtags]/page.tsx
+++ b/src/app/t/[hashtags]/page.tsx
@@ -1,13 +1,12 @@
 'use client';
 
-import { useEffect, useMemo } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useMemo } from 'react';
+import { useParams } from 'next/navigation';
 import { decodeMaybe } from '@/lib/utils';
-import { LoadingLayout } from '@/components/LoadingLayout';
+import SearchView from '@/components/SearchView';
 
 export default function HashtagsPage() {
   const params = useParams<{ hashtags: string }>();
-  const router = useRouter();
   const rawHashtags = params?.hashtags || '';
 
   const normalizedQuery = useMemo(() => {
@@ -34,10 +33,11 @@ export default function HashtagsPage() {
     }
   }, [rawHashtags]);
 
-  useEffect(() => {
-    if (!normalizedQuery) return;
-    router.replace(`/?q=${encodeURIComponent(normalizedQuery)}`);
-  }, [normalizedQuery, router]);
-
-  return <LoadingLayout message={`Searching hashtags: ${rawHashtags}`} />;
+  return (
+    <main className="min-h-screen bg-[#1a1a1a] text-gray-100">
+      <div className="max-w-2xl mx-auto px-4 min-h-screen flex items-center w-full">
+        <SearchView initialQuery={normalizedQuery} manageUrl={false} />
+      </div>
+    </main>
+  );
 }

--- a/src/app/t/[hashtags]/page.tsx
+++ b/src/app/t/[hashtags]/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { useMemo } from 'react';
-import { useParams } from 'next/navigation';
-import { decodeMaybe, processHashtagInput } from '@/lib/utils';
+import { useParams, useRouter } from 'next/navigation';
+import { decodeMaybe, processHashtagInput, isHashtagOnlyQuery, hashtagQueryToUrl } from '@/lib/utils';
 import SearchView from '@/components/SearchView';
 
 export default function HashtagsPage() {
   const params = useParams<{ hashtags: string }>();
+  const router = useRouter();
   const rawHashtags = params?.hashtags || '';
 
   const normalizedQuery = useMemo(() => {
@@ -14,10 +15,28 @@ export default function HashtagsPage() {
     return processHashtagInput(hashtags);
   }, [rawHashtags]);
 
+  // Custom URL management for hashtag pages
+  const handleUrlUpdate = (query: string) => {
+    if (isHashtagOnlyQuery(query)) {
+      // If it's hashtag-only, update to /t/ path
+      const hashtagUrl = hashtagQueryToUrl(query);
+      if (hashtagUrl) {
+        router.replace(`/t/${hashtagUrl}`);
+      }
+    } else {
+      // If it's not hashtag-only, redirect to main search
+      router.replace(`/?q=${encodeURIComponent(query)}`);
+    }
+  };
+
   return (
     <main className="min-h-screen bg-[#1a1a1a] text-gray-100">
       <div className="max-w-2xl mx-auto px-4 min-h-screen flex items-center w-full">
-        <SearchView initialQuery={normalizedQuery} manageUrl={false} />
+        <SearchView 
+          initialQuery={normalizedQuery} 
+          manageUrl={false}
+          onUrlUpdate={handleUrlUpdate}
+        />
       </div>
     </main>
   );

--- a/src/components/LoadingLayout.tsx
+++ b/src/components/LoadingLayout.tsx
@@ -1,0 +1,13 @@
+interface LoadingLayoutProps {
+  message: string;
+}
+
+export function LoadingLayout({ message }: LoadingLayoutProps) {
+  return (
+    <main className="min-h-screen bg-[#1a1a1a] text-gray-100">
+      <div className="max-w-2xl mx-auto px-4 pt-6 space-y-4">
+        <div className="text-sm text-gray-400">{message}</div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -24,7 +24,7 @@ import ClientFilters, { FilterSettings } from '@/components/ClientFilters';
 import CopyButton from '@/components/CopyButton';
 import { nip19 } from 'nostr-tools';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { shortenNevent, shortenNpub, shortenString, trimImageUrl } from '@/lib/utils';
+import { shortenNevent, shortenNpub, shortenString, trimImageUrl, isHashtagOnlyQuery, hashtagQueryToUrl } from '@/lib/utils';
 import emojiRegex from 'emoji-regex';
 import { faMagnifyingGlass, faImage, faExternalLink, faUser, faEye, faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
 import { setPrefetchedProfile, prepareProfileEventForPrefetch } from '@/lib/profile/prefetch';
@@ -696,7 +696,16 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
   const updateUrlForSearch = useCallback((searchQuery: string) => {
     if (!manageUrl) return;
     
+    // Check if this is a hashtag-only query and we're not already on a profile page
     const currentProfileNpub = getCurrentProfileNpub(pathname);
+    if (!currentProfileNpub && isHashtagOnlyQuery(searchQuery)) {
+      const hashtagUrl = hashtagQueryToUrl(searchQuery);
+      if (hashtagUrl) {
+        router.replace(`/t/${hashtagUrl}`);
+        return;
+      }
+    }
+    
     if (currentProfileNpub) {
       // URL should be implicit on profile pages: strip matching by:npub
       const urlValue = toImplicitUrlQuery(searchQuery, currentProfileNpub);

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -739,8 +739,13 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       return;
     }
 
-    // Update URL immediately when search is triggered
-    updateUrlForSearch(searchQuery);
+    // Update URL immediately when search is triggered (but not if we're on /t/ path with hashtag-only query)
+    const isOnTagPath = pathname?.startsWith('/t/');
+    const isHashtagQuery = isHashtagOnlyQuery(searchQuery);
+    
+    if (!(isOnTagPath && isHashtagQuery)) {
+      updateUrlForSearch(searchQuery);
+    }
 
     // Abort any ongoing search
     if (abortControllerRef.current) {

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -695,13 +695,13 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
 
   // Helper function to update URL immediately when search is triggered
   const updateUrlForSearch = useCallback((searchQuery: string) => {
-    if (!manageUrl) return;
-    
     // If custom URL update handler is provided, use it instead
     if (onUrlUpdate) {
       onUrlUpdate(searchQuery);
       return;
     }
+    
+    if (!manageUrl) return;
     
     // Check if this is a hashtag-only query and we're not already on a profile page
     const currentProfileNpub = getCurrentProfileNpub(pathname);
@@ -998,9 +998,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
     if (isSlashCommand(raw)) {
       runSlashCommand(raw);
       setQuery(raw);
-      if (manageUrl) {
-        updateUrlForSearch(raw);
-      }
+      updateUrlForSearch(raw);
       // Clear prior results immediately before async search
       setResults([]);
       setTopCommandText(buildCli(raw.replace(/^\//, ''), topExamples ? topExamples : ''));
@@ -1251,9 +1249,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
                 e.stopPropagation();
                 const nextQuery = fullUrl;
                 setQuery(nextQuery);
-                if (manageUrl) {
-                  updateUrlForSearch(nextQuery);
-                }
+                updateUrlForSearch(nextQuery);
                 (async () => {
                   setLoading(true);
                   try {
@@ -1478,9 +1474,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
                   onClick={() => {
                     const q = token;
                     setQuery(q);
-                    if (manageUrl) {
-                      updateUrlForSearch(q);
-                    }
+                    updateUrlForSearch(q);
                     handleSearch(q);
                   }}
                 >
@@ -1561,9 +1555,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
                   onClick={() => {
                     const nextQuery = part;
                     setQuery(nextQuery);
-                    if (manageUrl) {
-                      updateUrlForSearch(nextQuery);
-                    }
+                    updateUrlForSearch(nextQuery);
                     handleSearch(nextQuery);
                   }}
                   className="text-blue-400 hover:text-blue-300 hover:underline cursor-pointer"
@@ -1584,9 +1576,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
                       onClick={() => {
                         const nextQuery = emojis[i] as string;
                         setQuery(nextQuery);
-                        if (manageUrl) {
-                          updateUrlForSearch(nextQuery);
-                        }
+                        updateUrlForSearch(nextQuery);
                         handleSearch(nextQuery);
                       }}
                       className="text-yellow-400 hover:text-yellow-300 hover:scale-110 transition-transform cursor-pointer"
@@ -1605,7 +1595,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
     });
 
     return finalNodes;
-  }, [stripPreviewUrls, stripMediaUrls, setQuery, manageUrl, handleSearch, setLoading, setResults, abortControllerRef, goToProfile, updateUrlForSearch]);
+  }, [stripPreviewUrls, stripMediaUrls, setQuery, handleSearch, setLoading, setResults, abortControllerRef, goToProfile, updateUrlForSearch]);
 
   const getReplyToEventId = useCallback((event: NDKEvent): string | null => {
     try {
@@ -1713,9 +1703,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
               onSearch={(targetUrl) => {
                 const nextQuery = targetUrl;
                 setQuery(nextQuery);
-                if (manageUrl) {
-                  updateUrlForSearch(nextQuery);
-                }
+                updateUrlForSearch(nextQuery);
                 (async () => {
                   setLoading(true);
                   try {
@@ -2017,9 +2005,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
                             className="text-left w-full hover:underline"
                             onClick={() => {
                               setQuery(ex);
-                              if (manageUrl) {
-                                updateUrlForSearch(ex);
-                              }
+                              updateUrlForSearch(ex);
                               handleSearch(ex);
                             }}
                           >
@@ -2088,9 +2074,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
                               const nevent = nip19.neventEncode({ id: event.id });
                               const q = nevent;
                               setQuery(q);
-                              if (manageUrl) {
-                                updateUrlForSearch(q);
-                              }
+                              updateUrlForSearch(q);
                               handleSearch(q);
                             } catch {}
                           }}
@@ -2166,9 +2150,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
                               const nevent = nip19.neventEncode({ id: event.id });
                               const q = nevent;
                               setQuery(q);
-                              if (manageUrl) {
-                                updateUrlForSearch(q);
-                              }
+                              updateUrlForSearch(q);
                               handleSearch(q);
                             } catch {}
                           }}
@@ -2246,9 +2228,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
                               const nevent = nip19.neventEncode({ id: event.id });
                               const q = nevent;
                               setQuery(q);
-                              if (manageUrl) {
-                                updateUrlForSearch(q);
-                              }
+                              updateUrlForSearch(q);
                               handleSearch(q);
                             } catch {}
                           }}
@@ -2281,9 +2261,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
                               const nevent = nip19.neventEncode({ id: event.id });
                               const q = nevent;
                               setQuery(q);
-                              if (manageUrl) {
-                                updateUrlForSearch(q);
-                              }
+                              updateUrlForSearch(q);
                               handleSearch(q);
                             } catch {}
                           }}
@@ -2311,9 +2289,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
                               const nevent = nip19.neventEncode({ id: event.id });
                               const q = nevent;
                               setQuery(q);
-                              if (manageUrl) {
-                                updateUrlForSearch(q);
-                              }
+                              updateUrlForSearch(q);
                               handleSearch(q);
                             } catch {}
                           }}

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -170,6 +170,7 @@ import { Highlight, themes, type RenderProps } from 'prism-react-renderer';
 type Props = {
   initialQuery?: string;
   manageUrl?: boolean;
+  onUrlUpdate?: (query: string) => void;
 };
 
 // Component to handle image loading with blurhash placeholder
@@ -456,7 +457,7 @@ function VideoWithBlurhash({
 
 // (Local AuthorBadge removed; using global `components/AuthorBadge` inside EventCard.)
 
-export default function SearchView({ initialQuery = '', manageUrl = true }: Props) {
+export default function SearchView({ initialQuery = '', manageUrl = true, onUrlUpdate }: Props) {
   const SLASH_COMMANDS = useMemo(() => ([
     { key: 'help', label: '/help', description: 'Show this help' },
     { key: 'examples', label: '/examples', description: 'List example queries' },
@@ -696,6 +697,12 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
   const updateUrlForSearch = useCallback((searchQuery: string) => {
     if (!manageUrl) return;
     
+    // If custom URL update handler is provided, use it instead
+    if (onUrlUpdate) {
+      onUrlUpdate(searchQuery);
+      return;
+    }
+    
     // Check if this is a hashtag-only query and we're not already on a profile page
     const currentProfileNpub = getCurrentProfileNpub(pathname);
     if (!currentProfileNpub && isHashtagOnlyQuery(searchQuery)) {
@@ -717,7 +724,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
       params.set('q', searchQuery);
       router.replace(`?${params.toString()}`);
     }
-  }, [manageUrl, pathname, searchParams, router]);
+  }, [manageUrl, onUrlUpdate, pathname, searchParams, router]);
 
   const handleSearch = useCallback(async (searchQuery: string) => {
     if (!searchQuery.trim()) {

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -726,6 +726,12 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
     }
   }, [manageUrl, onUrlUpdate, pathname, searchParams, router]);
 
+  // DRY helper function for setting query and updating URL
+  const setQueryAndUpdateUrl = useCallback((query: string) => {
+    setQuery(query);
+    updateUrlForSearch(query);
+  }, [updateUrlForSearch]);
+
   const handleSearch = useCallback(async (searchQuery: string) => {
     if (!searchQuery.trim()) {
       setResults([]);
@@ -1248,8 +1254,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
               onClick={(e) => { 
                 e.stopPropagation();
                 const nextQuery = fullUrl;
-                setQuery(nextQuery);
-                updateUrlForSearch(nextQuery);
+                setQueryAndUpdateUrl(nextQuery);
                 (async () => {
                   setLoading(true);
                   try {
@@ -1473,8 +1478,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
                   title="Search this reference"
                   onClick={() => {
                     const q = token;
-                    setQuery(q);
-                    updateUrlForSearch(q);
+                    setQueryAndUpdateUrl(q);
                     handleSearch(q);
                   }}
                 >
@@ -1575,8 +1579,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
                       key={`emoji-${segIndex}-${chunkIdx}-${subIdx}-${index}-${i}`}
                       onClick={() => {
                         const nextQuery = emojis[i] as string;
-                        setQuery(nextQuery);
-                        updateUrlForSearch(nextQuery);
+                        setQueryAndUpdateUrl(nextQuery);
                         handleSearch(nextQuery);
                       }}
                       className="text-yellow-400 hover:text-yellow-300 hover:scale-110 transition-transform cursor-pointer"
@@ -1595,7 +1598,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
     });
 
     return finalNodes;
-  }, [stripPreviewUrls, stripMediaUrls, setQuery, handleSearch, setLoading, setResults, abortControllerRef, goToProfile, updateUrlForSearch]);
+  }, [stripPreviewUrls, stripMediaUrls, setQuery, handleSearch, setLoading, setResults, abortControllerRef, goToProfile, setQueryAndUpdateUrl, updateUrlForSearch]);
 
   const getReplyToEventId = useCallback((event: NDKEvent): string | null => {
     try {
@@ -1702,8 +1705,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
               }}
               onSearch={(targetUrl) => {
                 const nextQuery = targetUrl;
-                setQuery(nextQuery);
-                updateUrlForSearch(nextQuery);
+                setQueryAndUpdateUrl(nextQuery);
                 (async () => {
                   setLoading(true);
                   try {
@@ -1725,7 +1727,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
         </div>
       )}
     </>
-  ), [extractImageUrlsFromText, extractVideoUrlsFromText, setQuery, manageUrl, updateUrlForSearch]);
+  ), [extractImageUrlsFromText, extractVideoUrlsFromText, setQuery, manageUrl, setQueryAndUpdateUrl, updateUrlForSearch]);
 
   const renderParentChain = useCallback((childEvent: NDKEvent, isTop: boolean = true): React.ReactNode => {
     const parentId = getReplyToEventId(childEvent);
@@ -2004,8 +2006,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
                             type="button"
                             className="text-left w-full hover:underline"
                             onClick={() => {
-                              setQuery(ex);
-                              updateUrlForSearch(ex);
+                              setQueryAndUpdateUrl(ex);
                               handleSearch(ex);
                             }}
                           >
@@ -2304,7 +2305,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
             })}
           </div>
         );
-      }, [fuseFilteredResults, expandedParents, manageUrl, goToProfile, handleSearch, renderContentWithClickableHashtags, renderNoteMedia, renderParentChain, getReplyToEventId, topCommandText, topExamples, extractVideoUrlsFromText, updateUrlForSearch])}
+      }, [fuseFilteredResults, expandedParents, manageUrl, goToProfile, handleSearch, renderContentWithClickableHashtags, renderNoteMedia, renderParentChain, getReplyToEventId, topCommandText, topExamples, extractVideoUrlsFromText, setQueryAndUpdateUrl, updateUrlForSearch])}
     </div>
   );
 }

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -1696,9 +1696,9 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       )}
       {extractNonMediaUrlsFromText(content).length > 0 && (
         <div className="mt-3 grid grid-cols-1 gap-3">
-          {extractNonMediaUrlsFromText(content).map((u) => (
+          {extractNonMediaUrlsFromText(content).map((u, index) => (
             <UrlPreview
-              key={u}
+              key={`url-${index}-${u}`}
               url={u}
               onLoaded={(loadedUrl) => {
                 setSuccessfulPreviews((prev) => {

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -1633,10 +1633,10 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
     <>
       {extractImageUrlsFromText(content).length > 0 && (
         <div className="mt-3 grid grid-cols-1 gap-3">
-          {extractImageUrlsFromText(content).map((src) => {
+          {extractImageUrlsFromText(content).map((src, index) => {
             const trimmedSrc = src.trim();
             return (
-            <div key={trimmedSrc} className="relative">
+            <div key={`image-${index}-${trimmedSrc}`} className="relative">
               {isAbsoluteHttpUrl(trimmedSrc) ? (
                 <ImageWithBlurhash
                   src={trimImageUrl(trimmedSrc)}
@@ -1676,10 +1676,10 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
       )}
       {extractVideoUrlsFromText(content).length > 0 && (
         <div className="mt-3 grid grid-cols-1 gap-3">
-          {extractVideoUrlsFromText(content).map((src) => {
+          {extractVideoUrlsFromText(content).map((src, index) => {
             const trimmedSrc = src.trim();
             return (
-            <div key={trimmedSrc} className="relative w-full overflow-hidden rounded-md border border-[#3d3d3d] bg-[#1f1f1f]">
+            <div key={`video-${index}-${trimmedSrc}`} className="relative w-full overflow-hidden rounded-md border border-[#3d3d3d] bg-[#1f1f1f]">
               <video controls playsInline className="w-full h-auto">
                 <source src={trimmedSrc} />
                 Your browser does not support the video tag.
@@ -2112,7 +2112,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
                               const dim = dimensions[idx] || dimensions[0];
                               const hash = hashes[idx] || hashes[0] || null;
                               return (
-                                <div key={src} className="relative">
+                                <div key={`image-${idx}-${src}`} className="relative">
                                   <ImageWithBlurhash
                                     src={trimImageUrl(src)}
                                     blurhash={blurhash}
@@ -2195,7 +2195,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true }: Prop
                               const dim = dimensions[idx] || dimensions[0];
                               const hash = hashes[idx] || hashes[0] || null;
                               return (
-                                <div key={src} className="relative">
+                                <div key={`video-${idx}-${src}`} className="relative">
                                   <VideoWithBlurhash
                                     src={trimImageUrl(src)}
                                     blurhash={blurhash}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -200,3 +200,16 @@ export function trimImageUrl(url?: string | null): string {
   if (typeof url !== 'string') return '';
   return url.trim();
 }
+
+/**
+ * Safely decodes a URI component, returning the original string if decoding fails
+ * @param s - The string to decode
+ * @returns The decoded string or the original string if decoding fails
+ */
+export function decodeMaybe(s: string): string {
+  try { 
+    return decodeURIComponent(s); 
+  } catch { 
+    return s; 
+  }
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -213,3 +213,35 @@ export function decodeMaybe(s: string): string {
     return s; 
   }
 }
+
+/**
+ * Checks if a query contains only hashtags (with OR operators)
+ * @param query - The search query to check
+ * @returns true if the query contains only hashtags
+ */
+export function isHashtagOnlyQuery(query: string): boolean {
+  if (!query.trim()) return false;
+  
+  // Remove OR operators and split by whitespace
+  const terms = query.replace(/\s+OR\s+/gi, ' ').trim().split(/\s+/);
+  
+  // Check if all terms are hashtags (start with #)
+  return terms.every(term => term.startsWith('#'));
+}
+
+/**
+ * Converts a hashtag query to URL-friendly format for /t/ path
+ * @param query - The hashtag query (e.g., "#pugstr OR #dogstr OR #goatstr")
+ * @returns URL-friendly hashtag string (e.g., "pugstr,dogstr,goatstr")
+ */
+export function hashtagQueryToUrl(query: string): string {
+  if (!isHashtagOnlyQuery(query)) return '';
+  
+  // Remove OR operators and split by whitespace
+  const terms = query.replace(/\s+OR\s+/gi, ' ').trim().split(/\s+/);
+  
+  // Remove # prefix and join with commas
+  return terms
+    .map(term => term.startsWith('#') ? term.slice(1) : term)
+    .join(',');
+}


### PR DESCRIPTION
Add hashtag-specific URL paths with `/t/[hashtags]` route for improved search UX

This PR introduces a new `/t/[hashtags]` route that allows users to search multiple hashtags with clean, shareable URLs. The implementation includes smart URL rewriting logic that keeps hashtag-only queries on the `/t/` path while redirecting mixed queries to the standard `/?q=` format. The route supports multiple hashtag formats including comma-separated, plus-separated, and space-separated syntax.

• Added `/t/[hashtags]` route with support for `pugstr,dogstr,goatstr` and `pugstr+dogstr+goatstr` formats
• Implemented smart URL rewriting that preserves hashtag-only queries on `/t/` path while redirecting mixed queries to `/?q=`
• Fixed React key duplication errors and infinite loop issues in SearchView component
• Updated README documentation with examples for all URL paths (`/p/`, `/e/`, `/t/`)
