### PR TITLE
feat: use native browser video controls

### DIFF
--- a/src/components/VideoWithBlurhash.tsx
+++ b/src/components/VideoWithBlurhash.tsx
@@ -112,20 +112,14 @@ export default function VideoWithBlurhash({
         }}
         onLoadedData={() => { setVideoLoaded(true); setStatusCode(200); }}
         onError={() => {
-          try {
-            fetch(src, { method: 'HEAD' }).then((res) => {
+          setVideoError(true);
+          fetch(src, { method: 'HEAD' })
+            .then((res) => {
               setStatusCode(res.status || null);
-              if (res.status >= 400) {
-                setVideoError(true);
-              }
-            }).catch(() => {
+            })
+            .catch(() => {
               setStatusCode(null);
-              setVideoError(true);
             });
-          } catch { 
-            setStatusCode(null);
-            setVideoError(true);
-          }
         }}
       >
         <source src={src} />


### PR DESCRIPTION
Replaces the custom play/pause overlay with native HTML5 `<video controls>`.

**What you get:**
- Seek bar
- Volume control
- Fullscreen
- Picture-in-picture
- Playback speed (right-click → Playback speed)

**What's removed:**
- Custom play/pause overlay (`faPlay`/`faPause` icons)
- `isPlaying`/`showControls` state + click/hover handlers

Net result: **-53 lines**, better UX.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Video player now uses native browser controls for playback, removing the custom overlay play button and mouse-over control UI for a more consistent experience.
  * Blurhash placeholder, loading spinner, error display, and search/reverse-search overlays are preserved.
  * Video metadata (dimensions) are captured on load to improve sizing and layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->