### PR TITLE
Refine relay indicator and highlight search relays

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
+import { LoginTriggerProvider } from "@/lib/LoginTrigger";
 import { Suspense } from "react";
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? process.env.SITE_URL ?? "https://search.dergigi.com";
@@ -60,13 +61,15 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${geistSans.variable} ${geistMono.variable}`}>
       <body className="font-sans min-h-screen flex flex-col">
-        <Header />
-        <div className="flex-1">
-          {children}
-        </div>
-        <Suspense fallback={<div className="text-center text-xs text-gray-400 py-6 select-none bg-[#1a1a1a]">Loading...</div>}>
-          <Footer />
-        </Suspense>
+        <LoginTriggerProvider>
+          <Header />
+          <div className="flex-1">
+            {children}
+          </div>
+          <Suspense fallback={<div className="text-center text-xs text-gray-400 py-6 select-none bg-[#1a1a1a]">Loading...</div>}>
+            <Footer />
+          </Suspense>
+        </LoginTriggerProvider>
       </body>
     </html>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -27,13 +27,13 @@ export function Footer() {
           Gigi
         </a>
         <span className="mx-2">·</span>
-        Birthed during{' '}
+        Birthed at{' '}
         <a
           href="#"
           onClick={handleSearchClick('(#SovEng OR by:sovereignengineering.io)')}
           className="underline hover:text-gray-300"
         >
-          SEC-04
+          #SovEng
         </a>
         <span className="mx-2">·</span>
         Using{' '}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,11 +6,13 @@ import { NDKUser } from '@nostr-dev-kit/ndk';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import ProfileImage from '@/components/ProfileImage';
+import { useLoginTrigger } from '@/lib/LoginTrigger';
 
 export function Header() {
   const [user, setUser] = useState<NDKUser | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const router = useRouter();
+  const { triggerLogin } = useLoginTrigger();
 
   // Restore login state on mount
   useEffect(() => {
@@ -73,7 +75,8 @@ export function Header() {
       router.push(`/p/${user.npub}`);
       return;
     }
-    void handleLogin();
+    // Trigger the /login command in SearchView
+    triggerLogin();
   };
 
   const handleFaviconClick = () => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { login, restoreLogin } from '@/lib/nip07';
+import { restoreLogin } from '@/lib/nip07';
 import { useState, useEffect } from 'react';
 import { NDKUser } from '@nostr-dev-kit/ndk';
 import { useRouter } from 'next/navigation';
@@ -55,20 +55,6 @@ export function Header() {
       }
     };
   }, []);
-
-  const handleLogin = async () => {
-    try {
-      const loggedInUser = await login();
-      if (loggedInUser) {
-        // Fetch the user's profile to get the display name
-        await loggedInUser.fetchProfile();
-        setUser(loggedInUser);
-        console.log('Logged in successfully');
-      }
-    } catch (error) {
-      console.error('Login failed:', error);
-    }
-  };
 
   const handleAvatarClick = () => {
     if (user) {

--- a/src/components/RelayCollapsed.tsx
+++ b/src/components/RelayCollapsed.tsx
@@ -28,7 +28,6 @@ export default function RelayCollapsed({
       type="button"
       className="flex items-center gap-2 text-sm transition-colors touch-manipulation text-gray-400 hover:text-gray-300"
       onClick={onExpand}
-      title={formatConnectionTooltip(connectionDetails)}
     >
       <FontAwesomeIcon 
         icon={faServer} 

--- a/src/components/RelayCollapsed.tsx
+++ b/src/components/RelayCollapsed.tsx
@@ -2,15 +2,12 @@
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faServer, faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
-import { ConnectionStatus } from '@/lib/ndk';
 
 interface RelayCollapsedProps {
   connectionStatus: 'connecting' | 'connected' | 'timeout';
   connectedCount: number;
   totalCount: number;
   onExpand: () => void;
-  formatConnectionTooltip: (details: ConnectionStatus | null) => string;
-  connectionDetails: ConnectionStatus | null;
   isExpanded?: boolean;
 }
 
@@ -19,8 +16,6 @@ export default function RelayCollapsed({
   connectedCount,
   totalCount,
   onExpand,
-  formatConnectionTooltip,
-  connectionDetails,
   isExpanded = false
 }: RelayCollapsedProps) {
   return (

--- a/src/components/RelayExpanded.tsx
+++ b/src/components/RelayExpanded.tsx
@@ -31,7 +31,6 @@ export default function RelayExpanded({
           type="button"
           className="flex items-center gap-2 text-sm transition-colors touch-manipulation text-gray-400 hover:text-gray-300"
           onClick={onCollapse}
-          title={formatConnectionTooltip(connectionDetails)}
         >
           <FontAwesomeIcon 
             icon={faServer} 

--- a/src/components/RelayExpanded.tsx
+++ b/src/components/RelayExpanded.tsx
@@ -2,15 +2,12 @@
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faServer, faChevronUp } from '@fortawesome/free-solid-svg-icons';
-import { ConnectionStatus } from '@/lib/ndk';
 
 interface RelayExpandedProps {
   connectionStatus: 'connecting' | 'connected' | 'timeout';
   connectedCount: number;
   totalCount: number;
   onCollapse: () => void;
-  formatConnectionTooltip: (details: ConnectionStatus | null) => string;
-  connectionDetails: ConnectionStatus | null;
   children: React.ReactNode;
 }
 
@@ -19,8 +16,6 @@ export default function RelayExpanded({
   connectedCount,
   totalCount,
   onCollapse,
-  formatConnectionTooltip,
-  connectionDetails,
   children
 }: RelayExpandedProps) {
   return (

--- a/src/components/RelayIndicator.tsx
+++ b/src/components/RelayIndicator.tsx
@@ -7,15 +7,13 @@ interface RelayIndicatorProps {
   connectionDetails: ConnectionStatus | null;
   showConnectionDetails: boolean;
   onToggle: () => void;
-  formatConnectionTooltip: (details: ConnectionStatus | null) => string;
 }
 
 export default function RelayIndicator({
   connectionStatus,
   connectionDetails,
   showConnectionDetails,
-  onToggle,
-  formatConnectionTooltip
+  onToggle
 }: RelayIndicatorProps) {
   // Calculate connected and total relay counts
   const connectedCount = connectionDetails?.connectedRelays?.length || 0;

--- a/src/components/RelayIndicator.tsx
+++ b/src/components/RelayIndicator.tsx
@@ -26,7 +26,6 @@ export default function RelayIndicator({
       type="button"
       className="flex items-center gap-2 text-sm transition-colors touch-manipulation text-gray-400 hover:text-gray-300"
       onClick={onToggle}
-      title={formatConnectionTooltip(connectionDetails)}
     >
       <FontAwesomeIcon 
         icon={faServer} 

--- a/src/components/RelayStatusDisplay.tsx
+++ b/src/components/RelayStatusDisplay.tsx
@@ -35,7 +35,9 @@ export default function RelayStatusDisplay({
       {eventsReceivedRelays.length > 0 && (
         <div className="mb-2">
           <div className="text-blue-400 font-medium mb-1 flex items-center">
-            <FontAwesomeIcon icon={faWifi} className="mr-1" />
+            <div className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a] mr-2">
+              <FontAwesomeIcon icon={faWifi} className="text-xs" />
+            </div>
             Events received ({displayEventsReceivedCount})
           </div>
           <div className="space-y-1">
@@ -56,7 +58,9 @@ export default function RelayStatusDisplay({
       {otherRelays.length > 0 && (
         <div className="mb-2">
           <div className="text-gray-400 font-medium mb-1 flex items-center">
-            <FontAwesomeIcon icon={faServer} className="mr-1" />
+            <div className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a] mr-2">
+              <FontAwesomeIcon icon={faServer} className="text-xs" />
+            </div>
             Other Relays ({displayOthersCount})
           </div>
           <div className="space-y-1">

--- a/src/components/RelayStatusDisplay.tsx
+++ b/src/components/RelayStatusDisplay.tsx
@@ -43,8 +43,8 @@ export default function RelayStatusDisplay({
               const ping = connectionDetails?.relayPings?.get(relay);
               const pingDisplay = ping && ping > 0 ? ` (${ping}ms)` : '';
               return (
-                <div key={idx} className="text-gray-300 ml-2">
-                  • {relay.replace(/\/$/, '')}{pingDisplay}
+                <div key={idx} className="text-gray-300 ml-2 font-mono">
+                  {relay.replace(/\/$/, '')}{pingDisplay}
                 </div>
               );
             })}
@@ -64,8 +64,8 @@ export default function RelayStatusDisplay({
               const ping = connectionDetails?.relayPings?.get(relay);
               const pingDisplay = ping && ping > 0 ? ` (${ping}ms)` : '';
               return (
-                <div key={idx} className="text-gray-300 ml-2">
-                  • {relay.replace(/\/$/, '')}{pingDisplay}
+                <div key={idx} className="text-gray-300 ml-2 font-mono">
+                  {relay.replace(/\/$/, '')}{pingDisplay}
                 </div>
               );
             })}

--- a/src/components/RelayStatusDisplay.tsx
+++ b/src/components/RelayStatusDisplay.tsx
@@ -43,7 +43,7 @@ export default function RelayStatusDisplay({
               const ping = connectionDetails?.relayPings?.get(relay);
               const pingDisplay = ping && ping > 0 ? ` (${ping}ms)` : '';
               return (
-                <div key={idx} className="text-gray-300 ml-2 font-mono">
+                <div key={idx} className="text-[11px] text-gray-400 font-mono ml-2">
                   {relay.replace(/\/$/, '')}{pingDisplay}
                 </div>
               );
@@ -64,7 +64,7 @@ export default function RelayStatusDisplay({
               const ping = connectionDetails?.relayPings?.get(relay);
               const pingDisplay = ping && ping > 0 ? ` (${ping}ms)` : '';
               return (
-                <div key={idx} className="text-gray-300 ml-2 font-mono">
+                <div key={idx} className="text-[11px] text-gray-400 font-mono ml-2">
                   {relay.replace(/\/$/, '')}{pingDisplay}
                 </div>
               );

--- a/src/components/RelayStatusDisplay.tsx
+++ b/src/components/RelayStatusDisplay.tsx
@@ -6,11 +6,13 @@ import { getRelayLists } from '@/lib/relayCounts';
 interface RelayStatusDisplayProps {
   connectionDetails: ConnectionStatus;
   recentlyActive: string[];
+  onSearch?: (query: string) => void;
 }
 
 export default function RelayStatusDisplay({ 
   connectionDetails, 
-  recentlyActive 
+  recentlyActive,
+  onSearch
 }: RelayStatusDisplayProps) {
   // Use shared calculation logic to ensure consistency with other components
   const { 
@@ -46,7 +48,17 @@ export default function RelayStatusDisplay({
               const pingDisplay = ping && ping > 0 ? ` (${ping}ms)` : '';
               return (
                 <div key={idx} className="text-[11px] text-gray-400 font-mono ml-2">
-                  {relay.replace(/\/$/, '')}{pingDisplay}
+                  {onSearch ? (
+                    <button
+                      type="button"
+                      onClick={() => onSearch(relay.replace(/\/$/, ''))}
+                      className="hover:text-gray-200 hover:underline cursor-pointer"
+                    >
+                      {relay.replace(/\/$/, '')}{pingDisplay}
+                    </button>
+                  ) : (
+                    <span>{relay.replace(/\/$/, '')}{pingDisplay}</span>
+                  )}
                 </div>
               );
             })}
@@ -69,7 +81,17 @@ export default function RelayStatusDisplay({
               const pingDisplay = ping && ping > 0 ? ` (${ping}ms)` : '';
               return (
                 <div key={idx} className="text-[11px] text-gray-400 font-mono ml-2">
-                  {relay.replace(/\/$/, '')}{pingDisplay}
+                  {onSearch ? (
+                    <button
+                      type="button"
+                      onClick={() => onSearch(relay.replace(/\/$/, ''))}
+                      className="hover:text-gray-200 hover:underline cursor-pointer"
+                    >
+                      {relay.replace(/\/$/, '')}{pingDisplay}
+                    </button>
+                  ) : (
+                    <span>{relay.replace(/\/$/, '')}{pingDisplay}</span>
+                  )}
                 </div>
               );
             })}

--- a/src/components/RelayStatusDisplay.tsx
+++ b/src/components/RelayStatusDisplay.tsx
@@ -3,26 +3,26 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faHardDrive } from '@fortawesome/free-solid-svg-icons';
 import { getRelayLists } from '@/lib/relayCounts';
 
+type RelayInfo = ReturnType<typeof getRelayLists> & { relayPings?: Map<string, number> };
+
 interface RelayStatusDisplayProps {
   connectionDetails: ConnectionStatus;
-  recentlyActive: string[];
+  relayInfo: RelayInfo;
   onSearch?: (query: string) => void;
 }
 
 export default function RelayStatusDisplay({ 
-  connectionDetails, 
-  recentlyActive,
+  connectionDetails,
+  relayInfo,
   onSearch
 }: RelayStatusDisplayProps) {
-  // Use shared calculation logic to ensure consistency with other components
   const { 
     eventsReceivedRelays, 
     otherRelays, 
     eventsReceivedCount, 
     totalCount 
-  } = getRelayLists(connectionDetails, recentlyActive);
-  
-  // Use the shared calculation results for consistency
+  } = relayInfo;
+
   const displayEventsReceivedCount = eventsReceivedCount;
   const displayOthersCount = totalCount - eventsReceivedCount;
 
@@ -41,7 +41,7 @@ export default function RelayStatusDisplay({
           </div>
           <div className="space-y-1">
             {eventsReceivedRelays.map((relay, idx) => {
-              const ping = connectionDetails?.relayPings?.get(relay);
+              const ping = connectionDetails?.relayPings?.get?.(relay);
               const pingDisplay = ping && ping > 0 ? ` (${ping}ms)` : '';
               return (
                 <div key={idx} className="text-[11px] text-gray-400 font-mono flex items-center gap-1">
@@ -74,7 +74,7 @@ export default function RelayStatusDisplay({
           </div>
           <div className="space-y-1">
             {otherRelays.map((relay, idx) => {
-              const ping = connectionDetails?.relayPings?.get(relay);
+              const ping = connectionDetails?.relayPings?.get?.(relay);
               const pingDisplay = ping && ping > 0 ? ` (${ping}ms)` : '';
               return (
                 <div key={idx} className="text-[11px] text-gray-400 font-mono flex items-center gap-1">

--- a/src/components/RelayStatusDisplay.tsx
+++ b/src/components/RelayStatusDisplay.tsx
@@ -44,7 +44,7 @@ export default function RelayStatusDisplay({
               const ping = connectionDetails?.relayPings?.get(relay);
               const pingDisplay = ping && ping > 0 ? ` (${ping}ms)` : '';
               return (
-                <div key={idx} className="text-[11px] text-gray-400 font-mono ml-2 flex items-center gap-1">
+                <div key={idx} className="text-[11px] text-gray-400 font-mono flex items-center gap-1">
                   <div className="w-5 h-5 rounded-md text-blue-400 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]">
                     <FontAwesomeIcon icon={faHardDrive} className="text-xs" />
                   </div>
@@ -77,7 +77,7 @@ export default function RelayStatusDisplay({
               const ping = connectionDetails?.relayPings?.get(relay);
               const pingDisplay = ping && ping > 0 ? ` (${ping}ms)` : '';
               return (
-                <div key={idx} className="text-[11px] text-gray-400 font-mono ml-2 flex items-center gap-1">
+                <div key={idx} className="text-[11px] text-gray-400 font-mono flex items-center gap-1">
                   <div className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]">
                     <FontAwesomeIcon icon={faHardDrive} className="text-xs" />
                   </div>

--- a/src/components/RelayStatusDisplay.tsx
+++ b/src/components/RelayStatusDisplay.tsx
@@ -1,6 +1,6 @@
 import { ConnectionStatus } from '@/lib/ndk';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faWifi, faServer, faHardDrive } from '@fortawesome/free-solid-svg-icons';
+import { faHardDrive } from '@fortawesome/free-solid-svg-icons';
 import { getRelayLists } from '@/lib/relayCounts';
 
 interface RelayStatusDisplayProps {
@@ -36,10 +36,7 @@ export default function RelayStatusDisplay({
       {/* Events received relays */}
       {eventsReceivedRelays.length > 0 && (
         <div className="mb-2">
-          <div className="text-blue-400 font-medium mb-1 flex items-center">
-            <div className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a] mr-2">
-              <FontAwesomeIcon icon={faWifi} className="text-xs" />
-            </div>
+          <div className="text-blue-400 font-medium mb-1">
             Events received ({displayEventsReceivedCount})
           </div>
           <div className="space-y-1">
@@ -72,10 +69,7 @@ export default function RelayStatusDisplay({
       {/* Other relays */}
       {otherRelays.length > 0 && (
         <div className="mb-2">
-          <div className="text-gray-400 font-medium mb-1 flex items-center">
-            <div className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a] mr-2">
-              <FontAwesomeIcon icon={faServer} className="text-xs" />
-            </div>
+          <div className="text-gray-400 font-medium mb-1">
             Other Relays ({displayOthersCount})
           </div>
           <div className="space-y-1">

--- a/src/components/RelayStatusDisplay.tsx
+++ b/src/components/RelayStatusDisplay.tsx
@@ -48,7 +48,9 @@ export default function RelayStatusDisplay({
               const pingDisplay = ping && ping > 0 ? ` (${ping}ms)` : '';
               return (
                 <div key={idx} className="text-[11px] text-gray-400 font-mono ml-2 flex items-center gap-1">
-                  <FontAwesomeIcon icon={faHardDrive} className="text-xs text-gray-500" />
+                  <div className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]">
+                    <FontAwesomeIcon icon={faHardDrive} className="text-xs" />
+                  </div>
                   {onSearch ? (
                     <button
                       type="button"
@@ -82,7 +84,9 @@ export default function RelayStatusDisplay({
               const pingDisplay = ping && ping > 0 ? ` (${ping}ms)` : '';
               return (
                 <div key={idx} className="text-[11px] text-gray-400 font-mono ml-2 flex items-center gap-1">
-                  <FontAwesomeIcon icon={faHardDrive} className="text-xs text-gray-500" />
+                  <div className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]">
+                    <FontAwesomeIcon icon={faHardDrive} className="text-xs" />
+                  </div>
                   {onSearch ? (
                     <button
                       type="button"

--- a/src/components/RelayStatusDisplay.tsx
+++ b/src/components/RelayStatusDisplay.tsx
@@ -1,6 +1,6 @@
 import { ConnectionStatus } from '@/lib/ndk';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faWifi, faServer } from '@fortawesome/free-solid-svg-icons';
+import { faWifi, faServer, faHardDrive } from '@fortawesome/free-solid-svg-icons';
 import { getRelayLists } from '@/lib/relayCounts';
 
 interface RelayStatusDisplayProps {
@@ -47,7 +47,8 @@ export default function RelayStatusDisplay({
               const ping = connectionDetails?.relayPings?.get(relay);
               const pingDisplay = ping && ping > 0 ? ` (${ping}ms)` : '';
               return (
-                <div key={idx} className="text-[11px] text-gray-400 font-mono ml-2">
+                <div key={idx} className="text-[11px] text-gray-400 font-mono ml-2 flex items-center gap-1">
+                  <FontAwesomeIcon icon={faHardDrive} className="text-xs text-gray-500" />
                   {onSearch ? (
                     <button
                       type="button"
@@ -80,7 +81,8 @@ export default function RelayStatusDisplay({
               const ping = connectionDetails?.relayPings?.get(relay);
               const pingDisplay = ping && ping > 0 ? ` (${ping}ms)` : '';
               return (
-                <div key={idx} className="text-[11px] text-gray-400 font-mono ml-2">
+                <div key={idx} className="text-[11px] text-gray-400 font-mono ml-2 flex items-center gap-1">
+                  <FontAwesomeIcon icon={faHardDrive} className="text-xs text-gray-500" />
                   {onSearch ? (
                     <button
                       type="button"

--- a/src/components/RelayStatusDisplay.tsx
+++ b/src/components/RelayStatusDisplay.tsx
@@ -45,7 +45,7 @@ export default function RelayStatusDisplay({
               const pingDisplay = ping && ping > 0 ? ` (${ping}ms)` : '';
               return (
                 <div key={idx} className="text-[11px] text-gray-400 font-mono ml-2 flex items-center gap-1">
-                  <div className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]">
+                  <div className="w-5 h-5 rounded-md text-blue-400 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]">
                     <FontAwesomeIcon icon={faHardDrive} className="text-xs" />
                   </div>
                   {onSearch ? (

--- a/src/components/RelayStatusDisplay.tsx
+++ b/src/components/RelayStatusDisplay.tsx
@@ -41,23 +41,26 @@ export default function RelayStatusDisplay({
           </div>
           <div className="space-y-1">
             {eventsReceivedRelays.map((relay, idx) => {
-              const ping = connectionDetails?.relayPings?.get?.(relay);
+              const ping = connectionDetails?.relayPings?.get?.(relay.url);
               const pingDisplay = ping && ping > 0 ? ` (${ping}ms)` : '';
+              const iconClasses = relay.isSearchRelay
+                ? 'text-blue-300 bg-blue-900/40 border border-blue-400/20'
+                : 'text-blue-400 bg-transparent';
               return (
                 <div key={idx} className="text-[11px] text-gray-400 font-mono flex items-center gap-1">
-                  <div className="w-5 h-5 rounded-md text-blue-400 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]">
+                  <div className={`w-5 h-5 rounded-md flex items-center justify-center text-[12px] leading-none ${iconClasses}`}>
                     <FontAwesomeIcon icon={faHardDrive} className="text-xs" />
                   </div>
                   {onSearch ? (
                     <button
                       type="button"
-                      onClick={() => onSearch(relay.replace(/\/$/, ''))}
+                      onClick={() => onSearch(relay.url.replace(/\/$/, ''))}
                       className="hover:text-gray-200 hover:underline cursor-pointer"
                     >
-                      {relay.replace(/\/$/, '')}{pingDisplay}
+                      {relay.url.replace(/\/$/, '')}{pingDisplay}
                     </button>
                   ) : (
-                    <span>{relay.replace(/\/$/, '')}{pingDisplay}</span>
+                    <span>{relay.url.replace(/\/$/, '')}{pingDisplay}</span>
                   )}
                 </div>
               );
@@ -74,23 +77,26 @@ export default function RelayStatusDisplay({
           </div>
           <div className="space-y-1">
             {otherRelays.map((relay, idx) => {
-              const ping = connectionDetails?.relayPings?.get?.(relay);
+              const ping = connectionDetails?.relayPings?.get?.(relay.url);
               const pingDisplay = ping && ping > 0 ? ` (${ping}ms)` : '';
+              const iconClasses = relay.isSearchRelay
+                ? 'text-gray-200 bg-blue-900/30 border border-blue-400/10'
+                : 'text-gray-300 bg-transparent';
               return (
                 <div key={idx} className="text-[11px] text-gray-400 font-mono flex items-center gap-1">
-                  <div className="w-5 h-5 rounded-md text-gray-300 flex items-center justify-center text-[12px] leading-none hover:bg-[#3a3a3a]">
+                  <div className={`w-5 h-5 rounded-md flex items-center justify-center text-[12px] leading-none ${iconClasses}`}>
                     <FontAwesomeIcon icon={faHardDrive} className="text-xs" />
                   </div>
                   {onSearch ? (
                     <button
                       type="button"
-                      onClick={() => onSearch(relay.replace(/\/$/, ''))}
+                      onClick={() => onSearch(relay.url.replace(/\/$/, ''))}
                       className="hover:text-gray-200 hover:underline cursor-pointer"
                     >
-                      {relay.replace(/\/$/, '')}{pingDisplay}
+                      {relay.url.replace(/\/$/, '')}{pingDisplay}
                     </button>
                   ) : (
-                    <span>{relay.replace(/\/$/, '')}{pingDisplay}</span>
+                    <span>{relay.url.replace(/\/$/, '')}{pingDisplay}</span>
                   )}
                 </div>
               );

--- a/src/components/RelayStatusDisplay.tsx
+++ b/src/components/RelayStatusDisplay.tsx
@@ -44,7 +44,7 @@ export default function RelayStatusDisplay({
               const pingDisplay = ping && ping > 0 ? ` (${ping}ms)` : '';
               return (
                 <div key={idx} className="text-gray-300 ml-2">
-                  • {relay.replace(/^wss:\/\//, '').replace(/\/$/, '')}{pingDisplay}
+                  • {relay.replace(/\/$/, '')}{pingDisplay}
                 </div>
               );
             })}
@@ -65,7 +65,7 @@ export default function RelayStatusDisplay({
               const pingDisplay = ping && ping > 0 ? ` (${ping}ms)` : '';
               return (
                 <div key={idx} className="text-gray-300 ml-2">
-                  • {relay.replace(/^wss:\/\//, '').replace(/\/$/, '')}{pingDisplay}
+                  • {relay.replace(/\/$/, '')}{pingDisplay}
                 </div>
               );
             })}

--- a/src/components/RelayStatusDisplay.tsx
+++ b/src/components/RelayStatusDisplay.tsx
@@ -3,17 +3,19 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faHardDrive } from '@fortawesome/free-solid-svg-icons';
 import { getRelayLists } from '@/lib/relayCounts';
 
-type RelayInfo = ReturnType<typeof getRelayLists> & { relayPings?: Map<string, number> };
+type RelayInfo = ReturnType<typeof getRelayLists>;
 
 interface RelayStatusDisplayProps {
   connectionDetails: ConnectionStatus;
   relayInfo: RelayInfo;
+  activeRelays: Set<string>;
   onSearch?: (query: string) => void;
 }
 
 export default function RelayStatusDisplay({ 
   connectionDetails,
   relayInfo,
+  activeRelays,
   onSearch
 }: RelayStatusDisplayProps) {
   const { 
@@ -43,9 +45,13 @@ export default function RelayStatusDisplay({
             {eventsReceivedRelays.map((relay, idx) => {
               const ping = connectionDetails?.relayPings?.get?.(relay.url);
               const pingDisplay = ping && ping > 0 ? ` (${ping}ms)` : '';
+              const cleanedUrl = relay.url.replace(/\/$/, '');
+              const isActive = activeRelays.has(cleanedUrl);
               const iconClasses = relay.isSearchRelay
-                ? 'text-blue-300 bg-blue-900/40 border border-blue-400/20'
-                : 'text-blue-400 bg-transparent';
+                ? `border border-blue-400/20 ${isActive ? 'text-blue-300 bg-blue-900/60' : 'text-blue-300 bg-blue-900/30'}`
+                : isActive
+                  ? 'text-blue-300 bg-blue-700/40 border border-blue-400/30'
+                  : 'text-blue-400 bg-transparent';
               return (
                 <div key={idx} className="text-[11px] text-gray-400 font-mono flex items-center gap-1">
                   <div className={`w-5 h-5 rounded-md flex items-center justify-center text-[12px] leading-none ${iconClasses}`}>
@@ -54,13 +60,13 @@ export default function RelayStatusDisplay({
                   {onSearch ? (
                     <button
                       type="button"
-                      onClick={() => onSearch(relay.url.replace(/\/$/, ''))}
+                      onClick={() => onSearch(cleanedUrl)}
                       className="hover:text-gray-200 hover:underline cursor-pointer"
                     >
-                      {relay.url.replace(/\/$/, '')}{pingDisplay}
+                      {cleanedUrl}{pingDisplay}
                     </button>
                   ) : (
-                    <span>{relay.url.replace(/\/$/, '')}{pingDisplay}</span>
+                    <span>{cleanedUrl}{pingDisplay}</span>
                   )}
                 </div>
               );
@@ -79,9 +85,13 @@ export default function RelayStatusDisplay({
             {otherRelays.map((relay, idx) => {
               const ping = connectionDetails?.relayPings?.get?.(relay.url);
               const pingDisplay = ping && ping > 0 ? ` (${ping}ms)` : '';
+              const cleanedUrl = relay.url.replace(/\/$/, '');
+              const isActive = activeRelays.has(cleanedUrl);
               const iconClasses = relay.isSearchRelay
-                ? 'text-gray-200 bg-blue-900/30 border border-blue-400/10'
-                : 'text-gray-300 bg-transparent';
+                ? `border border-blue-400/10 ${isActive ? 'text-blue-200 bg-blue-900/40' : 'text-gray-200 bg-blue-900/20'}`
+                : isActive
+                  ? 'text-blue-200 bg-blue-700/30 border border-blue-400/20'
+                  : 'text-gray-300 bg-transparent';
               return (
                 <div key={idx} className="text-[11px] text-gray-400 font-mono flex items-center gap-1">
                   <div className={`w-5 h-5 rounded-md flex items-center justify-center text-[12px] leading-none ${iconClasses}`}>
@@ -90,13 +100,13 @@ export default function RelayStatusDisplay({
                   {onSearch ? (
                     <button
                       type="button"
-                      onClick={() => onSearch(relay.url.replace(/\/$/, ''))}
+                      onClick={() => onSearch(cleanedUrl)}
                       className="hover:text-gray-200 hover:underline cursor-pointer"
                     >
-                      {relay.url.replace(/\/$/, '')}{pingDisplay}
+                      {cleanedUrl}{pingDisplay}
                     </button>
                   ) : (
-                    <span>{relay.url.replace(/\/$/, '')}{pingDisplay}</span>
+                    <span>{cleanedUrl}{pingDisplay}</span>
                   )}
                 </div>
               );

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -783,9 +783,11 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       if (searchInputRef.current) {
         searchInputRef.current.focus();
       }
+      // Execute the /login command immediately
+      runSlashCommand('/login');
     });
     return cleanup;
-  }, [onLoginTrigger]);
+  }, [onLoginTrigger, runSlashCommand]);
 
   useEffect(() => {
     if (!manageUrl) return;

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -783,11 +783,13 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       if (searchInputRef.current) {
         searchInputRef.current.focus();
       }
+      // Update URL immediately
+      updateUrlForSearch('/login');
       // Execute the /login command immediately
       runSlashCommand('/login');
     });
     return cleanup;
-  }, [onLoginTrigger, runSlashCommand]);
+  }, [onLoginTrigger, runSlashCommand, updateUrlForSearch]);
 
   useEffect(() => {
     if (!manageUrl) return;

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -732,9 +732,16 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
   useEffect(() => {
     const id = setInterval(() => {
       setRecentlyActive(getRecentlyActiveRelays());
-    }, 2000); // Update every 2 seconds to catch relay activity
+    }, 1000); // Update every 1 second to catch relay activity more quickly
     return () => clearInterval(id);
   }, []);
+
+  // Update recently active relays when results change (events received)
+  useEffect(() => {
+    if (results.length > 0) {
+      setRecentlyActive(getRecentlyActiveRelays());
+    }
+  }, [results.length]);
 
 
   // Removed separate RecentlyActiveRelays section; now merged into Reachable
@@ -1334,8 +1341,14 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
           <div className="flex items-center justify-end gap-3">
             <RelayCollapsed
               connectionStatus={connectionStatus}
-              connectedCount={calculateRelayCounts(connectionDetails, recentlyActive).eventsReceivedCount}
-              totalCount={calculateRelayCounts(connectionDetails, recentlyActive).totalCount}
+              connectedCount={Math.max(
+                calculateRelayCounts(connectionDetails, recentlyActive).eventsReceivedCount,
+                recentlyActive.length || 0
+              )}
+              totalCount={Math.max(
+                calculateRelayCounts(connectionDetails, recentlyActive).totalCount,
+                recentlyActive.length || 1 // Fallback to show at least 1 if we have recent activity
+              )}
               onExpand={() => setShowConnectionDetails(!showConnectionDetails)}
               isExpanded={showConnectionDetails}
             />

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -1368,6 +1368,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
             <RelayStatusDisplay 
               connectionDetails={connectionDetails}
               recentlyActive={recentlyActive}
+              onSearch={handleSearch}
             />
           )}
 

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -723,6 +723,19 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
     return () => clearInterval(id);
   }, [showConnectionDetails]);
 
+  // Update recently active relays immediately when connection status changes
+  useEffect(() => {
+    setRecentlyActive(getRecentlyActiveRelays());
+  }, [connectionDetails]);
+
+  // Periodically update recently active relays to catch relay activity changes
+  useEffect(() => {
+    const id = setInterval(() => {
+      setRecentlyActive(getRecentlyActiveRelays());
+    }, 2000); // Update every 2 seconds to catch relay activity
+    return () => clearInterval(id);
+  }, []);
+
 
   // Removed separate RecentlyActiveRelays section; now merged into Reachable
 

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -57,6 +57,7 @@ import Fuse from 'fuse.js';
 import { getFilteredExamples } from '@/lib/examples';
 import { isLoggedIn, login, logout } from '@/lib/nip07';
 import { Highlight, themes, type RenderProps } from 'prism-react-renderer';
+import { useLoginTrigger } from '@/lib/LoginTrigger';
 
 type Props = {
   initialQuery?: string;
@@ -104,6 +105,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
   const [topCommandText, setTopCommandText] = useState<string | null>(null);
   const [topExamples, setTopExamples] = useState<string[] | null>(null);
   const isSlashCommand = useCallback((input: string): boolean => /^\s*\//.test(input), []);
+  const { onLoginTrigger } = useLoginTrigger();
   
   // Determine if filters should be enabled based on filterMode
   const shouldEnableFilters = useMemo(() => {
@@ -772,6 +774,18 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       document.removeEventListener('keydown', handleKeyDown);
     };
   }, [loading]);
+
+  // Listen for login trigger from Header
+  useEffect(() => {
+    const cleanup = onLoginTrigger(() => {
+      setQuery('/login');
+      // Focus the search input
+      if (searchInputRef.current) {
+        searchInputRef.current.focus();
+      }
+    });
+    return cleanup;
+  }, [onLoginTrigger]);
 
   useEffect(() => {
     if (!manageUrl) return;

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -1014,39 +1014,6 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
 
 
 
-  const formatConnectionTooltip = (details: ConnectionStatus | null): string => {
-    if (!details) return 'Connection status unknown';
-    
-    const { connectedRelays, failedRelays } = details;
-    const connectedCount = connectedRelays.length;
-    const failedCount = failedRelays.length;
-    
-    let tooltip = '';
-    
-    
-    if (connectedCount > 0) {
-      tooltip += `✅ Reachable (WebSocket) ${connectedCount} relay${connectedCount > 1 ? 's' : ''}:\n`;
-      connectedRelays.forEach(relay => {
-        const shortName = relay.replace(/^wss:\/\//, '').replace(/\/$/, '');
-        tooltip += `  • ${shortName}\n`;
-      });
-    }
-    
-    if (failedCount > 0) {
-      if (connectedCount > 0) tooltip += '\n';
-      tooltip += `❌ Unreachable (socket closed) ${failedCount} relay${failedCount > 1 ? 's' : ''}:\n`;
-      failedRelays.forEach(relay => {
-        const shortName = relay.replace(/^wss:\/\//, '').replace(/\/$/, '');
-        tooltip += `  • ${shortName}\n`;
-      });
-    }
-    
-    if (connectedCount === 0 && failedCount === 0) {
-      tooltip = 'No relay connection information available';
-    }
-    
-    return tooltip.trim();
-  };
 
 
   // Use the utility function from urlUtils
@@ -1357,8 +1324,6 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
               connectedCount={calculateRelayCounts(connectionDetails, recentlyActive).eventsReceivedCount}
               totalCount={calculateRelayCounts(connectionDetails, recentlyActive).totalCount}
               onExpand={() => setShowConnectionDetails(!showConnectionDetails)}
-              formatConnectionTooltip={formatConnectionTooltip}
-              connectionDetails={connectionDetails}
               isExpanded={showConnectionDetails}
             />
 

--- a/src/lib/LoginTrigger.tsx
+++ b/src/lib/LoginTrigger.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { createContext, useContext, useCallback, useState, ReactNode } from 'react';
+
+interface LoginTriggerContextType {
+  triggerLogin: () => void;
+  onLoginTrigger: (callback: () => void) => () => void;
+}
+
+const LoginTriggerContext = createContext<LoginTriggerContextType | null>(null);
+
+export function LoginTriggerProvider({ children }: { children: ReactNode }) {
+  const [listeners, setListeners] = useState<(() => void)[]>([]);
+
+  const triggerLogin = useCallback(() => {
+    listeners.forEach(listener => listener());
+  }, [listeners]);
+
+  const onLoginTrigger = useCallback((callback: () => void) => {
+    setListeners(prev => [...prev, callback]);
+    // Return cleanup function
+    return () => {
+      setListeners(prev => prev.filter(listener => listener !== callback));
+    };
+  }, []);
+
+  return (
+    <LoginTriggerContext.Provider value={{ triggerLogin, onLoginTrigger }}>
+      {children}
+    </LoginTriggerContext.Provider>
+  );
+}
+
+export function useLoginTrigger() {
+  const context = useContext(LoginTriggerContext);
+  if (!context) {
+    throw new Error('useLoginTrigger must be used within a LoginTriggerProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
Refine the relay indicator so all relay views share the same counts, highlight NIP-50 relays, and call out which relays returned results for the active query. The header display, collapsed indicator, and expanded list now read from the same memoized data, keeping everything in sync.
- memoize relay metadata once and reuse it across components
- mark search capable relays and highlight ones that returned events
- keep relay search shortcuts and ping details intact
