### PR TITLE
feat: tighten highlight source URLs

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -13,7 +13,8 @@ import CardActions from '@/components/CardActions';
 import Nip05Display from '@/components/Nip05Display';
 import { parseHighlightEvent, HIGHLIGHTS_KIND } from '@/lib/highlights';
 import { compareTwoStrings } from 'string-similarity';
-import { shortenNevent, shortenNpub, extractDomainFromUrl } from '@/lib/utils';
+import { shortenNevent, shortenNpub } from '@/lib/utils';
+import { formatUrlResponsive } from '@/lib/utils/urlUtils';
 import { nip19 } from 'nostr-tools';
 import { ndk } from '@/lib/ndk';
 
@@ -247,21 +248,29 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
                     </button>
                     {sourceUrl ? (
                       // r tag - external URL
-                      <>
-                        <span className="font-medium">Source:</span>{' '}
-                        <SearchButton query={sourceUrl}>
-                          {extractDomainFromUrl(sourceUrl)}
-                        </SearchButton>
-                        <a
-                          href={sourceUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="ml-1 text-gray-500 hover:text-gray-400"
-                          title="Open in new tab"
-                        >
-                          <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-xs" />
-                        </a>
-                      </>
+                      (() => {
+                        const { displayText, fullUrl } = formatUrlResponsive(sourceUrl, {
+                          desktopMaxLength: 42,
+                          mobileMaxLength: 28
+                        });
+                        return (
+                          <>
+                            <span className="font-medium">Source:</span>{' '}
+                            <SearchButton query={fullUrl}>
+                              {displayText}
+                            </SearchButton>
+                            <a
+                              href={fullUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="ml-1 text-gray-500 hover:text-gray-400"
+                              title="Open in new tab"
+                            >
+                              <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-xs" />
+                            </a>
+                          </>
+                        );
+                      })()
                     ) : sourceEvent ? (
                       // a or e tag - nostr event
                       (() => {

--- a/src/lib/relativeTime.ts
+++ b/src/lib/relativeTime.ts
@@ -1,12 +1,11 @@
 import RelativeTimeFormat from 'relative-time-format';
 import en from 'relative-time-format/locale/en.json';
-import { isBrowser } from '@/lib/utils/ssr';
+import { isMobileViewport as detectMobileViewport } from '@/lib/utils/ssr';
 
 // Add the English locale data
 RelativeTimeFormat.addLocale(en);
 
 // Constants for time calculations
-const MOBILE_BREAKPOINT = 768;
 const SECONDS_IN_MINUTE = 60;
 const MINUTES_IN_HOUR = 60;
 const HOURS_IN_DAY = 24;
@@ -23,9 +22,10 @@ const formatters = {
  * Detects if the current viewport is mobile
  * @returns boolean indicating if the viewport is mobile
  */
+const MOBILE_BREAKPOINT = 768;
+
 function isMobileViewport(): boolean {
-  if (!isBrowser()) return false;
-  return window.innerWidth < MOBILE_BREAKPOINT;
+  return detectMobileViewport(MOBILE_BREAKPOINT);
 }
 
 /**

--- a/src/lib/utils/ssr.ts
+++ b/src/lib/utils/ssr.ts
@@ -11,6 +11,16 @@ export function isBrowser(): boolean {
 }
 
 /**
+ * Checks if the current viewport width is considered mobile
+ * @param breakpoint - Optional breakpoint width (default: 768px)
+ * @returns true if running in browser and viewport width is below breakpoint
+ */
+export function isMobileViewport(breakpoint: number = 768): boolean {
+  if (!isBrowser()) return false;
+  return window.innerWidth < breakpoint;
+}
+
+/**
  * Safely executes a function only in browser environment
  * @param fn - Function to execute
  * @param fallback - Value to return if not in browser

--- a/src/lib/utils/urlUtils.ts
+++ b/src/lib/utils/urlUtils.ts
@@ -156,6 +156,47 @@ export function formatUrlForDisplay(url: string, maxLength: number = 40): {
 }
 
 /**
+ * Get responsive URL display text based on viewport width
+ * @param url - The URL to format
+ * @param options - Optional configuration for desktop and mobile max lengths
+ * @returns Display text tailored for desktop and mobile along with metadata
+ */
+export function formatUrlResponsive(
+  url: string,
+  options: {
+    desktopMaxLength?: number;
+    mobileMaxLength?: number;
+    breakpoint?: number;
+  } = {}
+): {
+  displayText: string;
+  fullUrl: string;
+  isShortened: boolean;
+} {
+  const {
+    desktopMaxLength = 40,
+    mobileMaxLength = 28,
+    breakpoint = 768
+  } = options;
+
+  if (!url) {
+    return { displayText: '', fullUrl: '', isShortened: false };
+  }
+
+  const fullUrl = url;
+  const isMobile = isMobileViewport(breakpoint);
+  const maxLength = isMobile ? mobileMaxLength : desktopMaxLength;
+  const shortened = shortenUrl(url, { maxLength, showProtocol: false, showPath: true });
+  const isShortened = shortened.length < url.length;
+
+  return {
+    displayText: shortened,
+    fullUrl,
+    isShortened
+  };
+}
+
+/**
  * Check if a string is a valid HTTP/HTTPS URL
  * @param value - The value to check
  * @returns True if it's a valid HTTP/HTTPS URL

--- a/src/lib/utils/urlUtils.ts
+++ b/src/lib/utils/urlUtils.ts
@@ -1,3 +1,5 @@
+import { isMobileViewport } from '@/lib/utils/ssr';
+
 // Centralized URL utilities (DRY approach)
 // Consolidates all URL handling logic from across the codebase
 


### PR DESCRIPTION
Ensure highlight cards show source URLs on a single line across devices by extending the shared URL utilities and reusing the new `isMobileViewport` helper.

- add `formatUrlResponsive` to centralize viewport-aware shortening
- update highlight source rendering to consume the shared shortening logic
- expose a reusable `isMobileViewport` helper in SSR utilities
