### PR TITLE
Always show search explanation

### DIFF
--- a/src/app/e/[id]/page.tsx
+++ b/src/app/e/[id]/page.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useCallback } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { LoadingLayout } from '@/components/LoadingLayout';
 import SearchView from '@/components/SearchView';
 import { parseEventIdentifier, isValidEventIdentifier } from '@/lib/utils/nostrIdentifiers';
+import { isHashtagOnlyQuery, hashtagQueryToUrl } from '@/lib/utils';
 
 export default function EidRedirectPage() {
   const params = useParams<{ id: string }>();
@@ -15,6 +16,22 @@ export default function EidRedirectPage() {
 
   // If we have a valid nevent/note, display it directly instead of redirecting
   const isValidNevent = useMemo(() => isValidEventIdentifier(normalizedQuery), [normalizedQuery]);
+
+  // Unified URL update handler: while on /e/ pages, any non-empty query
+  // should navigate to either /t/<tags> for hashtag-only queries or
+  // to the root search with ?q=<query> for general searches.
+  const handleUrlUpdate = useCallback((q: string) => {
+    const query = (q || '').trim();
+    if (!query) return;
+    if (isHashtagOnlyQuery(query)) {
+      const tagUrl = hashtagQueryToUrl(query);
+      if (tagUrl) {
+        router.replace(`/t/${tagUrl}`);
+        return;
+      }
+    }
+    router.replace(`/?q=${encodeURIComponent(query)}`);
+  }, [router]);
 
   useEffect(() => {
     if (!normalizedQuery) return;
@@ -33,6 +50,7 @@ export default function EidRedirectPage() {
           <SearchView 
             initialQuery={normalizedQuery} 
             manageUrl={false}
+            onUrlUpdate={handleUrlUpdate}
           />
         </div>
       </main>

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -849,7 +849,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
         }
       }
     }
-  }, [pathname, router, isSlashCommand, isUrl, updateUrlForSearch, profileScopeUser, initialQuery, manageUrl]);
+  }, [pathname, router, isSlashCommand, isUrl, updateUrlForSearch, profileScopeUser, initialQuery, manageUrl, generateTranslation]);
 
   // While connecting, show a static placeholder; remove animated loading dots
 

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -492,6 +492,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
     
     // Handle transitions from special paths to root with query
     if ((isOnTagPath || isOnEventPath) && !isHashtagOnlyQuery(searchQuery)) {
+      console.log('Transitioning from special path to root with query:', searchQuery);
       const params = new URLSearchParams();
       params.set('q', searchQuery);
       router.replace(`/?${params.toString()}`);
@@ -707,6 +708,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
     }
 
     // Always update URL to reflect the current search
+    console.log('Updating URL for search:', searchQuery, 'on path:', pathname);
     updateUrlForSearch(searchQuery);
 
     // Abort any ongoing search

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -475,33 +475,31 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       return;
     }
     
-    // Check if this is a hashtag-only query and we're not already on a profile page
+    // Detect current path type
     const currentProfileNpub = getCurrentProfileNpub(pathname);
     const isOnTagPath = pathname?.startsWith('/t/');
+    const isOnEventPath = pathname?.startsWith('/e/');
+    const isOnProfilePath = currentProfileNpub !== null;
     
-    if (!currentProfileNpub && isHashtagOnlyQuery(searchQuery)) {
+    // Handle hashtag-only queries
+    if (!isOnProfilePath && isHashtagOnlyQuery(searchQuery)) {
       const hashtagUrl = hashtagQueryToUrl(searchQuery);
       if (hashtagUrl) {
-        // If we're already on a tag path, update the same path
-        // If we're on a different path, navigate to the tag path
-        if (isOnTagPath) {
-          router.replace(`/t/${hashtagUrl}`);
-        } else {
-          router.replace(`/t/${hashtagUrl}`);
-        }
+        router.replace(`/t/${hashtagUrl}`);
         return;
       }
     }
     
-    // If we're on a tag path but the query is not hashtag-only, navigate to root with query
-    if (isOnTagPath && !isHashtagOnlyQuery(searchQuery)) {
+    // Handle transitions from special paths to root with query
+    if ((isOnTagPath || isOnEventPath) && !isHashtagOnlyQuery(searchQuery)) {
       const params = new URLSearchParams();
       params.set('q', searchQuery);
       router.replace(`/?${params.toString()}`);
       return;
     }
     
-    if (currentProfileNpub) {
+    // Handle profile pages
+    if (isOnProfilePath) {
       // URL should be implicit on profile pages: strip matching by:npub
       const urlValue = toImplicitUrlQuery(searchQuery, currentProfileNpub);
       const params = new URLSearchParams(searchParams.toString());
@@ -520,6 +518,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
         router.replace(newUrl);
       }
     } else {
+      // Handle root path
       const params = new URLSearchParams(searchParams.toString());
       params.set('q', searchQuery);
       router.replace(`?${params.toString()}`);
@@ -662,8 +661,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       return;
     }
 
-    // Update URL immediately when search is triggered (but not if we're on /t/ path with hashtag-only query)
-    const isOnTagPath = pathname?.startsWith('/t/');
+    // Update URL immediately when search is triggered
     const normalizedInput = searchQuery.trim();
     const nip19Identifiers = extractNip19Identifiers(normalizedInput);
     const identifierToken = nip19Identifiers.length > 0 ? nip19Identifiers[0].trim() : null;
@@ -708,8 +706,6 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       }
     }
 
-    const isHashtagQuery = isHashtagOnlyQuery(searchQuery);
-    
     // Always update URL to reflect the current search
     updateUrlForSearch(searchQuery);
 

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -477,12 +477,28 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
     
     // Check if this is a hashtag-only query and we're not already on a profile page
     const currentProfileNpub = getCurrentProfileNpub(pathname);
+    const isOnTagPath = pathname?.startsWith('/t/');
+    
     if (!currentProfileNpub && isHashtagOnlyQuery(searchQuery)) {
       const hashtagUrl = hashtagQueryToUrl(searchQuery);
       if (hashtagUrl) {
-        router.replace(`/t/${hashtagUrl}`);
+        // If we're already on a tag path, update the same path
+        // If we're on a different path, navigate to the tag path
+        if (isOnTagPath) {
+          router.replace(`/t/${hashtagUrl}`);
+        } else {
+          router.replace(`/t/${hashtagUrl}`);
+        }
         return;
       }
+    }
+    
+    // If we're on a tag path but the query is not hashtag-only, navigate to root with query
+    if (isOnTagPath && !isHashtagOnlyQuery(searchQuery)) {
+      const params = new URLSearchParams();
+      params.set('q', searchQuery);
+      router.replace(`/?${params.toString()}`);
+      return;
     }
     
     if (currentProfileNpub) {
@@ -694,9 +710,8 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
 
     const isHashtagQuery = isHashtagOnlyQuery(searchQuery);
     
-    if (!(isOnTagPath && isHashtagQuery)) {
-      updateUrlForSearch(searchQuery);
-    }
+    // Always update URL to reflect the current search
+    updateUrlForSearch(searchQuery);
 
     // Abort any ongoing search
     if (abortControllerRef.current) {

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -481,6 +481,15 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
     const isOnEventPath = pathname?.startsWith('/e/');
     const isOnProfilePath = currentProfileNpub !== null;
     
+    console.log('updateUrlForSearch debug:', {
+      searchQuery,
+      pathname,
+      isOnTagPath,
+      isOnEventPath,
+      isOnProfilePath,
+      isHashtagOnly: isHashtagOnlyQuery(searchQuery)
+    });
+    
     // Handle hashtag-only queries
     if (!isOnProfilePath && isHashtagOnlyQuery(searchQuery)) {
       const hashtagUrl = hashtagQueryToUrl(searchQuery);

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -110,7 +110,121 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
   const [successfulPreviews, setSuccessfulPreviews] = useState<Set<string>>(new Set());
   const [translation, setTranslation] = useState<string>('');
   const [showExternalButton, setShowExternalButton] = useState(false);
+  
+  // Cache for author resolution to avoid repeated requests
+  const authorResolutionCache = useRef<Map<string, string>>(new Map());
+  const authorResolutionTimeout = useRef<NodeJS.Timeout | null>(null);
   const [filterSettings, setFilterSettings] = useState<FilterSettings>({ maxEmojis: 3, maxHashtags: 3, maxMentions: 6, hideLinks: false, hideBridged: true, resultFilter: '', verifiedOnly: false, fuzzyEnabled: true, hideBots: false, hideNsfw: false, filterMode: 'intelligently' });
+  
+  // DRY helper function for translation logic
+  const generateTranslation = useCallback(async (query: string, skipAuthorResolution = false): Promise<string> => {
+    try {
+      // 1) Apply simple replacements first
+      const afterReplacements = await applySimpleReplacements(query);
+
+      // 2) Recursive OR substitution (distribute parentheses)
+      const distributed = expandParenthesizedOr(afterReplacements);
+
+      // Helper: resolve all by:<author> tokens within a single query string
+      const resolveByTokensInQuery = async (q: string): Promise<string> => {
+        const rx = /(^|\s)by:(\S+)/gi;
+        let result = '';
+        let lastIndex = 0;
+        let m: RegExpExecArray | null;
+        while ((m = rx.exec(q)) !== null) {
+          const full = m[0];
+          const pre = m[1] || '';
+          const raw = m[2] || '';
+          const match = raw.match(/^([^),.;]+)([),.;]*)$/);
+          const core = (match && match[1]) || raw;
+          const suffix = (match && match[2]) || '';
+          let replacement = core;
+          
+          if (!skipAuthorResolution && !/^npub1[0-9a-z]+$/i.test(core)) {
+            // Check cache first
+            if (authorResolutionCache.current.has(core)) {
+              replacement = authorResolutionCache.current.get(core) || core;
+            } else {
+              try {
+                const npub = await resolveAuthorToNpub(core);
+                if (npub) {
+                  replacement = npub;
+                  authorResolutionCache.current.set(core, npub);
+                }
+              } catch {}
+            }
+          }
+          result += q.slice(lastIndex, m.index);
+          result += `${pre}by:${replacement}${suffix}`;
+          lastIndex = m.index + full.length;
+        }
+        result += q.slice(lastIndex);
+        return result;
+      };
+
+      // Helper: normalize p:<token> where token may be hex, npub or nprofile
+      const resolvePTokensInQuery = (q: string): string => {
+        const rx = /(^|\s)p:(\S+)/gi;
+        let result = '';
+        let lastIndex = 0;
+        let m: RegExpExecArray | null;
+        while ((m = rx.exec(q)) !== null) {
+          const full = m[0];
+          const pre = m[1] || '';
+          const raw = m[2] || '';
+          const match = raw.match(/^([^),.;]+)([),.;]*)$/);
+          const core = (match && match[1]) || raw;
+          const suffix = (match && match[2]) || '';
+          let replacement = core;
+          if (/^[0-9a-fA-F]{64}$/.test(core)) {
+            try { replacement = nip19.npubEncode(core.toLowerCase()); } catch {}
+          } else if (/^npub1[0-9a-z]+$/i.test(core)) {
+            replacement = core;
+          } else if (/^nprofile1[0-9a-z]+$/i.test(core)) {
+            try {
+              const decoded = nip19.decode(core);
+              if (decoded?.type === 'nprofile') {
+                const pk = (decoded.data as { pubkey: string }).pubkey;
+                replacement = nip19.npubEncode(pk);
+              }
+            } catch {}
+          }
+          result += q.slice(lastIndex, m.index);
+          result += `${pre}p:${replacement}${suffix}`;
+          lastIndex = m.index + full.length;
+        }
+        result += q.slice(lastIndex);
+        return result;
+      };
+
+      // 3) Resolve authors inside each distributed branch (if not skipping)
+      const resolvedDistributed = skipAuthorResolution 
+        ? distributed 
+        : await Promise.all(distributed.map((q) => resolveByTokensInQuery(q)));
+
+      const withPResolved = resolvedDistributed.map((q) => resolvePTokensInQuery(q));
+
+      // 4) Split into multiple queries if top-level OR exists
+      const finalQueriesSet = new Set<string>();
+      for (const q of withPResolved) {
+        const parts = parseOrQuery(q);
+        if (parts.length > 1) {
+          parts.forEach((p) => { const s = p.trim(); if (s) finalQueriesSet.add(s); });
+        } else {
+          const s = q.trim(); if (s) finalQueriesSet.add(s);
+        }
+      }
+      const finalQueries = Array.from(finalQueriesSet);
+
+      // Format compact preview
+      const preview = finalQueries.length > 0 ? finalQueries.join('\n') : afterReplacements;
+      // For hashtag queries, always show the translation even if it's the same as the original
+      const finalPreview = (preview === query && isHashtagOnlyQuery(query)) ? `Searching for: ${query}` : preview;
+      return finalPreview;
+    } catch {
+      return '';
+    }
+  }, [authorResolutionCache]);
   const [topCommandText, setTopCommandText] = useState<string | null>(null);
   const [topExamples, setTopExamples] = useState<string[] | null>(null);
   const isSlashCommand = useCallback((input: string): boolean => /^\s*\//.test(input), []);
@@ -659,88 +773,8 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
         setResolvingAuthor(false);
         
         // Update translation after author resolution
-        try {
-          const afterReplacements = await applySimpleReplacements(effectiveQuery);
-          const distributed = expandParenthesizedOr(afterReplacements);
-          
-          // Helper: resolve all by:<author> tokens within a single query string
-          const resolveByTokensInQuery = async (q: string): Promise<string> => {
-            const rx = /(^|\s)by:(\S+)/gi;
-            let result = '';
-            let lastIndex = 0;
-            let m: RegExpExecArray | null;
-            while ((m = rx.exec(q)) !== null) {
-              const full = m[0];
-              const pre = m[1] || '';
-              const raw = m[2] || '';
-              const match = raw.match(/^([^),.;]+)([),.;]*)$/);
-              const core = (match && match[1]) || raw;
-              const suffix = (match && match[2]) || '';
-              let replacement = core;
-              try {
-                const npub = await resolveAuthorToNpub(core);
-                if (npub) replacement = npub;
-              } catch {}
-              result += q.slice(lastIndex, m.index);
-              result += `${pre}by:${replacement}${suffix}`;
-              lastIndex = m.index + full.length;
-            }
-            result += q.slice(lastIndex);
-            return result;
-          };
-          
-          // Helper: normalize p:<token> where token may be hex, npub or nprofile
-          const resolvePTokensInQuery = (q: string): string => {
-            const rx = /(^|\s)p:(\S+)/gi;
-            let result = '';
-            let lastIndex = 0;
-            let m: RegExpExecArray | null;
-            while ((m = rx.exec(q)) !== null) {
-              const full = m[0];
-              const pre = m[1] || '';
-              const raw = m[2] || '';
-              const match = raw.match(/^([^),.;]+)([),.;]*)$/);
-              const core = (match && match[1]) || raw;
-              const suffix = (match && match[2]) || '';
-              let replacement = core;
-              if (/^[0-9a-fA-F]{64}$/.test(core)) {
-                try { replacement = nip19.npubEncode(core.toLowerCase()); } catch {}
-              } else if (/^npub1[0-9a-z]+$/i.test(core)) {
-                replacement = core;
-              } else if (/^nprofile1[0-9a-z]+$/i.test(core)) {
-                try {
-                  const decoded = nip19.decode(core);
-                  if (decoded?.type === 'nprofile') {
-                    const pk = (decoded.data as { pubkey: string }).pubkey;
-                    replacement = nip19.npubEncode(pk);
-                  }
-                } catch {}
-              }
-              result += q.slice(lastIndex, m.index);
-              result += `${pre}p:${replacement}${suffix}`;
-              lastIndex = m.index + full.length;
-            }
-            result += q.slice(lastIndex);
-            return result;
-          };
-          
-          const resolvedDistributed = await Promise.all(distributed.map((q) => resolveByTokensInQuery(q)));
-          const withPResolved = resolvedDistributed.map((q) => resolvePTokensInQuery(q));
-          const finalQueriesSet = new Set<string>();
-          for (const q of withPResolved) {
-            const parts = parseOrQuery(q);
-            if (parts.length > 1) {
-              parts.forEach((p) => { const s = p.trim(); if (s) finalQueriesSet.add(s); });
-            } else {
-              const s = q.trim(); if (s) finalQueriesSet.add(s);
-            }
-          }
-          const finalQueries = Array.from(finalQueriesSet);
-          const preview = finalQueries.length > 0 ? finalQueries.join('\n') : afterReplacements;
-          setTranslation(preview);
-        } catch {
-          setTranslation('');
-        }
+        const translation = await generateTranslation(effectiveQuery, false);
+        setTranslation(translation);
       }
 
       const expanded = await applySimpleReplacements(effectiveQuery);
@@ -760,88 +794,8 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       
       // Set translation for searches without author resolution
       if (!needsAuthorResolution) {
-        try {
-          const afterReplacements = await applySimpleReplacements(effectiveQuery);
-          const distributed = expandParenthesizedOr(afterReplacements);
-          
-          // Helper: resolve all by:<author> tokens within a single query string
-          const resolveByTokensInQuery = async (q: string): Promise<string> => {
-            const rx = /(^|\s)by:(\S+)/gi;
-            let result = '';
-            let lastIndex = 0;
-            let m: RegExpExecArray | null;
-            while ((m = rx.exec(q)) !== null) {
-              const full = m[0];
-              const pre = m[1] || '';
-              const raw = m[2] || '';
-              const match = raw.match(/^([^),.;]+)([),.;]*)$/);
-              const core = (match && match[1]) || raw;
-              const suffix = (match && match[2]) || '';
-              let replacement = core;
-              try {
-                const npub = await resolveAuthorToNpub(core);
-                if (npub) replacement = npub;
-              } catch {}
-              result += q.slice(lastIndex, m.index);
-              result += `${pre}by:${replacement}${suffix}`;
-              lastIndex = m.index + full.length;
-            }
-            result += q.slice(lastIndex);
-            return result;
-          };
-          
-          // Helper: normalize p:<token> where token may be hex, npub or nprofile
-          const resolvePTokensInQuery = (q: string): string => {
-            const rx = /(^|\s)p:(\S+)/gi;
-            let result = '';
-            let lastIndex = 0;
-            let m: RegExpExecArray | null;
-            while ((m = rx.exec(q)) !== null) {
-              const full = m[0];
-              const pre = m[1] || '';
-              const raw = m[2] || '';
-              const match = raw.match(/^([^),.;]+)([),.;]*)$/);
-              const core = (match && match[1]) || raw;
-              const suffix = (match && match[2]) || '';
-              let replacement = core;
-              if (/^[0-9a-fA-F]{64}$/.test(core)) {
-                try { replacement = nip19.npubEncode(core.toLowerCase()); } catch {}
-              } else if (/^npub1[0-9a-z]+$/i.test(core)) {
-                replacement = core;
-              } else if (/^nprofile1[0-9a-z]+$/i.test(core)) {
-                try {
-                  const decoded = nip19.decode(core);
-                  if (decoded?.type === 'nprofile') {
-                    const pk = (decoded.data as { pubkey: string }).pubkey;
-                    replacement = nip19.npubEncode(pk);
-                  }
-                } catch {}
-              }
-              result += q.slice(lastIndex, m.index);
-              result += `${pre}p:${replacement}${suffix}`;
-              lastIndex = m.index + full.length;
-            }
-            result += q.slice(lastIndex);
-            return result;
-          };
-          
-          const resolvedDistributed = await Promise.all(distributed.map((q) => resolveByTokensInQuery(q)));
-          const withPResolved = resolvedDistributed.map((q) => resolvePTokensInQuery(q));
-          const finalQueriesSet = new Set<string>();
-          for (const q of withPResolved) {
-            const parts = parseOrQuery(q);
-            if (parts.length > 1) {
-              parts.forEach((p) => { const s = p.trim(); if (s) finalQueriesSet.add(s); });
-            } else {
-              const s = q.trim(); if (s) finalQueriesSet.add(s);
-            }
-          }
-          const finalQueries = Array.from(finalQueriesSet);
-          const preview = finalQueries.length > 0 ? finalQueries.join('\n') : afterReplacements;
-          setTranslation(preview);
-        } catch {
-          setTranslation('');
-        }
+        const translation = await generateTranslation(effectiveQuery, false);
+        setTranslation(translation);
       }
 
       // Track relays that returned events for this search
@@ -1183,108 +1137,46 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
     }
   };
 
-  // Live translation preview (debounced)
+  // Live translation preview with smart author resolution
   useEffect(() => {
     let cancelled = false;
-    const id = setTimeout(() => {
-      (async () => {
-        try {
-          // 1) Apply simple replacements first
-          const afterReplacements = await applySimpleReplacements(query);
-
-          // 2) Recursive OR substitution (distribute parentheses)
-          const distributed = expandParenthesizedOr(afterReplacements);
-
-          // Helper: resolve all by:<author> tokens within a single query string
-          const resolveByTokensInQuery = async (q: string): Promise<string> => {
-            const rx = /(^|\s)by:(\S+)/gi;
-            let result = '';
-            let lastIndex = 0;
-            let m: RegExpExecArray | null;
-            while ((m = rx.exec(q)) !== null) {
-              const full = m[0];
-              const pre = m[1] || '';
-              const raw = m[2] || '';
-              const match = raw.match(/^([^),.;]+)([),.;]*)$/);
-              const core = (match && match[1]) || raw;
-              const suffix = (match && match[2]) || '';
-              let replacement = core;
-              try {
-                const npub = await resolveAuthorToNpub(core);
-                if (npub) replacement = npub;
-              } catch {}
-              result += q.slice(lastIndex, m.index);
-              result += `${pre}by:${replacement}${suffix}`;
-              lastIndex = m.index + full.length;
-            }
-            result += q.slice(lastIndex);
-            return result;
-          };
-
-          // 3) Resolve authors inside each distributed branch
-          const resolvedDistributed = await Promise.all(distributed.map((q) => resolveByTokensInQuery(q)));
-
-          // Helper: normalize p:<token> where token may be hex, npub or nprofile
-          const resolvePTokensInQuery = (q: string): string => {
-            const rx = /(^|\s)p:(\S+)/gi;
-            let result = '';
-            let lastIndex = 0;
-            let m: RegExpExecArray | null;
-            while ((m = rx.exec(q)) !== null) {
-              const full = m[0];
-              const pre = m[1] || '';
-              const raw = m[2] || '';
-              const match = raw.match(/^([^),.;]+)([),.;]*)$/);
-              const core = (match && match[1]) || raw;
-              const suffix = (match && match[2]) || '';
-              let replacement = core;
-              if (/^[0-9a-fA-F]{64}$/.test(core)) {
-                try { replacement = nip19.npubEncode(core.toLowerCase()); } catch {}
-              } else if (/^npub1[0-9a-z]+$/i.test(core)) {
-                replacement = core;
-              } else if (/^nprofile1[0-9a-z]+$/i.test(core)) {
-                try {
-                  const decoded = nip19.decode(core);
-                  if (decoded?.type === 'nprofile') {
-                    const pk = (decoded.data as { pubkey: string }).pubkey;
-                    replacement = nip19.npubEncode(pk);
-                  }
-                } catch {}
-              }
-              result += q.slice(lastIndex, m.index);
-              result += `${pre}p:${replacement}${suffix}`;
-              lastIndex = m.index + full.length;
-            }
-            result += q.slice(lastIndex);
-            return result;
-          };
-
-          const withPResolved = resolvedDistributed.map((q) => resolvePTokensInQuery(q));
-
-          // 4) Split into multiple queries if top-level OR exists
-          const finalQueriesSet = new Set<string>();
-          for (const q of withPResolved) {
-            const parts = parseOrQuery(q);
-            if (parts.length > 1) {
-              parts.forEach((p) => { const s = p.trim(); if (s) finalQueriesSet.add(s); });
-            } else {
-              const s = q.trim(); if (s) finalQueriesSet.add(s);
-            }
-          }
-          const finalQueries = Array.from(finalQueriesSet);
-
-          // Format compact preview
-          const preview = finalQueries.length > 0 ? finalQueries.join('\n') : afterReplacements;
-          // For hashtag queries, always show the translation even if it's the same as the original
-          const finalPreview = (preview === query && isHashtagOnlyQuery(query)) ? `Searching for: ${query}` : preview;
-          if (!cancelled) setTranslation(finalPreview);
-        } catch {
-          if (!cancelled) setTranslation('');
+    
+    // Clear any existing timeout
+    if (authorResolutionTimeout.current) {
+      clearTimeout(authorResolutionTimeout.current);
+    }
+    
+    // Check if query contains author resolution tokens
+    const hasAuthorTokens = /(^|\s)by:(\S+)/gi.test(query);
+    
+    if (hasAuthorTokens) {
+      // For queries with author tokens, show immediate translation without resolution
+      // then update with resolution after a delay
+      generateTranslation(query, true).then((immediateTranslation) => {
+        if (!cancelled) setTranslation(immediateTranslation);
+      });
+      
+      // Debounce author resolution to avoid excessive requests
+      authorResolutionTimeout.current = setTimeout(async () => {
+        if (!cancelled) {
+          const fullTranslation = await generateTranslation(query, false);
+          if (!cancelled) setTranslation(fullTranslation);
         }
-      })();
-    }, 120);
-    return () => { cancelled = true; clearTimeout(id); };
-  }, [query]);
+      }, 500); // 500ms delay for author resolution
+    } else {
+      // For queries without author tokens, update immediately
+      generateTranslation(query, false).then((translation) => {
+        if (!cancelled) setTranslation(translation);
+      });
+    }
+    
+    return () => { 
+      cancelled = true; 
+      if (authorResolutionTimeout.current) {
+        clearTimeout(authorResolutionTimeout.current);
+      }
+    };
+  }, [query, generateTranslation]);
 
   const goToProfile = useCallback((npub: string, prefetchEvent?: NDKEvent) => {
     try {

--- a/src/lib/examples.ts
+++ b/src/lib/examples.ts
@@ -48,6 +48,7 @@ export const searchExamples = [
   // Direct npub
   'GN by:npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc',
   'proof-of-work by:npub1satsv3728d65nenvkmzthrge0aduj8088dvwkxk70rydm407cl4s87sfhu',
+  'essay by:npub1sfhflz2msx45rfzjyf5tyj0x35pv4qtq3hh4v2jf8nhrtl79cavsl2ymqt',
 
   // Profile lookup / NIP-05
   'p:fiatjaf',


### PR DESCRIPTION
Always show and live-update the search explanation; fix URL handling on `/t/` and `/e/` paths

This PR ensures the search explanation is always visible and updates live as the user types, with smart debounced author resolution and caching for `by:` tokens. It also fixes URL updates across special paths: hashtag queries navigate to `/t/<tags>`, generic queries navigate to `/?q=...`, and `/e/` pages now delegate URL updates via `onUrlUpdate`. Minor refactors keep logic DRY and consistent.

- Optimize live translation with `generateTranslation` and author cache/debounce
- Unify URL update logic; add `onUrlUpdate` on `/e/` and `/t/` pages
- Add example `essay by:npub1sfhflz2msx45rfzjyf5tyj0x35pv4qtq3hh4v2jf8nhrtl79cavsl2ymqt`
