### PR TITLE
Fix automatic search for /e/[id] routes

### DIFF
--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -542,8 +542,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
 
         if (firstPointer.type === 'nevent' || firstPointer.type === 'note' || firstPointer.type === 'naddr') {
           // Only redirect if we're not already on the /e/[id] page
-          const isOnEventPage = pathname?.startsWith('/e/');
-          if (!isOnEventPage) {
+          if (!pathname?.startsWith('/e/')) {
             lastPointerRedirectRef.current = pointerLower;
             router.push(`/e/${pointerLower}`);
             return;

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -541,9 +541,14 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
         setResolvingAuthor(false);
 
         if (firstPointer.type === 'nevent' || firstPointer.type === 'note' || firstPointer.type === 'naddr') {
-          lastPointerRedirectRef.current = pointerLower;
-          router.push(`/e/${pointerLower}`);
-          return;
+          // Only redirect if we're not already on the /e/[id] page
+          const isOnEventPage = pathname?.startsWith('/e/');
+          if (!isOnEventPage) {
+            lastPointerRedirectRef.current = pointerLower;
+            router.push(`/e/${pointerLower}`);
+            return;
+          }
+          // If we're already on the /e/[id] page, continue with the search instead of redirecting
         }
         if (firstPointer.type === 'nprofile' || firstPointer.type === 'npub') {
           lastPointerRedirectRef.current = pointerLower;


### PR DESCRIPTION
Fix automatic search for `/e/[id]` routes by preventing redirect loops when already on event pages.

The issue was that when visiting `/e/nevent1...` URLs, the SearchView component would detect the nevent and attempt to redirect to `/e/nevent1...` again, creating a redirect loop that prevented the automatic search from executing.

- Add check to prevent redirecting to `/e/[id]` when already on event page
- Simplify code by removing unnecessary variable assignment
- Maintain existing functionality for other nevent redirects

This ensures that nevent URLs load automatically without requiring manual search button interaction.
