### PR TITLE
fix: guard preview url regex

### DIFF
--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -1226,10 +1226,18 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
   const stripPreviewUrls = useCallback((text: string): string => {
     if (!text) return '';
     let cleaned = text;
-    successfulPreviews.forEach(url => {
-      const escapedUrl = url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      const regex = new RegExp(escapedUrl.replace(/[),.;]+$/, ''), 'gi');
-      cleaned = cleaned.replace(regex, '');
+    successfulPreviews.forEach((url) => {
+      if (!url) return;
+      const trimmedUrl = url.replace(/[),.;]+$/, '');
+      if (!trimmedUrl) return;
+      const escapedUrl = trimmedUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      try {
+        const regex = new RegExp(`${escapedUrl}[),.;]*`, 'gi');
+        cleaned = cleaned.replace(regex, '');
+      } catch (error) {
+        cleaned = cleaned.split(trimmedUrl).join('');
+        console.warn('Failed to strip preview URL', url, error);
+      }
     });
     return normalizeWhitespace(cleaned);
   }, [successfulPreviews, normalizeWhitespace]);


### PR DESCRIPTION
Guard preview URL regex creation and add fallback cleanup when RegExp construction fails to avoid runtime crashes from malformed URLs while stripping previews.
- skip empty entries before building regexes
- escape trimmed URLs to build safe patterns
- fallback to string replacement when regex creation throws
