### PR TITLE
fix: deduplicate replaceable events in search results

### DIFF
--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -74,6 +74,7 @@ import { useLoginTrigger } from '@/lib/LoginTrigger';
 import { useClearTrigger } from '@/lib/ClearTrigger';
 import { SearchResultsPlaceholder, PlaceholderStyles } from './Placeholder';
 import { detectSearchType } from '@/lib/search/searchTypeDetection';
+import { deduplicateReplaceableEvents } from '@/lib/search/searchUtils';
 import packageJson from '../../package.json';
 
 type Props = {
@@ -436,9 +437,10 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
 
   // Apply optional fuzzy filter on top of client-side filters
   const fuseFilteredResults = useMemo(() => {
+    const deduplicated = deduplicateReplaceableEvents(filteredResults);
     const q = (shouldEnableFilters && filterSettings.fuzzyEnabled ? (filterSettings.resultFilter || '') : '').trim();
-    if (!q) return filteredResults;
-    const fuse = new Fuse(filteredResults, {
+    if (!q) return deduplicated;
+    const fuse = new Fuse(deduplicated, {
       includeScore: false,
       threshold: 0.35,
       ignoreLocation: true,

--- a/src/lib/search/searchUtils.ts
+++ b/src/lib/search/searchUtils.ts
@@ -51,5 +51,31 @@ export function buildSearchQueryWithExtensions(baseQuery: string, extensions: Ni
   return query.trim();
 }
 
+/**
+ * Deduplicate parameterized replaceable events (kinds 30000-39999).
+ * These are keyed by kind:pubkey:d-tag — keeps only the newest version.
+ * Non-replaceable events pass through unchanged.
+ */
+export function deduplicateReplaceableEvents(events: NDKEvent[]): NDKEvent[] {
+  const replaceableNewest = new Map<string, NDKEvent>();
+  const result: NDKEvent[] = [];
+
+  for (const event of events) {
+    const kind = event.kind ?? 0;
+    if (kind >= 30000 && kind < 40000) {
+      const dTag = event.tags?.find((t) => t[0] === 'd')?.[1] ?? '';
+      const key = `${kind}:${event.pubkey}:${dTag}`;
+      const existing = replaceableNewest.get(key);
+      if (!existing || (event.created_at ?? 0) > (existing.created_at ?? 0)) {
+        replaceableNewest.set(key, event);
+      }
+    } else {
+      result.push(event);
+    }
+  }
+
+  return [...result, ...replaceableNewest.values()];
+}
+
 // Re-export the subscription functions from the subscriptions module
 export { subscribeAndStream, subscribeAndCollect } from './subscriptions';


### PR DESCRIPTION
## Problem

Parameterized replaceable events (kinds 30000-39999, e.g. kind:30023 articles) appear as duplicates in search results. Each time an author updates their article, a new event ID is created, but the dedup logic only checks `event.id` — so multiple versions of the same article show up.

## Fix

Added `deduplicateReplaceableEvents()` in `searchUtils.ts` that keys replaceable events by `kind:pubkey:d-tag` and keeps only the newest version. Applied in SearchView's `fuseFilteredResults` memo so it catches all results regardless of search strategy.

Non-replaceable events pass through unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved search result accuracy by deduplicating events—only the most recent version of each replaceable event now appears in results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->