### PR TITLE
Fix duplicate OR in has:image replacement expansion

### DIFF
--- a/public/replacements.txt
+++ b/public/replacements.txt
@@ -28,7 +28,7 @@ site:hackernews => (news.ycombinator.com OR www.news.ycombinator.com)
 site:hn => (news.ycombinator.com OR www.news.ycombinator.com)
 
 # --- HAS ---
-has:image => (.png OR .jpg OR .jpeg OR OR .webp OR .avif OR .svg)
+has:image => (.png OR .jpg OR .jpeg OR .webp OR .avif OR .svg)
 has:video => (.mp4 OR .webm OR .ogg OR .ogv OR .mov OR .m4v)
 has:gif => (.gif OR .gifs OR .apng)
 


### PR DESCRIPTION
Fixes a syntax error in the `has:image` replacement expansion where a duplicate `OR` operator was causing incorrect query expansion. The pattern now correctly expands to `.png OR .jpg OR .jpeg OR .webp OR .avif OR .svg` without the extra `OR`.

- Removed duplicate `OR` operator in `has:image` replacement pattern
- Corrects query expansion for image searches
