### PR TITLE
Add /tutorial slash command and improve command UI

### DIFF
--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -231,7 +231,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       setTopExamples(null);
       handleSearch(tutorialNevent);
     }
-  }), [buildCli, setTopCommandText, setPlaceholder, setTopExamples, setLoginState, setCurrentUser, handleSearch]);
+  }), [buildCli, setTopCommandText, setPlaceholder, setTopExamples, setLoginState, setCurrentUser]);
 
   const [profileScopeUser, setProfileScopeUser] = useState<NDKUser | null>(null);
   const [successfullyActiveRelays, setSuccessfullyActiveRelays] = useState<Set<string>>(new Set());

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -224,8 +224,14 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       } catch (error) {
         setTopCommandText(buildCli('clear', `Cache clearing failed: ${error}`));
       }
+    },
+    onTutorial: () => {
+      const tutorialNevent = 'nevent1qqstgekdlmaeu3n6gf3ss7nnlq4f0hfx3nm3nmy0pf84xs7e98wyt2ssw5p34';
+      setTopCommandText(buildCli('tutorial', 'Loading tutorial event...'));
+      setTopExamples(null);
+      handleSearch(tutorialNevent);
     }
-  }), [buildCli, setTopCommandText, setPlaceholder, setTopExamples, setLoginState, setCurrentUser]);
+  }), [buildCli, setTopCommandText, setPlaceholder, setTopExamples, setLoginState, setCurrentUser, handleSearch]);
 
   const [profileScopeUser, setProfileScopeUser] = useState<NDKUser | null>(null);
   const [successfullyActiveRelays, setSuccessfullyActiveRelays] = useState<Set<string>>(new Set());

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -1602,40 +1602,42 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
                 event={new NDKEvent(ndk)}
                 onAuthorClick={goToProfile}
                 renderContent={() => (
-                  topExamples && topExamples.length > 0 ? (
-                    <pre className="text-xs overflow-x-auto rounded-md p-3 bg-[#1f1f1f] border border-[#3d3d3d]">
-                      <div>{topCommandText.split('\n')[0]}</div>
-                      <div>&nbsp;</div>
-                      {topExamples.map((ex, idx) => (
-                        <div key={`${ex}-${idx}`}>
-                          <button
-                            type="button"
-                            className="text-left w-full hover:underline"
-                            onClick={() => handleContentSearch(ex)}
-                          >
-                            {ex}
-                          </button>
-                        </div>
-                      ))}
-                    </pre>
-                  ) : (
-                    <Highlight code={topCommandText} language="bash" theme={themes.nightOwl}>
-                      {({ className: cls, style, tokens, getLineProps, getTokenProps }: RenderProps) => (
-                        <pre
-                          className={`${cls} text-xs overflow-x-auto rounded-md p-3 bg-[#1f1f1f] border border-[#3d3d3d]`.trim()}
-                          style={{ ...style, background: 'transparent', whiteSpace: 'pre' }}
-                        >
-                          {tokens.map((line, i) => (
-                            <div key={`cmd-${i}`} {...getLineProps({ line })}>
-                              {line.map((token, key) => (
-                                <span key={`cmd-t-${i}-${key}`} {...getTokenProps({ token })} />
-                              ))}
-                            </div>
-                          ))}
-                        </pre>
-                      )}
-                    </Highlight>
-                  )
+                  <Highlight code={topCommandText} language="bash" theme={themes.nightOwl}>
+                    {({ className: cls, style, tokens, getLineProps, getTokenProps }: RenderProps) => (
+                      <pre
+                        className={`${cls} text-xs overflow-x-auto rounded-md p-3 bg-[#1f1f1f] border border-[#3d3d3d]`.trim()}
+                        style={{ ...style, background: 'transparent', whiteSpace: 'pre' }}
+                      >
+                        {topExamples && topExamples.length > 0 ? (
+                          <>
+                            <div>{topCommandText.split('\n')[0]}</div>
+                            <div>&nbsp;</div>
+                            {topExamples.map((ex, idx) => (
+                              <div key={`${ex}-${idx}`}>
+                                <button
+                                  type="button"
+                                  className="text-left w-full hover:underline"
+                                  onClick={() => handleContentSearch(ex)}
+                                >
+                                  {ex}
+                                </button>
+                              </div>
+                            ))}
+                          </>
+                        ) : (
+                          <>
+                            {tokens.map((line, i) => (
+                              <div key={`cmd-${i}`} {...getLineProps({ line })}>
+                                {line.map((token, key) => (
+                                  <span key={`cmd-t-${i}-${key}`} {...getTokenProps({ token })} />
+                                ))}
+                              </div>
+                            ))}
+                          </>
+                        )}
+                      </pre>
+                    )}
+                  </Highlight>
                 )}
                 variant="card"
                 showFooter={false}

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -158,7 +158,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
   const runSlashCommand = useMemo(() => createSlashCommandRunner({
     onHelp: (commands) => {
       const lines = ['Available commands:', ...commands.map(c => `  ${c.label.padEnd(12)} ${c.description}`)];
-      setTopCommandText(buildCli('help', lines));
+      setTopCommandText(buildCli('--help', lines));
       setTopExamples(commands.map(c => c.label));
     },
     onExamples: () => {
@@ -1599,7 +1599,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
                 renderContent={() => (
                   topExamples && topExamples.length > 0 ? (
                     <pre className="text-xs overflow-x-auto rounded-md p-3 bg-[#1f1f1f] border border-[#3d3d3d]">
-                      <div>$ ants examples</div>
+                      <div>$ ants --help</div>
                       <div>&nbsp;</div>
                       {topExamples.map((ex, idx) => (
                         <div key={`${ex}-${idx}`}>

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -1617,7 +1617,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
                                 <button
                                   type="button"
                                   className="text-left w-full hover:underline"
-                                  onClick={() => handleContentSearch(ex)}
+                                  onClick={() => handleContentSearch(ex.trim().split(/\s+/)[0])}
                                 >
                                   {ex}
                                 </button>

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -229,9 +229,10 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       const tutorialNevent = 'nevent1qqstgekdlmaeu3n6gf3ss7nnlq4f0hfx3nm3nmy0pf84xs7e98wyt2ssw5p34';
       setTopCommandText(buildCli('--help tutorial', 'Loading tutorial event...'));
       setTopExamples(null);
-      handleSearch(tutorialNevent);
+      setQuery(tutorialNevent);
+      updateSearchQuery(searchParams, router, tutorialNevent);
     }
-  }), [buildCli, setTopCommandText, setPlaceholder, setTopExamples, setLoginState, setCurrentUser]);
+  }), [buildCli, setTopCommandText, setPlaceholder, setTopExamples, setLoginState, setCurrentUser, setQuery, searchParams, router]);
 
   const [profileScopeUser, setProfileScopeUser] = useState<NDKUser | null>(null);
   const [successfullyActiveRelays, setSuccessfullyActiveRelays] = useState<Set<string>>(new Set());

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -159,7 +159,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
     onHelp: (commands) => {
       const lines = ['Available commands:', ...commands.map(c => `  ${c.label.padEnd(12)} ${c.description}`)];
       setTopCommandText(buildCli('--help', lines));
-      setTopExamples(commands.map(c => c.label));
+      setTopExamples(null);
     },
     onExamples: () => {
       const examples = getFilteredExamples(isLoggedIn());

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -176,7 +176,8 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
           // Immediately set current user and logged-in state for instant header update
           setCurrentUser(user);
           setLoginState('logged-in');
-          setTopCommandText(buildCli('login', `Logged in as ${user.profile?.displayName || user.profile?.name || user.npub}`));
+          const userDisplay = user.profile?.nip05 || user.profile?.displayName || user.profile?.name || user.npub;
+          setTopCommandText(buildCli('login', `Logged in as ${userDisplay}`));
           setPlaceholder(nextExample());
 
           // Fetch profile in the background to avoid blocking header update
@@ -190,6 +191,9 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
                 cloned.profile = { ...(user.profile as Record<string, unknown>) } as typeof user.profile;
               }
               setCurrentUser(cloned);
+              // Update login message with fetched profile info
+              const updatedDisplay = cloned.profile?.nip05 || cloned.profile?.displayName || cloned.profile?.name || cloned.npub;
+              setTopCommandText(buildCli('login', `Logged in as ${updatedDisplay}`));
             } catch {}
           })();
         } else {

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -1605,8 +1605,8 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
                   <Highlight code={topCommandText} language="bash" theme={themes.nightOwl}>
                     {({ className: cls, style, tokens, getLineProps, getTokenProps }: RenderProps) => (
                       <pre
-                        className={`${cls} text-xs overflow-x-auto rounded-md p-3 bg-[#1f1f1f] border border-[#3d3d3d]`.trim()}
-                        style={{ ...style, background: 'transparent', whiteSpace: 'pre' }}
+                        className={`${cls} text-xs overflow-x-auto rounded-md p-3 border border-[#3d3d3d]`.trim()}
+                        style={{ ...style, whiteSpace: 'pre' }}
                       >
                         {topExamples && topExamples.length > 0 ? (
                           <>

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { connect, nextExample, ndk, ConnectionStatus, addConnectionStatusListener, removeConnectionStatusListener, getRecentlyActiveRelays } from '@/lib/ndk';
-import { createSlashCommandRunner, executeClearCommand, SLASH_COMMANDS, type SlashCommand } from '@/lib/slashCommands';
+import { createSlashCommandRunner, executeClearCommand, type SlashCommand } from '@/lib/slashCommands';
 import { resolveAuthorToNpub } from '@/lib/vertex';
 import { NDKEvent } from '@nostr-dev-kit/ndk';
 import { searchEvents } from '@/lib/search';
@@ -1814,7 +1814,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
             })}
           </div>
         );
-      }, [fuseFilteredResults, expandedParents, goToProfile, renderContentWithClickableHashtags, renderNoteMedia, renderNoteHeader, renderParentChain, getReplyToEventId, topCommandText, topExamples, handleContentSearch, getCommonEventCardProps, isDirectQuery, loading, query])}
+      }, [fuseFilteredResults, expandedParents, goToProfile, renderContentWithClickableHashtags, renderNoteMedia, renderNoteHeader, renderParentChain, getReplyToEventId, topCommandText, topExamples, helpCommands, handleContentSearch, getCommonEventCardProps, isDirectQuery, loading, query])}
     </div>
   );
 }

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -159,7 +159,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
     onHelp: (commands) => {
       const lines = ['Available commands:', ...commands.map(c => `  ${c.label.padEnd(12)} ${c.description}`)];
       setTopCommandText(buildCli('--help', lines));
-      setTopExamples(null);
+      setTopExamples(commands.map(c => `${c.label.padEnd(12)} ${c.description}`));
     },
     onExamples: () => {
       const examples = getFilteredExamples(isLoggedIn());

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -1600,7 +1600,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
                 renderContent={() => (
                   topExamples && topExamples.length > 0 ? (
                     <pre className="text-xs overflow-x-auto rounded-md p-3 bg-[#1f1f1f] border border-[#3d3d3d]">
-                      <div>$ ants --help</div>
+                      <div>{topCommandText.split('\n')[0]}</div>
                       <div>&nbsp;</div>
                       {topExamples.map((ex, idx) => (
                         <div key={`${ex}-${idx}`}>

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -164,7 +164,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
     onExamples: () => {
       const examples = getFilteredExamples(isLoggedIn());
       setTopExamples(Array.from(examples));
-      setTopCommandText(buildCli('examples'));
+      setTopCommandText(buildCli('--help examples'));
     },
     onLogin: async () => {
       setLoginState('logging-in');
@@ -216,18 +216,18 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       setTopExamples(null);
     },
     onClear: async () => {
-      setTopCommandText(buildCli('clear', 'Clearing all caches...'));
+      setTopCommandText(buildCli('clear --cache', 'Clearing all caches...'));
       setTopExamples(null);
       try {
         await executeClearCommand();
-        setTopCommandText(buildCli('clear', 'All caches cleared successfully'));
+        setTopCommandText(buildCli('clear --cache', 'All caches cleared successfully'));
       } catch (error) {
-        setTopCommandText(buildCli('clear', `Cache clearing failed: ${error}`));
+        setTopCommandText(buildCli('clear --cache', `Cache clearing failed: ${error}`));
       }
     },
     onTutorial: () => {
       const tutorialNevent = 'nevent1qqstgekdlmaeu3n6gf3ss7nnlq4f0hfx3nm3nmy0pf84xs7e98wyt2ssw5p34';
-      setTopCommandText(buildCli('tutorial', 'Loading tutorial event...'));
+      setTopCommandText(buildCli('--help tutorial', 'Loading tutorial event...'));
       setTopExamples(null);
       handleSearch(tutorialNevent);
     }

--- a/src/lib/examples.ts
+++ b/src/lib/examples.ts
@@ -1,5 +1,9 @@
 // Search examples that we'll randomly select from and test
 export const searchExamples = [
+
+  // Slash Commands
+  '/help',
+
   // Basic
   'vibe coding',
   'nicolas-cage.gif',
@@ -44,11 +48,6 @@ export const searchExamples = [
   'freedom by:ulbricht',
   'knowledge by:platobot@dergigi.com',
   'is:muted by:fiatjaf',
-
-  // Direct npub
-  'GN by:npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc',
-  'proof-of-work by:npub1satsv3728d65nenvkmzthrge0aduj8088dvwkxk70rydm407cl4s87sfhu',
-  'essay by:npub1sfhflz2msx45rfzjyf5tyj0x35pv4qtq3hh4v2jf8nhrtl79cavsl2ymqt',
 
   // Profile lookup / NIP-05
   'p:fiatjaf',
@@ -125,16 +124,18 @@ export const searchExamples = [
   'is:highlight (bitcoin OR nostr)',
   'is:highlight (by:fiatjaf.com OR by:@f7z.io)',
 
-  // Multiple Authors
-  'NIP-EE (by:jeffg OR by:futurepaul OR by:franzap)',
-
   // Multiple hashtags
   '#penisbutter or #⭕️',
   '#pugstr or #horsestr or #goatstr',
 
-  // Slash Commands
-  '/help',
-  '/examples',
+  // Multiple Authors
+  'NIP-EE (by:jeffg OR by:futurepaul OR by:franzap)',
+
+  // Direct npub
+  'GN by:npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc',
+  'proof-of-work by:npub1satsv3728d65nenvkmzthrge0aduj8088dvwkxk70rydm407cl4s87sfhu',
+  'essay by:npub1sfhflz2msx45rfzjyf5tyj0x35pv4qtq3hh4v2jf8nhrtl79cavsl2ymqt',
+
 ] as const;
 
 // Examples that require login to work properly

--- a/src/lib/slashCommands.ts
+++ b/src/lib/slashCommands.ts
@@ -13,7 +13,7 @@ export const SLASH_COMMANDS: readonly SlashCommand[] = [
   { key: 'login', label: '/login', description: 'Connect with NIP-07' },
   { key: 'logout', label: '/logout', description: 'Clear session' },
   { key: 'clear', label: '/clear', description: 'Clear all caches' },
-  { key: 'tutorial', label: '/tutorial', description: 'Show tutorial event' }
+  { key: 'tutorial', label: '/tutorial', description: 'Show tutorial video' }
 ] as const;
 
 export interface SlashCommandHandlers {

--- a/src/lib/slashCommands.ts
+++ b/src/lib/slashCommands.ts
@@ -12,7 +12,8 @@ export const SLASH_COMMANDS: readonly SlashCommand[] = [
   { key: 'examples', label: '/examples', description: 'List example queries' },
   { key: 'login', label: '/login', description: 'Connect with NIP-07' },
   { key: 'logout', label: '/logout', description: 'Clear session' },
-  { key: 'clear', label: '/clear', description: 'Clear all caches' }
+  { key: 'clear', label: '/clear', description: 'Clear all caches' },
+  { key: 'tutorial', label: '/tutorial', description: 'Show tutorial event' }
 ] as const;
 
 export interface SlashCommandHandlers {
@@ -21,6 +22,7 @@ export interface SlashCommandHandlers {
   onLogin: () => Promise<void>;
   onLogout: () => void;
   onClear: () => Promise<void>;
+  onTutorial: () => void;
 }
 
 export function createSlashCommandRunner(handlers: SlashCommandHandlers) {
@@ -49,6 +51,11 @@ export function createSlashCommandRunner(handlers: SlashCommandHandlers) {
     
     if (cmd === 'clear') {
       handlers.onClear();
+      return;
+    }
+    
+    if (cmd === 'tutorial') {
+      handlers.onTutorial();
       return;
     }
     


### PR DESCRIPTION
Adds a `/tutorial` slash command that searches for a specific tutorial video event. Also improves the slash command interface with better styling and usability.

- All slash commands now display with consistent darker background using syntax highlighting
- Help command shows clickable command list with descriptions
- Login message prioritizes NIP-05 over npub for better readability
- Reorganized search examples to feature `/help` as the first discoverable command
