### PR TITLE
feat: add long-form article search examples

### DIFF
--- a/src/lib/examples.ts
+++ b/src/lib/examples.ts
@@ -148,9 +148,6 @@ export const searchExamples = [
   // Long-form Articles
   'is:article bitcoin',
   'is:longform by:dergigi',
-  'is:blogpost by:fiatjaf',
-  'is:article (bitcoin OR lightning)',
-  'is:longform by:odell',
 
   // Multiple Authors
   'NIP-EE (by:jeffg OR by:futurepaul OR by:franzap)',


### PR DESCRIPTION
Adds `is:article`, `is:longform`, and `is:blogpost` examples to the search examples list. These show up as placeholder suggestions in the search input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two example search queries in the Long-form Articles section to help users discover in-depth content and author-specific posts.
    - Examples added: `is:article bitcoin`
    - `is:longform by:dergigi`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->