### PR TITLE
Fix profile scope detection for NIP-05 identifiers

### DIFF
--- a/src/components/ProfileScopeIndicator.tsx
+++ b/src/components/ProfileScopeIndicator.tsx
@@ -1,0 +1,47 @@
+import { NDKUser } from '@nostr-dev-kit/ndk';
+import Image from 'next/image';
+import { shortenNpub, trimImageUrl } from '@/lib/utils';
+
+interface ProfileScopeIndicatorProps {
+  user: NDKUser | null;
+  isEnabled: boolean;
+  onToggle: () => void;
+}
+
+export default function ProfileScopeIndicator({ 
+  user, 
+  isEnabled, 
+  onToggle 
+}: ProfileScopeIndicatorProps) {
+  if (!user) return null;
+
+  return (
+    <div className="flex items-center">
+      <button
+        type="button"
+        onClick={onToggle}
+        className={`w-10 h-10 rounded-lg overflow-hidden border transition-all duration-200 hover:opacity-80 ${
+          isEnabled
+            ? 'bg-[#3d3d3d] border-green-400 shadow-sm'
+            : 'bg-[#2d2d2d] border-gray-600 opacity-50 grayscale'
+        }`}
+        title={isEnabled ? 'Disable profile scoping' : 'Enable profile scoping'}
+      >
+        {user.profile?.image ? (
+          <Image
+            src={trimImageUrl(user.profile.image)}
+            alt="Profile"
+            width={40}
+            height={40}
+            className="w-full h-full object-cover"
+            unoptimized
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-xs text-gray-300">
+            {(user.profile?.displayName || user.profile?.name || shortenNpub(user.npub)).slice(0, 2).toUpperCase()}
+          </div>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -2004,7 +2004,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
   }, [getReplyToEventId, expandedParents, setExpandedParents, fetchEventById, renderNoteMedia, goToProfile, renderContentWithClickableHashtags]);
 
   return (
-    <div className={`w-full ${(results.length > 0 || topCommandText) ? 'pt-4' : 'min-h-screen flex items-center'}`}>
+    <div className="w-full pt-4">
       <form ref={searchRowRef} onSubmit={handleSubmit} className={`w-full ${avatarOverlap ? 'pr-16' : ''}`} id="search-row">
         <div className="flex gap-2">
           <ProfileScopeIndicator 

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -77,7 +77,7 @@ function ProfileScopeIndicator({
       <button
         type="button"
         onClick={onToggle}
-        className={`w-10 h-10 rounded-lg overflow-hidden border-2 transition-all duration-200 hover:opacity-80 ${
+        className={`w-10 h-10 rounded-lg overflow-hidden border transition-all duration-200 hover:opacity-80 ${
           isEnabled
             ? 'bg-[#3d3d3d] border-green-400 shadow-sm'
             : 'bg-[#2d2d2d] border-gray-600 opacity-50 grayscale'

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -60,6 +60,32 @@ function SearchIconButton({
   );
 }
 
+// Profile scope indicator component
+function ProfileScopeIndicator({ user }: { user: NDKUser | null }) {
+  if (!user) return null;
+
+  return (
+    <div className="flex items-center">
+      <div className="w-10 h-10 rounded-lg overflow-hidden bg-[#3d3d3d] border border-[#3d3d3d]">
+        {user.profile?.image ? (
+          <Image
+            src={trimImageUrl(user.profile.image)}
+            alt="Profile"
+            width={40}
+            height={40}
+            className="w-full h-full object-cover"
+            unoptimized
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-xs text-gray-300">
+            {(user.profile?.displayName || user.profile?.name || shortenNpub(user.npub)).slice(0, 2).toUpperCase()}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 // Component for truncating long text with fade effect and expand arrow
 function TruncatedText({ 
   content, 
@@ -1918,26 +1944,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
     <div className={`w-full ${(results.length > 0 || topCommandText) ? 'pt-4' : 'min-h-screen flex items-center'}`}>
       <form ref={searchRowRef} onSubmit={handleSubmit} className={`w-full ${avatarOverlap ? 'pr-16' : ''}`} id="search-row">
         <div className="flex gap-2">
-          {profileScopeUser && (
-            <div className="flex items-center">
-              <div className="w-10 h-10 rounded-lg overflow-hidden bg-[#3d3d3d] border border-[#3d3d3d]">
-                {profileScopeUser.profile?.image ? (
-                  <Image
-                    src={trimImageUrl(profileScopeUser.profile.image)}
-                    alt="Profile"
-                    width={40}
-                    height={40}
-                    className="w-full h-full object-cover"
-                    unoptimized
-                  />
-                ) : (
-                  <div className="w-full h-full flex items-center justify-center text-xs text-gray-300">
-                    {(profileScopeUser.profile?.displayName || profileScopeUser.profile?.name || shortenNpub(profileScopeUser.npub)).slice(0, 2).toUpperCase()}
-                  </div>
-                )}
-              </div>
-            </div>
-          )}
+          <ProfileScopeIndicator user={profileScopeUser} />
           <div className="flex-1 relative">
             <input
               ref={searchInputRef}

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -636,6 +636,8 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
   // Simple input change handler: update local query state; searches run on submit
   const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value;
+    // Prevent any side-effects from interpreting this edit as a search trigger
+    suppressSearchRef.current = true;
     setQuery(newValue);
 
     // Detect if user manually removed the by:<current npub or nip05> filter
@@ -656,6 +658,8 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
         setProfileScopingEnabled(false);
       }
     }
+    // Release suppression on next tick so explicit submit still works
+    setTimeout(() => { suppressSearchRef.current = false; }, 0);
   }, [setQuery, pathname, profileScopeUser?.profile?.nip05, profileScopingEnabled, userManuallyDisabledScoping]);
 
   // Memoized client-side filtered results (for count and rendering)

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -1105,8 +1105,9 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
         runSlashCommand(urlQuery);
         handleSearch(urlQuery);
       } else {
-        // Use NIP-05 if available for display, otherwise use npub
-        const displayIdentifier = profileScopeUser?.profile?.nip05 || currentProfileNpub;
+        // Use normalized NIP-05 if available for display, otherwise use npub
+        const identifiers = getProfileScopeIdentifiers(profileScopeUser, currentProfileNpub);
+        const displayIdentifier = identifiers?.profileIdentifier || currentProfileNpub;
         const display = toExplicitInputFromUrl(urlQuery, currentProfileNpub, displayIdentifier);
         setQuery(display);
         const backend = ensureAuthorForBackend(urlQuery, currentProfileNpub);
@@ -1122,7 +1123,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       if (isSlashCommand(urlQuery)) runSlashCommand(urlQuery);
       handleSearch(urlQuery);
     }
-  }, [searchParams, handleSearch, manageUrl, pathname, router, runSlashCommand, isSlashCommand, profileScopeUser?.profile?.nip05]);
+  }, [searchParams, handleSearch, manageUrl, pathname, router, runSlashCommand, isSlashCommand, profileScopeUser, profileScopeIdentifiers?.profileIdentifier]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -77,10 +77,10 @@ function ProfileScopeIndicator({
       <button
         type="button"
         onClick={onToggle}
-        className={`w-10 h-10 rounded-lg overflow-hidden border transition-all duration-200 hover:opacity-80 ${
-          isEnabled 
-            ? 'bg-[#3d3d3d] border-[#3d3d3d]' 
-            : 'bg-[#2d2d2d] border-[#5d5d5d] opacity-60'
+        className={`w-10 h-10 rounded-lg overflow-hidden border-2 transition-all duration-200 hover:opacity-80 ${
+          isEnabled
+            ? 'bg-[#3d3d3d] border-green-400 shadow-sm'
+            : 'bg-[#2d2d2d] border-gray-600 opacity-50 grayscale'
         }`}
         title={isEnabled ? 'Disable profile scoping' : 'Enable profile scoping'}
       >

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -819,20 +819,13 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
         const decoded = nip19.decode(currentProfileNpub);
         if (decoded?.type === 'npub' && typeof decoded.data === 'string') {
           const pubkey = decoded.data;
-          const u = new NDKUser({ pubkey });
-          u.ndk = ndk;
+          const user = new NDKUser({ pubkey });
+          user.ndk = ndk;
           // Set immediately so the indicator renders (initials) while profile loads
-          setProfileScopeUser(u);
-          // Fetch profile to get image/nip05, then force a re-render with a new instance
-          try {
-            await u.fetchProfile();
-            const refreshed = new NDKUser({ pubkey });
-            refreshed.ndk = ndk;
-            (refreshed as unknown as { profile?: unknown }).profile = u.profile;
-            setProfileScopeUser(refreshed);
-          } catch {
-            // Continue even if profile fetch fails
-          }
+          setProfileScopeUser(user);
+          // Fetch profile to get image/nip05, then set the same instance again to refresh UI
+          try { await user.fetchProfile(); } catch {}
+          setProfileScopeUser(user);
         } else {
           setProfileScopeUser(null);
         }

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -636,8 +636,6 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
   // Simple input change handler: update local query state; searches run on submit
   const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value;
-    // Prevent any side-effects from interpreting this edit as a search trigger
-    suppressSearchRef.current = true;
     setQuery(newValue);
 
     // Detect if user manually removed the by:<current npub or nip05> filter
@@ -858,7 +856,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
     const nip05 = profileScopeUser?.profile?.nip05 as string | undefined;
     const currentProfileNpub = getCurrentProfileNpub(pathname);
     if (!nip05 || !currentProfileNpub) return;
-    const rx = new RegExp(`(^|\\s)by:${currentProfileNpub}(?=\\s|$)`, 'i');
+    const rx = new RegExp(`(^|\\s)by:${currentProfileNpub}(?=\\s|$)`, 'gi');
     if (rx.test(query)) {
       const updated = query.replace(rx, (m, pre) => `${pre}by:${nip05}`).replace(/\s{2,}/g, ' ').trim();
       if (updated !== query) setQuery(updated);

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -779,7 +779,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
     };
 
     setupProfileUser();
-  }, [manageUrl, pathname, query, ndk]);
+  }, [manageUrl, pathname, query]);
   const handleSearch = useCallback(async (searchQuery: string) => {
     if (!searchQuery.trim()) {
       setResults([]);
@@ -1092,7 +1092,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       if (isSlashCommand(urlQuery)) runSlashCommand(urlQuery);
       handleSearch(urlQuery);
     }
-  }, [searchParams, handleSearch, manageUrl, pathname, router, runSlashCommand, isSlashCommand]);
+  }, [searchParams, handleSearch, manageUrl, pathname, router, runSlashCommand, isSlashCommand, profileScopeUser?.profile?.nip05]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -1918,13 +1918,13 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
         <div className="flex gap-2">
           {profileScopeUser && (
             <div className="flex items-center">
-              <div className="w-8 h-8 rounded-lg overflow-hidden bg-[#3d3d3d] border border-[#3d3d3d]">
+              <div className="w-10 h-10 rounded-lg overflow-hidden bg-[#3d3d3d] border border-[#3d3d3d]">
                 {profileScopeUser.profile?.image ? (
                   <Image
                     src={trimImageUrl(profileScopeUser.profile.image)}
                     alt="Profile"
-                    width={32}
-                    height={32}
+                    width={40}
+                    height={40}
                     className="w-full h-full object-cover"
                     unoptimized
                   />

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -1965,7 +1965,30 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
           <ProfileScopeIndicator 
             user={profileScopeUser} 
             isEnabled={profileScopingEnabled}
-            onToggle={() => setProfileScopingEnabled(!profileScopingEnabled)}
+            onToggle={() => {
+              const newEnabled = !profileScopingEnabled;
+              setProfileScopingEnabled(newEnabled);
+              
+              // Update the search box content without triggering search
+              const currentProfileNpub = getCurrentProfileNpub(pathname);
+              if (currentProfileNpub) {
+                const currentQuery = query.trim();
+                const hasExplicitBy = /(^|\s)by:\S+(?=\s|$)/i.test(currentQuery);
+                
+                if (newEnabled && !hasExplicitBy) {
+                  // Add by: filter
+                  let byValue = currentProfileNpub;
+                  if (profileScopeUser?.profile?.nip05) {
+                    byValue = profileScopeUser.profile.nip05;
+                  }
+                  setQuery(`${currentQuery} by:${byValue}`.trim());
+                } else if (!newEnabled && hasExplicitBy) {
+                  // Remove by: filter
+                  const cleanedQuery = currentQuery.replace(/(^|\s)by:\S+(?=\s|$)/i, '').trim();
+                  setQuery(cleanedQuery);
+                }
+              }
+            }}
           />
           <div className="flex-1 relative">
             <input

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -990,7 +990,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
         setResolvingAuthor(false);
       }
     }
-  }, [pathname, router, isSlashCommand, isUrl, updateUrlForSearch]);
+  }, [pathname, router, isSlashCommand, isUrl, updateUrlForSearch, profileScopingEnabled, userManuallyDisabledScoping]);
 
   // While connecting, show a static placeholder; remove animated loading dots
 

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -1072,7 +1072,12 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
         runSlashCommand(urlQuery);
         handleSearch(urlQuery);
       } else {
-        const display = toExplicitInputFromUrl(urlQuery, currentProfileNpub);
+        // Use NIP-05 if available for display, otherwise use npub
+        let displayNpub = currentProfileNpub;
+        if (profileScopeUser?.profile?.nip05) {
+          displayNpub = profileScopeUser.profile.nip05;
+        }
+        const display = toExplicitInputFromUrl(urlQuery, displayNpub);
         setQuery(display);
         const backend = ensureAuthorForBackend(urlQuery, currentProfileNpub);
         handleSearch(backend);
@@ -1114,7 +1119,12 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
     // Keep input explicit; on /p add missing by:<current npub> to the input value on submit
     let displayVal = raw;
     if (currentProfileNpub && !/(^|\s)by:\S+(?=\s|$)/i.test(displayVal)) {
-      displayVal = `${displayVal} by:${currentProfileNpub}`.trim();
+      // Try to use NIP-05 if available, otherwise fall back to npub
+      let byValue = currentProfileNpub;
+      if (profileScopeUser?.profile?.nip05) {
+        byValue = profileScopeUser.profile.nip05;
+      }
+      displayVal = `${displayVal} by:${byValue}`.trim();
     }
     setQuery(displayVal);
     if (manageUrl) {

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -24,6 +24,7 @@ import UrlPreview from '@/components/UrlPreview';
 import ProfileCard from '@/components/ProfileCard';
 import ClientFilters, { FilterSettings } from '@/components/ClientFilters';
 import CopyButton from '@/components/CopyButton';
+import ProfileScopeIndicator from '@/components/ProfileScopeIndicator';
 import { nip19 } from 'nostr-tools';
 import { extractNip19Identifiers, decodeNip19Pointer } from '@/lib/utils/nostrIdentifiers';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -62,48 +63,6 @@ function SearchIconButton({
   );
 }
 
-// Profile scope indicator component
-function ProfileScopeIndicator({ 
-  user, 
-  isEnabled, 
-  onToggle 
-}: { 
-  user: NDKUser | null; 
-  isEnabled: boolean; 
-  onToggle: () => void; 
-}) {
-  if (!user) return null;
-
-  return (
-    <div className="flex items-center">
-      <button
-        type="button"
-        onClick={onToggle}
-        className={`w-10 h-10 rounded-lg overflow-hidden border transition-all duration-200 hover:opacity-80 ${
-          isEnabled
-            ? 'bg-[#3d3d3d] border-green-400 shadow-sm'
-            : 'bg-[#2d2d2d] border-gray-600 opacity-50 grayscale'
-        }`}
-        title={isEnabled ? 'Disable profile scoping' : 'Enable profile scoping'}
-      >
-        {user.profile?.image ? (
-          <Image
-            src={trimImageUrl(user.profile.image)}
-            alt="Profile"
-            width={40}
-            height={40}
-            className="w-full h-full object-cover"
-            unoptimized
-          />
-        ) : (
-          <div className="w-full h-full flex items-center justify-center text-xs text-gray-300">
-            {(user.profile?.displayName || user.profile?.name || shortenNpub(user.npub)).slice(0, 2).toUpperCase()}
-          </div>
-        )}
-      </button>
-    </div>
-  );
-}
 
 // Component for truncating long text with fade effect and expand arrow
 function TruncatedText({ 

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -756,14 +756,6 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       return;
     }
 
-    const trimmedQuery = (query || '').trim();
-    const hasExplicitScope = /(^|\s)by:\S+(?=\s|$)/i.test(trimmedQuery);
-    
-    if (hasExplicitScope) {
-      setProfileScopeUser(null);
-      return;
-    }
-
     // Create NDKUser for the profile scope and fetch profile
     const setupProfileUser = async () => {
       try {

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -1147,11 +1147,8 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
         handleSearch(urlQuery);
       } else {
         // Use NIP-05 if available for display, otherwise use npub
-        let displayNpub = currentProfileNpub;
-        if (profileScopeUser?.profile?.nip05) {
-          displayNpub = profileScopeUser.profile.nip05;
-        }
-        const display = toExplicitInputFromUrl(urlQuery, displayNpub);
+        const displayIdentifier = profileScopeUser?.profile?.nip05 || currentProfileNpub;
+        const display = toExplicitInputFromUrl(urlQuery, currentProfileNpub, displayIdentifier);
         setQuery(display);
         const backend = ensureAuthorForBackend(urlQuery, currentProfileNpub);
         handleSearch(backend);

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -764,19 +764,29 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       return;
     }
 
-    // Create NDKUser for the profile scope
-    try {
-      const decoded = nip19.decode(currentProfileNpub);
-      if (decoded?.type === 'npub' && typeof decoded.data === 'string') {
-        const user = new NDKUser({ pubkey: decoded.data });
-        user.ndk = ndk;
-        setProfileScopeUser(user);
-      } else {
+    // Create NDKUser for the profile scope and fetch profile
+    const setupProfileUser = async () => {
+      try {
+        const decoded = nip19.decode(currentProfileNpub);
+        if (decoded?.type === 'npub' && typeof decoded.data === 'string') {
+          const user = new NDKUser({ pubkey: decoded.data });
+          user.ndk = ndk;
+          // Fetch the profile to get the image
+          try {
+            await user.fetchProfile();
+          } catch {
+            // Continue even if profile fetch fails
+          }
+          setProfileScopeUser(user);
+        } else {
+          setProfileScopeUser(null);
+        }
+      } catch {
         setProfileScopeUser(null);
       }
-    } catch {
-      setProfileScopeUser(null);
-    }
+    };
+
+    setupProfileUser();
   }, [manageUrl, pathname, query, ndk]);
   const handleSearch = useCallback(async (searchQuery: string) => {
     if (!searchQuery.trim()) {

--- a/src/lib/search/profileScope.ts
+++ b/src/lib/search/profileScope.ts
@@ -11,7 +11,8 @@ export type ProfileScopeIdentifiers = {
   profileIdentifier: string;
 };
 
-const BY_TOKEN_REGEX = /(^|\s)by:([^\s),.;]+)(?=[\s),.;]|$)/gi;
+// Allow dots in tokens so NIP-05 like dergigi.com is fully captured
+const BY_TOKEN_REGEX = /(^|\s)by:([^\s),;]+)(?=[\s),.;]|$)/gi;
 
 type Nip05Like = string | { url?: string | undefined } | undefined;
 

--- a/src/lib/search/profileScope.ts
+++ b/src/lib/search/profileScope.ts
@@ -89,7 +89,7 @@ export function addProfileScope(query: string, identifiers: ProfileScopeIdentifi
   const tokens = trimmed.split(/\s+/);
   for (const token of tokens) {
     if (tokenMatchesProfile(token.replace(/^by:/i, ''), identifiers)) {
-      return trimmed;
+      return replaceProfileScopeIdentifier(trimmed, identifiers);
     }
   }
   return `${trimmed} by:${value}`.trim();
@@ -101,8 +101,4 @@ export function removeProfileScope(query: string, identifiers: ProfileScopeIdent
     return tokenMatchesProfile(token || '', identifiers) ? pre || '' : full;
   });
   return result.replace(/\s{2,}/g, ' ').trim();
-}
-
-export function applyProfileScopePreference(query: string, identifiers: ProfileScopeIdentifiers, enabled: boolean): string {
-  return enabled ? addProfileScope(query, identifiers) : removeProfileScope(query, identifiers);
 }

--- a/src/lib/search/profileScope.ts
+++ b/src/lib/search/profileScope.ts
@@ -30,12 +30,13 @@ function normalizeIdentifier(value?: string): string {
   const trimmed = (value || '').trim();
   const withoutLeadingUnderscores = trimmed.replace(/^_+/, '');
   const withoutAtPrefix = withoutLeadingUnderscores.replace(/^@+/, '');
-  return withoutAtPrefix.toLowerCase();
+  const normalized = withoutAtPrefix.toLowerCase();
+  console.log('DEBUG: normalizeIdentifier - input:', value, 'output:', normalized);
+  return normalized;
 }
 
 function extractNip05(user: NDKUser | null): string | undefined {
   const raw = user?.profile?.nip05 as Nip05Like;
-  console.log('DEBUG: extractNip05 - user:', user?.npub, 'profile:', user?.profile, 'raw nip05:', raw);
   if (!raw) return undefined;
   if (typeof raw === 'string') return raw;
   if (typeof raw === 'object' && 'url' in raw && typeof raw.url === 'string') return raw.url;
@@ -53,17 +54,6 @@ export function getProfileScopeIdentifiers(user: NDKUser | null, currentProfileN
   const normalizedNpub = normalizeIdentifier(currentProfileNpub);
   const normalizedNip05 = nip05 ? normalizeIdentifier(nip05) : undefined;
   
-  console.log('DEBUG: getProfileScopeIdentifiers -', {
-    currentProfileNpub,
-    nip05Raw,
-    nip05,
-    hasNip05,
-    profileIdentifier,
-    normalizedIdentifier,
-    normalizedNpub,
-    normalizedNip05
-  });
-  
   return { 
     npub: currentProfileNpub, 
     nip05, 
@@ -79,10 +69,15 @@ export function getProfileScopeIdentifiers(user: NDKUser | null, currentProfileN
 function tokenMatchesProfile(token: string, identifiers: ProfileScopeIdentifiers): boolean {
   const normalizedToken = normalizeIdentifier(token);
   if (!normalizedToken) return false;
-  if (normalizedToken === identifiers.normalizedIdentifier) return true;
-  if (normalizedToken === identifiers.normalizedNpub) return true;
-  if (identifiers.normalizedNip05 && normalizedToken === identifiers.normalizedNip05) return true;
-  return false;
+  const matches = normalizedToken === identifiers.normalizedIdentifier || 
+                  normalizedToken === identifiers.normalizedNpub || 
+                  (identifiers.normalizedNip05 && normalizedToken === identifiers.normalizedNip05);
+  console.log('DEBUG: tokenMatchesProfile - token:', token, 'normalizedToken:', normalizedToken, 'matches:', matches, 'identifiers:', {
+    normalizedIdentifier: identifiers.normalizedIdentifier,
+    normalizedNpub: identifiers.normalizedNpub,
+    normalizedNip05: identifiers.normalizedNip05
+  });
+  return matches;
 }
 
 export function containsProfileScope(query: string, identifiers: ProfileScopeIdentifiers): boolean {

--- a/src/lib/search/profileScope.ts
+++ b/src/lib/search/profileScope.ts
@@ -17,13 +17,9 @@ type Nip05Like = string | { url?: string | undefined } | undefined;
 
 function sanitizeNip05(value?: string): string | undefined {
   if (!value) return undefined;
-  let trimmed = value.trim();
-  trimmed = trimmed.replace(/^_+/, '');
-  if (!trimmed) return undefined;
-  if (!trimmed.startsWith('@') && trimmed.includes('@')) {
-    trimmed = `@${trimmed}`;
-  }
-  return trimmed;
+  const normalized = normalizeIdentifier(value);
+  if (!normalized) return undefined;
+  return normalized;
 }
 
 function normalizeIdentifier(value?: string): string {
@@ -50,7 +46,7 @@ export function getProfileScopeIdentifiers(user: NDKUser | null, currentProfileN
   const identifier = profileIdentifier;
   const normalizedIdentifier = normalizeIdentifier(identifier);
   const normalizedNpub = normalizeIdentifier(currentProfileNpub);
-  const normalizedNip05 = nip05 ? normalizeIdentifier(nip05) : undefined;
+  const normalizedNip05 = nip05; // nip05 is already normalized by sanitizeNip05
   
   return { 
     npub: currentProfileNpub, 

--- a/src/lib/search/profileScope.ts
+++ b/src/lib/search/profileScope.ts
@@ -30,9 +30,7 @@ function normalizeIdentifier(value?: string): string {
   const trimmed = (value || '').trim();
   const withoutLeadingUnderscores = trimmed.replace(/^_+/, '');
   const withoutAtPrefix = withoutLeadingUnderscores.replace(/^@+/, '');
-  const normalized = withoutAtPrefix.toLowerCase();
-  console.log('DEBUG: normalizeIdentifier - input:', value, 'output:', normalized);
-  return normalized;
+  return withoutAtPrefix.toLowerCase();
 }
 
 function extractNip05(user: NDKUser | null): string | undefined {
@@ -69,15 +67,10 @@ export function getProfileScopeIdentifiers(user: NDKUser | null, currentProfileN
 function tokenMatchesProfile(token: string, identifiers: ProfileScopeIdentifiers): boolean {
   const normalizedToken = normalizeIdentifier(token);
   if (!normalizedToken) return false;
-  const matches = normalizedToken === identifiers.normalizedIdentifier || 
-                  normalizedToken === identifiers.normalizedNpub || 
-                  (identifiers.normalizedNip05 && normalizedToken === identifiers.normalizedNip05);
-  console.log('DEBUG: tokenMatchesProfile - token:', token, 'normalizedToken:', normalizedToken, 'matches:', matches, 'identifiers:', {
-    normalizedIdentifier: identifiers.normalizedIdentifier,
-    normalizedNpub: identifiers.normalizedNpub,
-    normalizedNip05: identifiers.normalizedNip05
-  });
-  return matches;
+  if (normalizedToken === identifiers.normalizedIdentifier) return true;
+  if (normalizedToken === identifiers.normalizedNpub) return true;
+  if (identifiers.normalizedNip05 && normalizedToken === identifiers.normalizedNip05) return true;
+  return false;
 }
 
 export function containsProfileScope(query: string, identifiers: ProfileScopeIdentifiers): boolean {

--- a/src/lib/search/profileScope.ts
+++ b/src/lib/search/profileScope.ts
@@ -62,6 +62,12 @@ export function getProfileScopeIdentifiers(user: NDKUser | null, currentProfileN
 
 function tokenMatchesProfile(token: string, identifiers: ProfileScopeIdentifiers): boolean {
   const normalizedToken = normalizeIdentifier(token);
+  console.log('DEBUG: tokenMatchesProfile - token:', token, 'normalizedToken:', normalizedToken);
+  console.log('DEBUG: comparing against:', {
+    normalizedIdentifier: identifiers.normalizedIdentifier,
+    normalizedNpub: identifiers.normalizedNpub,
+    normalizedNip05: identifiers.normalizedNip05
+  });
   if (!normalizedToken) return false;
   if (normalizedToken === identifiers.normalizedIdentifier) return true;
   if (normalizedToken === identifiers.normalizedNpub) return true;
@@ -72,11 +78,16 @@ function tokenMatchesProfile(token: string, identifiers: ProfileScopeIdentifiers
 export function containsProfileScope(query: string, identifiers: ProfileScopeIdentifiers): boolean {
   BY_TOKEN_REGEX.lastIndex = 0;
   let match: RegExpExecArray | null;
+  console.log('DEBUG: containsProfileScope - query:', query, 'identifiers:', identifiers);
   while ((match = BY_TOKEN_REGEX.exec(query)) !== null) {
-    if (tokenMatchesProfile(match[2] || '', identifiers)) {
+    const token = match[2] || '';
+    console.log('DEBUG: found by: token:', token);
+    if (tokenMatchesProfile(token, identifiers)) {
+      console.log('DEBUG: token matches profile, returning true');
       return true;
     }
   }
+  console.log('DEBUG: no matching tokens found, returning false');
   return false;
 }
 

--- a/src/lib/search/profileScope.ts
+++ b/src/lib/search/profileScope.ts
@@ -1,0 +1,83 @@
+import { NDKUser } from '@nostr-dev-kit/ndk';
+
+export type ProfileScopeIdentifiers = {
+  npub: string;
+  nip05?: string;
+  identifier: string;
+};
+
+const BY_TOKEN_REGEX = /(^|\s)by:([^\s),.;]+)(?=[\s),.;]|$)/gi;
+
+type Nip05Like = string | { url?: string | undefined } | undefined;
+
+function normalizeIdentifier(value?: string): string {
+  const trimmed = (value || '').trim();
+  const withoutLocalUnderscores = trimmed.replace(/^_+/, '');
+  if (withoutLocalUnderscores.startsWith('@')) {
+    return withoutLocalUnderscores.slice(1).toLowerCase();
+  }
+  return withoutLocalUnderscores.toLowerCase();
+}
+
+function extractNip05(user: NDKUser | null): string | undefined {
+  const raw = user?.profile?.nip05 as Nip05Like;
+  if (!raw) return undefined;
+  if (typeof raw === 'string') return raw;
+  if (typeof raw === 'object' && 'url' in raw && typeof raw.url === 'string') return raw.url;
+  return undefined;
+}
+
+export function getProfileScopeIdentifiers(user: NDKUser | null, currentProfileNpub: string | null): ProfileScopeIdentifiers | null {
+  if (!currentProfileNpub) return null;
+  const nip05 = extractNip05(user);
+  const identifier = nip05 && nip05.trim().length > 0 ? nip05 : currentProfileNpub;
+  return { npub: currentProfileNpub, nip05, identifier };
+}
+
+function tokenMatchesProfile(token: string, identifiers: ProfileScopeIdentifiers): boolean {
+  const normalizedToken = normalizeIdentifier(token);
+  if (normalizedToken === normalizeIdentifier(identifiers.identifier)) return true;
+  return false;
+}
+
+export function hasProfileScope(query: string, identifiers: ProfileScopeIdentifiers): boolean {
+  BY_TOKEN_REGEX.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = BY_TOKEN_REGEX.exec(query)) !== null) {
+    if (tokenMatchesProfile(match[2] || '', identifiers)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function replaceProfileScopeIdentifier(query: string, identifiers: ProfileScopeIdentifiers): string {
+  const value = identifiers.identifier;
+  BY_TOKEN_REGEX.lastIndex = 0;
+  const replaced = query.replace(BY_TOKEN_REGEX, (full, pre, token) => {
+    return tokenMatchesProfile(token || '', identifiers) ? `${pre || ''}by:${value}` : full;
+  });
+  return replaced;
+}
+
+export function addProfileScope(query: string, identifiers: ProfileScopeIdentifiers): string {
+  const trimmed = query.trim();
+  if (hasProfileScope(trimmed, identifiers)) {
+    return replaceProfileScopeIdentifier(trimmed, identifiers);
+  }
+  const value = identifiers.identifier;
+  if (!trimmed) return `by:${value}`;
+  return `${trimmed} by:${value}`.trim();
+}
+
+export function removeProfileScope(query: string, identifiers: ProfileScopeIdentifiers): string {
+  BY_TOKEN_REGEX.lastIndex = 0;
+  const result = query.replace(BY_TOKEN_REGEX, (full, pre, token) => {
+    return tokenMatchesProfile(token || '', identifiers) ? pre || '' : full;
+  });
+  return result.replace(/\s{2,}/g, ' ').trim();
+}
+
+export function applyProfileScopePreference(query: string, identifiers: ProfileScopeIdentifiers, enabled: boolean): string {
+  return enabled ? addProfileScope(query, identifiers) : removeProfileScope(query, identifiers);
+}

--- a/src/lib/search/profileScope.ts
+++ b/src/lib/search/profileScope.ts
@@ -35,6 +35,7 @@ function normalizeIdentifier(value?: string): string {
 
 function extractNip05(user: NDKUser | null): string | undefined {
   const raw = user?.profile?.nip05 as Nip05Like;
+  console.log('DEBUG: extractNip05 - user:', user?.npub, 'profile:', user?.profile, 'raw nip05:', raw);
   if (!raw) return undefined;
   if (typeof raw === 'string') return raw;
   if (typeof raw === 'object' && 'url' in raw && typeof raw.url === 'string') return raw.url;
@@ -51,6 +52,18 @@ export function getProfileScopeIdentifiers(user: NDKUser | null, currentProfileN
   const normalizedIdentifier = normalizeIdentifier(identifier);
   const normalizedNpub = normalizeIdentifier(currentProfileNpub);
   const normalizedNip05 = nip05 ? normalizeIdentifier(nip05) : undefined;
+  
+  console.log('DEBUG: getProfileScopeIdentifiers -', {
+    currentProfileNpub,
+    nip05Raw,
+    nip05,
+    hasNip05,
+    profileIdentifier,
+    normalizedIdentifier,
+    normalizedNpub,
+    normalizedNip05
+  });
+  
   return { 
     npub: currentProfileNpub, 
     nip05, 

--- a/src/lib/search/queryTransforms.ts
+++ b/src/lib/search/queryTransforms.ts
@@ -23,11 +23,12 @@ export function toImplicitUrlQuery(explicitQuery: string, currentNpub: string | 
 }
 
 // For the input on /p pages: ensure by:<current npub> is visible/explicit alongside urlQuery
-export function toExplicitInputFromUrl(urlQuery: string, currentNpub: string | null): string {
+export function toExplicitInputFromUrl(urlQuery: string, currentNpub: string | null, displayIdentifier?: string | null): string {
   if (!currentNpub) return (urlQuery || '').trim();
   const base = (urlQuery || '').trim();
-  if (!base) return `by:${currentNpub}`;
-  return /(^|\s)by:\S+(?=\s|$)/i.test(base) ? base : `${base} by:${currentNpub}`;
+  const identifier = displayIdentifier || currentNpub;
+  if (!base) return `by:${identifier}`;
+  return /(^|\s)by:\S+(?=\s|$)/i.test(base) ? base : `${base} by:${identifier}`;
 }
 
 // For backend searches on /p pages: ensure by:<current npub> filter is included

--- a/test-regex.js
+++ b/test-regex.js
@@ -1,0 +1,14 @@
+// Test the BY_TOKEN_REGEX with the query from the screenshot
+const BY_TOKEN_REGEX = /(^|\s)by:([^\s),.;]+)(?=[\s),.;]|$)/gi;
+
+const query = "by:_@dergigi.com";
+console.log('Testing regex with query:', query);
+
+BY_TOKEN_REGEX.lastIndex = 0;
+let match;
+while ((match = BY_TOKEN_REGEX.exec(query)) !== null) {
+  console.log('Match found:', match);
+  console.log('Full match:', match[0]);
+  console.log('Prefix:', match[1]);
+  console.log('Token:', match[2]);
+}


### PR DESCRIPTION
Fix profile scope detection for NIP-05 identifiers and improve search box display consistency. The system now properly detects profile scope using NIP-05 identifiers in all their variations (`_@dergigi.com`, `@dergigi.com`, `dergigi.com`) and displays the clean normalized form (`dergigi.com`) in the search box instead of the raw format with underscores and @ symbols.

• Updated `BY_TOKEN_REGEX` to allow dots in NIP-05 tokens, ensuring full capture of identifiers like `dergigi.com`
• Extracted `ProfileScopeIndicator` component to separate file for better code organization
• Fixed display logic to use normalized `profileIdentifier` instead of raw `profile.nip05`
