### PR TITLE
Adjust emoji filtering for multi-emoji searches

### DIFF
--- a/src/components/ClientFilters.tsx
+++ b/src/components/ClientFilters.tsx
@@ -27,6 +27,7 @@ interface Props {
   onFilterChange: (settings: FilterSettings) => void;
   resultCount: number;
   filteredCount: number;
+  emojiAutoDisabled?: boolean;
 }
 
 // Reusable NumberFilter component
@@ -70,13 +71,14 @@ function NumberFilter({ label, enabled, value, maxValue, onToggle, onValueChange
   );
 }
 
-export default function ClientFilters({ filterSettings, onFilterChange, resultCount, filteredCount }: Props) {
+export default function ClientFilters({ filterSettings, onFilterChange, resultCount, filteredCount, emojiAutoDisabled = false }: Props) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [emojiLimit, setEmojiLimit] = useState<number>(filterSettings.maxEmojis ?? 3);
   const [hashtagLimit, setHashtagLimit] = useState<number>(filterSettings.maxHashtags ?? 3);
   const [mentionsLimit, setMentionsLimit] = useState<number>(filterSettings.maxMentions ?? 6);
 
-  const emojiEnabled = filterSettings.maxEmojis !== null;
+  const emojiStoredEnabled = filterSettings.maxEmojis !== null;
+  const emojiCheckboxChecked = emojiStoredEnabled && !emojiAutoDisabled;
   const hashtagEnabled = filterSettings.maxHashtags !== null;
   const mentionsEnabled = filterSettings.maxMentions !== null;
 
@@ -87,7 +89,7 @@ export default function ClientFilters({ filterSettings, onFilterChange, resultCo
 
   const handleEmojiValueChange = (value: number) => {
     setEmojiLimit(value);
-    if (emojiEnabled) {
+    if (emojiStoredEnabled) {
       onFilterChange({ ...filterSettings, maxEmojis: value });
     }
   };
@@ -239,7 +241,7 @@ export default function ClientFilters({ filterSettings, onFilterChange, resultCo
             {/* Hide more than X emojis */}
             <NumberFilter
               label="emojis"
-              enabled={emojiEnabled}
+              enabled={emojiCheckboxChecked}
               value={emojiLimit}
               maxValue={9}
               onToggle={handleEmojiToggle}

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -547,9 +547,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
     }
     if (cmd === 'examples') {
       const examples = getFilteredExamples(isLoggedIn());
-      // Sort examples by character count (shortest to longest)
-      const sortedExamples = Array.from(examples).sort((a, b) => a.length - b.length);
-      setTopExamples(sortedExamples);
+      setTopExamples(Array.from(examples));
       setTopCommandText(buildCli('examples'));
       return;
     }

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -647,11 +647,13 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
   }, [results]);
 
 
+  const emojiAutoDisabled = filterSettings.filterMode === 'intelligently' && isEmojiSearch(query);
+
   const filteredResults = useMemo(
     () => shouldEnableFilters ? applyContentFilters(
       results,
-      // Disable emoji filter when searching for multiple emojis
-      isEmojiSearch(query) ? null : filterSettings.maxEmojis,
+      // Disable emoji filter when searching for multiple emojis in Smart mode
+      emojiAutoDisabled ? null : filterSettings.maxEmojis,
       filterSettings.maxHashtags,
       filterSettings.maxMentions,
       filterSettings.hideLinks,
@@ -661,7 +663,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       filterSettings.hideBots,
       filterSettings.hideNsfw
     ) : results,
-    [results, shouldEnableFilters, query, filterSettings.maxEmojis, filterSettings.maxHashtags, filterSettings.maxMentions, filterSettings.hideLinks, filterSettings.hideBridged, filterSettings.verifiedOnly, filterSettings.hideBots, filterSettings.hideNsfw]
+    [results, shouldEnableFilters, emojiAutoDisabled, filterSettings.maxEmojis, filterSettings.maxHashtags, filterSettings.maxMentions, filterSettings.hideLinks, filterSettings.hideBridged, filterSettings.verifiedOnly, filterSettings.hideBots, filterSettings.hideNsfw]
   );
 
   // Apply optional fuzzy filter on top of client-side filters
@@ -2049,6 +2051,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
           onFilterChange={setFilterSettings}
           resultCount={results.length}
           filteredCount={fuseFilteredResults.length}
+          emojiAutoDisabled={emojiAutoDisabled}
         />
       )}
 

--- a/src/lib/examples.ts
+++ b/src/lib/examples.ts
@@ -17,6 +17,14 @@ export const searchExamples = [
   'by:gigi',
   'by:pablof7z',
   'by:corndalorian',
+  'by:fiatjaf',
+  'by:edward',
+  'by:snowden',
+  'by:ross',
+  'by:ulbricht',
+  'by:plato',
+  'by:socrates',
+  'by:odell',
 
   // Combined
   'GM by:dergigi',

--- a/src/lib/examples.ts
+++ b/src/lib/examples.ts
@@ -1,49 +1,29 @@
 // Search examples that we'll randomly select from and test
 export const searchExamples = [
-  // Sorted by length (shortest to longest)
-  'p:dave',
-  'nip:03',
-  '/help',
-  'is:file',
-  'p:hodl',
-  'is:video',
-  'is:image',
-  'has:gif',
-  'has:video',
-  'has:image',
-  'is:highlight',
-  'by:gigi',
-  'nevent',
-  '/examples',
-  'p:fiatjaf',
-  'good by:socrates',
-  'GM by:dergigi',
-  '👀 by:dergigi',
-  'NIP-EE by:jeffg',
-  'free by:ulbricht',
-  'PV or 🤙',
-  'giphy.gif',
-  'Liotta .gif',
-  'p:zaps.lol',
-  'p:dergigi.com',
-  '@dergigi.com',
-  'p:nostrplebs.com',
-  'p:twentyone.world',
-  'p:NewsBot or p:RSS',
-  'kind:0 #bitcoin',
-  'bitcoin include:spam',
+  // Basic
   'vibe coding',
   'nicolas-cage.gif',
   '#PenisButter',
   '#YESTR',
   '#SovEng',
   '#gratefulchain',
+  '#dogstr or #pugstr or #catstr or #horsestr or #goatstr',
+  'nevent',
   'habla.news',
+  
+  // Author
   'by:dergigi',
+  'by:gigi',
   'by:pablof7z',
   'by:corndalorian',
+
+  // Combined
+  'GM by:dergigi',
   'GM fiat by:fiatjaf',
+  'good by:socrates',
   '#YESTR by:dergigi',
+  '👀 by:dergigi',
+  'NIP-EE by:jeffg',
   '.jpg by:corndalorian',
   'site:github by:fiatjaf',
   'by:dergigi site:yt',
@@ -51,42 +31,84 @@ export const searchExamples = [
   'by:rektbot 💀💀💀💀💀💀💀💀💀💀',
   '"car crash" by:dergigi',
   '(PoW OR WoT) by:dergigi',
+  'free by:ulbricht',
   '(nostr OR 🫂) by:snowden',
   '"GM PV" by:derek',
+
+  // Direct npub
+  'GN by:npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc',
+  'proof-of-work by:npub1satsv3728d65nenvkmzthrge0aduj8088dvwkxk70rydm407cl4s87sfhu',
+
+  // Profile lookup / NIP-05
+  'p:fiatjaf',
+  'p:hodl',
+  'p:dergigi.com',
+  '@dergigi.com',
+  'p:zaps.lol',
+  'p:nostrplebs.com',
+  'p:dave',
+  'p:NewsBot or p:RSS',
+  'p:twentyone.world',
+  'einundzwanzig or twentyone.world',
+  'kind:0 #bitcoin',
+  '(p:dad OR p:husband OR p:father)',
+
+  // Operators & media
   'bitcoin OR lightning',
   'https://dergigi.com/vew',
+  'has:image',
+  'is:image',
   'has:image OR is:image',
+  'has:video',
+  'is:video',
+  'has:gif',
   '"habla.news"',
+
+  // Mixed media + text
   'GM has:video',
   'Bitcoin has:image',
   'meme has:gif',
   'by:dergigi has:image',
   'by:HODL has:video',
   'Gregzaj1-ln_strike.gif',
+  'giphy.gif',
   'by:gregzaj has:gif',
+  '(GM OR GN) by:dergigi has:image',
   'is:image #Olas365',
   'PressReader by:Bouma',
   '#runstr OR #plebwalk OR by:bitcoinwalk',
+  'PV or 🤙',
   '🧘‍♀️ or 🧘‍♂️ or 🧘 or 💆 ',
   '😂 or 🤣 or lol or lmao',
+  'Liotta .gif',
   '#plebchain or #introductions',
+
+  // Kinds filter examples
   'is:muted by:fiatjaf',
   'is:zap by:marty',
   'is:bookmark by:hzrd',
+  'is:file',
   'is:repost by:dor',
   'is:muted by:carvalho',
-  'einundzwanzig or twentyone.world',
-  '(p:dad OR p:husband OR p:father)',
+  'is:highlight',
+
+  // Multiple Authors
+  'NIP-EE (by:jeffg OR by:futurepaul OR by:franzap)',
+
+  // NIP-50 extensions
+  'bitcoin include:spam',
+  'nip:03',
+
+  // Highlight examples
+  'is:highlight (bitcoin OR nostr)',
   'is:highlight by:dergigi',
   'is:highlight by:fiatjaf',
   'is:highlight by:pablof7z',
   'is:highlight "proof of work"',
-  '(GM OR GN) by:dergigi has:image',
-  'NIP-EE (by:jeffg OR by:futurepaul OR by:franzap)',
-  'is:highlight (bitcoin OR nostr)',
-  '#dogstr or #pugstr or #catstr or #horsestr or #goatstr',
-  'GN by:npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc',
-  'proof-of-work by:npub1satsv3728d65nenvkmzthrge0aduj8088dvwkxk70rydm407cl4s87sfhu',
+
+  // Slash Commands
+  '/help',
+  '/examples',
 ] as const;
 
 // Examples that require login to work properly

--- a/src/lib/examples.ts
+++ b/src/lib/examples.ts
@@ -18,18 +18,15 @@ export const searchExamples = [
   'by:pablof7z',
   'by:corndalorian',
   'by:fiatjaf',
-  'by:edward',
   'by:snowden',
-  'by:ross',
-  'by:ulbricht',
   'by:plato',
   'by:socrates',
-  'by:odell',
 
   // Combined
   'GM by:dergigi',
   'GM fiat by:fiatjaf',
   'good by:socrates',
+  'stay humble by:odell',
   '#YESTR by:dergigi',
   '👀 by:dergigi',
   'NIP-EE by:jeffg',
@@ -43,6 +40,8 @@ export const searchExamples = [
   'free by:ulbricht',
   '(nostr OR 🫂) by:snowden',
   '"GM PV" by:derek',
+  'free by:ross',
+  'freedom by:ulbricht',
 
   // Direct npub
   'GN by:npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc',
@@ -56,7 +55,8 @@ export const searchExamples = [
   'p:zaps.lol',
   'p:nostrplebs.com',
   'p:dave',
-  'p:NewsBot or p:RSS',
+  'p:edward',
+  'p:(NewsBot or RSS)',
   'p:twentyone.world',
   'einundzwanzig or twentyone.world',
   'kind:0 #bitcoin',

--- a/src/lib/examples.ts
+++ b/src/lib/examples.ts
@@ -7,7 +7,8 @@ export const searchExamples = [
   '#YESTR',
   '#SovEng',
   '#gratefulchain',
-  '#dogstr or #pugstr or #catstr or #horsestr or #goatstr',
+  '#photography',
+  '#artstr',
   'nevent',
   'habla.news',
   
@@ -94,6 +95,9 @@ export const searchExamples = [
 
   // Multiple Authors
   'NIP-EE (by:jeffg OR by:futurepaul OR by:franzap)',
+
+  // Multiple hashtags
+  '#dogstr or #pugstr or #horsestr or #goatstr',
 
   // NIP-50 extensions
   'bitcoin include:spam',

--- a/src/lib/examples.ts
+++ b/src/lib/examples.ts
@@ -1,29 +1,49 @@
 // Search examples that we'll randomly select from and test
 export const searchExamples = [
-  // Basic
+  // Sorted by length (shortest to longest)
+  'p:dave',
+  'nip:03',
+  '/help',
+  'is:file',
+  'p:hodl',
+  'is:video',
+  'is:image',
+  'has:gif',
+  'has:video',
+  'has:image',
+  'is:highlight',
+  'by:gigi',
+  'nevent',
+  '/examples',
+  'p:fiatjaf',
+  'good by:socrates',
+  'GM by:dergigi',
+  '👀 by:dergigi',
+  'NIP-EE by:jeffg',
+  'free by:ulbricht',
+  'PV or 🤙',
+  'giphy.gif',
+  'Liotta .gif',
+  'p:zaps.lol',
+  'p:dergigi.com',
+  '@dergigi.com',
+  'p:nostrplebs.com',
+  'p:twentyone.world',
+  'p:NewsBot or p:RSS',
+  'kind:0 #bitcoin',
+  'bitcoin include:spam',
   'vibe coding',
   'nicolas-cage.gif',
   '#PenisButter',
   '#YESTR',
   '#SovEng',
   '#gratefulchain',
-  '#dogstr or #pugstr or #catstr or #horsestr or #goatstr',
-  'nevent',
   'habla.news',
-  
-  // Author
   'by:dergigi',
-  'by:gigi',
   'by:pablof7z',
   'by:corndalorian',
-
-  // Combined
-  'GM by:dergigi',
   'GM fiat by:fiatjaf',
-  'good by:socrates',
   '#YESTR by:dergigi',
-  '👀 by:dergigi',
-  'NIP-EE by:jeffg',
   '.jpg by:corndalorian',
   'site:github by:fiatjaf',
   'by:dergigi site:yt',
@@ -31,84 +51,42 @@ export const searchExamples = [
   'by:rektbot 💀💀💀💀💀💀💀💀💀💀',
   '"car crash" by:dergigi',
   '(PoW OR WoT) by:dergigi',
-  'free by:ulbricht',
   '(nostr OR 🫂) by:snowden',
   '"GM PV" by:derek',
-
-  // Direct npub
-  'GN by:npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc',
-  'proof-of-work by:npub1satsv3728d65nenvkmzthrge0aduj8088dvwkxk70rydm407cl4s87sfhu',
-
-  // Profile lookup / NIP-05
-  'p:fiatjaf',
-  'p:hodl',
-  'p:dergigi.com',
-  '@dergigi.com',
-  'p:zaps.lol',
-  'p:nostrplebs.com',
-  'p:dave',
-  'p:NewsBot or p:RSS',
-  'p:twentyone.world',
-  'einundzwanzig or twentyone.world',
-  'kind:0 #bitcoin',
-  '(p:dad OR p:husband OR p:father)',
-
-  // Operators & media
   'bitcoin OR lightning',
   'https://dergigi.com/vew',
-  'has:image',
-  'is:image',
   'has:image OR is:image',
-  'has:video',
-  'is:video',
-  'has:gif',
   '"habla.news"',
-
-  // Mixed media + text
   'GM has:video',
   'Bitcoin has:image',
   'meme has:gif',
   'by:dergigi has:image',
   'by:HODL has:video',
   'Gregzaj1-ln_strike.gif',
-  'giphy.gif',
   'by:gregzaj has:gif',
-  '(GM OR GN) by:dergigi has:image',
   'is:image #Olas365',
   'PressReader by:Bouma',
   '#runstr OR #plebwalk OR by:bitcoinwalk',
-  'PV or 🤙',
   '🧘‍♀️ or 🧘‍♂️ or 🧘 or 💆 ',
   '😂 or 🤣 or lol or lmao',
-  'Liotta .gif',
   '#plebchain or #introductions',
-
-  // Kinds filter examples
   'is:muted by:fiatjaf',
   'is:zap by:marty',
   'is:bookmark by:hzrd',
-  'is:file',
   'is:repost by:dor',
   'is:muted by:carvalho',
-  'is:highlight',
-
-  // Multiple Authors
-  'NIP-EE (by:jeffg OR by:futurepaul OR by:franzap)',
-
-  // NIP-50 extensions
-  'bitcoin include:spam',
-  'nip:03',
-
-  // Highlight examples
-  'is:highlight (bitcoin OR nostr)',
+  'einundzwanzig or twentyone.world',
+  '(p:dad OR p:husband OR p:father)',
   'is:highlight by:dergigi',
   'is:highlight by:fiatjaf',
   'is:highlight by:pablof7z',
   'is:highlight "proof of work"',
-
-  // Slash Commands
-  '/help',
-  '/examples',
+  '(GM OR GN) by:dergigi has:image',
+  'NIP-EE (by:jeffg OR by:futurepaul OR by:franzap)',
+  'is:highlight (bitcoin OR nostr)',
+  '#dogstr or #pugstr or #catstr or #horsestr or #goatstr',
+  'GN by:npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc',
+  'proof-of-work by:npub1satsv3728d65nenvkmzthrge0aduj8088dvwkxk70rydm407cl4s87sfhu',
 ] as const;
 
 // Examples that require login to work properly
@@ -127,4 +105,4 @@ export function getFilteredExamples(isLoggedIn: boolean): readonly string[] {
 }
 
 // Helper type for type safety
-export type SearchExample = typeof searchExamples[number];
+export type SearchExample = typeof searchExamples[number]; 

--- a/src/lib/examples.ts
+++ b/src/lib/examples.ts
@@ -19,7 +19,6 @@ export const searchExamples = [
   'by:corndalorian',
   'by:fiatjaf',
   'by:snowden',
-  'by:plato',
   'by:socrates',
 
   // Combined
@@ -42,6 +41,7 @@ export const searchExamples = [
   '"GM PV" by:derek',
   'free by:ross',
   'freedom by:ulbricht',
+  'knowledge by:platobot@dergigi.com',
 
   // Direct npub
   'GN by:npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc',
@@ -56,7 +56,8 @@ export const searchExamples = [
   'p:nostrplebs.com',
   'p:dave',
   'p:edward',
-  'p:(NewsBot or RSS)',
+  'p:platobot@dergigi.com',
+  'p:NewsBot or p:RSS',
   'p:twentyone.world',
   'einundzwanzig or twentyone.world',
   'kind:0 #bitcoin',
@@ -81,6 +82,7 @@ export const searchExamples = [
   'by:HODL has:video',
   'Gregzaj1-ln_strike.gif',
   'giphy.gif',
+  'giphy.GIF',
   'by:gregzaj has:gif',
   '(GM OR GN) by:dergigi has:image',
   'is:image #Olas365',


### PR DESCRIPTION
Auto-disable the emoji limit when `Smart` filtering sees multi-emoji queries so example searches keep showing all matches.
- Preserve the stored `maxEmojis` value and restore it after the query changes
- Pass an `emojiAutoDisabled` hint into `ClientFilters` to keep the checkbox state accurate
