### PR TITLE
fix: handle naddr identifiers to prevent redirect loop

### DIFF
--- a/src/app/e/[id]/page.tsx
+++ b/src/app/e/[id]/page.tsx
@@ -14,7 +14,7 @@ export default function EidRedirectPage() {
 
   const normalizedQuery = useMemo(() => parseEventIdentifier(rawId), [rawId]);
 
-  // If we have a valid nevent/note, display it directly instead of redirecting
+  // If we have a valid nevent/note/naddr, display it directly instead of redirecting
   const isValidNevent = useMemo(() => isValidEventIdentifier(normalizedQuery), [normalizedQuery]);
 
   // Unified URL update handler: while on /e/ pages, any non-empty query
@@ -53,13 +53,13 @@ export default function EidRedirectPage() {
   useEffect(() => {
     if (!normalizedQuery) return;
     
-    // Only redirect if it's not a valid nevent/note to avoid infinite loop
+    // Only redirect if it's not a valid nevent/note/naddr to avoid infinite loop
     if (!isValidNevent) {
       router.replace(`/?q=${encodeURIComponent(normalizedQuery)}`);
     }
   }, [normalizedQuery, router, isValidNevent]);
 
-  // If it's a valid nevent/note, display the search view directly
+  // If it's a valid nevent/note/naddr, display the search view directly
   if (isValidNevent) {
     return (
       <main className="min-h-screen bg-[#1a1a1a] text-gray-100">

--- a/src/lib/utils/nostrIdentifiers.ts
+++ b/src/lib/utils/nostrIdentifiers.ts
@@ -196,16 +196,16 @@ export function normalizeNostrIdentifier(rawId: string): string {
 }
 
 /**
- * Parses an identifier for event pages (/e/[id]) - handles nevent, note, and hex event IDs
+ * Parses an identifier for event pages (/e/[id]) - handles nevent, note, naddr, and hex event IDs
  */
 export function parseEventIdentifier(rawId: string): string {
   const token = normalizeNostrIdentifier(rawId);
   if (!token) return '';
 
-  // If it's bech32 nevent/note, pass through unchanged
+  // If it's bech32 nevent/note/naddr, pass through unchanged
   try {
     const decoded = nip19.decode(token);
-    if (decoded?.type === 'nevent' || decoded?.type === 'note') {
+    if (decoded?.type === 'nevent' || decoded?.type === 'note' || decoded?.type === 'naddr') {
       return token;
     }
   } catch {}
@@ -244,13 +244,13 @@ export function parseProfileIdentifier(rawId: string): string {
 }
 
 /**
- * Checks if an identifier is a valid nevent or note
+ * Checks if an identifier is a valid nevent, note, or naddr
  */
 export function isValidEventIdentifier(identifier: string): boolean {
   if (!identifier) return false;
   try {
     const decoded = nip19.decode(identifier);
-    return decoded?.type === 'nevent' || decoded?.type === 'note';
+    return decoded?.type === 'nevent' || decoded?.type === 'note' || decoded?.type === 'naddr';
   } catch {
     return false;
   }


### PR DESCRIPTION
Fix infinite redirect loop when opening naddr URLs by properly handling naddr identifiers in event identifier validation and parsing functions.

- Update `isValidEventIdentifier` to recognize `naddr` as a valid event identifier type
- Update `parseEventIdentifier` to handle `naddr` properly alongside `nevent` and `note`
- Update comments in `/e/[id]` page to reflect naddr support
