### PR TITLE
fix: remove dead ternary in EventCard

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -122,7 +122,7 @@ export default function EventCard({ event, onAuthorClick, renderContent, variant
           const result = await resolveProfileName(pubkeyHex);
           if (!isMounted) return;
           if (result) {
-            setLabel(result.isNpubFallback ? result.display : result.display);
+            setLabel(result.display);
           } else {
             setLabel(shortenNpub(npubVal));
           }


### PR DESCRIPTION
Both branches of `result.isNpubFallback ? result.display : result.display` were identical. Simplified to `result.display`.

The bench/nip66.ts nit from #138 is no longer relevant since #136 (NIP-66) is now merged and the benchmark file belongs there.

Closes #138