### PR TITLE
feat: add NIP-05 well-known endpoint for _@ants.sh

### DIFF
--- a/src/app/.well-known/nostr.json/route.ts
+++ b/src/app/.well-known/nostr.json/route.ts
@@ -10,6 +10,8 @@ const NIP05_DATA = {
       'wss://relay.primal.net',
       'wss://nos.lol',
       'wss://purplepag.es',
+      'wss://haven.dergigi.com',
+      'wss://wot.dergigi.com',
     ],
   },
 };


### PR DESCRIPTION
Adds a `/.well-known/nostr.json` route handler that serves the NIP-05 identity `_@ants.sh`, mapping it to the ants.sh project pubkey.

- Maps `_` (root identifier) → `e530f930efb36ec1da0f5f249ad3db8edf19b667570acab817c82185d562e889`
- Includes relay list in the response
- Sets `Access-Control-Allow-Origin: *` (required by NIP-05 spec)
- 1-hour cache for performance

Once merged and deployed, the nostr profile can set `nip05: _@ants.sh` and it will validate.