### PR TITLE
feat: align relay usage and cached profile tracking

### DIFF
--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -882,7 +882,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       if (isDirectQuery) {
         // Direct queries (NIP-19): use all relays
         console.log('[Search] Direct query detected, using all relays');
-        relaySet = await relaySets.search();
+        relaySet = await relaySets.default();
       } else {
         // Search queries (NIP-50): use NIP-50 capable relays only
         console.log('[Search] Search query detected, using NIP-50 relays');

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -882,7 +882,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       if (isDirectQuery) {
         // Direct queries (NIP-19): use all relays
         console.log('[Search] Direct query detected, using all relays');
-        relaySet = await relaySets.default();
+        relaySet = await relaySets.search();
       } else {
         // Search queries (NIP-50): use NIP-50 capable relays only
         console.log('[Search] Search query detected, using NIP-50 relays');

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -3,7 +3,7 @@ import { ndk, connectWithTimeout, markRelayActivity, safeSubscribe, isValidFilte
 import { getStoredPubkey } from './nip07';
 import { searchProfilesFullText, resolveNip05ToPubkey, profileEventFromPubkey, resolveAuthor } from './vertex';
 import { nip19 } from 'nostr-tools';
-import { relaySets as predefinedRelaySets, RELAYS, getNip50SearchRelaySet } from './relays';
+import { relaySets as predefinedRelaySets, RELAYS, getNip50SearchRelaySet, extendWithUserAndPremium } from './relays';
 import { getUserRelayAdditions } from './storage';
 import { normalizeRelayUrl } from './urlUtils';
 import { trackEventRelay, getEventRelaySources, getRelayContributions } from './eventRelayTracking';
@@ -47,12 +47,10 @@ async function getSearchRelaySet(): Promise<NDKRelaySet> {
 }
 
 async function getBroadRelaySet(): Promise<NDKRelaySet> {
-  const union = new Set<string>([
-    ...RELAYS.DEFAULT,
-    ...RELAYS.SEARCH,
-    ...getUserRelayAdditions()
-  ]);
-  return NDKRelaySet.fromRelayUrls(Array.from(union), ndk);
+  const base = await extendWithUserAndPremium([...RELAYS.DEFAULT, ...RELAYS.SEARCH]);
+  const manual = getUserRelayAdditions();
+  const combined = new Set<string>([...base, ...manual]);
+  return NDKRelaySet.fromRelayUrls(Array.from(combined), ndk);
 }
 
 // (Removed heuristic content filter; rely on recursive OR expansion + relay-side search)


### PR DESCRIPTION
Aligns relay handling with the NIP-50/51 expectations and ensures cached profile results still light up the correct relays in the UI.
- extend relay sets with user lists, blocklists, and premium/search relays where appropriate
- distinguish NIP-50 searches from direct NIP-19 lookups when choosing relay coverage
- record relay activity for cached profile responses so `RelayStatusDisplay` highlights stay accurate
