### PR TITLE
perf(search): speed up by: author resolution with dedup and caching

### DIFF
--- a/src/lib/profile/__tests__/resolver.test.ts
+++ b/src/lib/profile/__tests__/resolver.test.ts
@@ -1,0 +1,109 @@
+import { NDKEvent } from '@nostr-dev-kit/ndk';
+
+// Track how many times searchProfilesFullText is called
+let searchCallCount = 0;
+
+jest.mock('../search', () => ({
+  searchProfilesFullText: jest.fn(() => {
+    searchCallCount++;
+    // Simulate network delay
+    return new Promise<NDKEvent[]>((resolve) => {
+      setTimeout(() => {
+        const mockEvent = {
+          id: 'mock-event-id',
+          pubkey: 'abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234',
+          kind: 0,
+          content: JSON.stringify({ name: 'dergigi', display_name: 'Gigi' }),
+          created_at: 1700000000,
+          tags: [],
+          author: { pubkey: 'abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234' },
+        } as unknown as NDKEvent;
+        resolve([mockEvent]);
+      }, 100);
+    });
+  }),
+}));
+
+jest.mock('../nip05', () => ({
+  resolveNip05ToPubkey: jest.fn(() => Promise.resolve(null)),
+}));
+
+jest.mock('../utils', () => ({
+  profileEventFromPubkey: jest.fn(() => Promise.resolve(null)),
+}));
+
+jest.mock('../username-cache', () => {
+  const cache = new Map<string, NDKEvent | null>();
+  return {
+    getCachedUsername: jest.fn((key: string) => cache.get(key)),
+    setCachedUsername: jest.fn((key: string, val: NDKEvent | null) => cache.set(key, val)),
+  };
+});
+
+jest.mock('../profile-event-cache', () => ({
+  getCachedProfileEvent: jest.fn(() => null),
+  setCachedProfileEvent: jest.fn(),
+}));
+
+import { resolveAuthor } from '../resolver';
+
+describe('resolveAuthor', () => {
+  beforeEach(() => {
+    searchCallCount = 0;
+    jest.clearAllMocks();
+  });
+
+  test('resolves a username to a pubkey', async () => {
+    const result = await resolveAuthor('dergigi');
+    expect(result.pubkeyHex).toBe('abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234');
+    expect(searchCallCount).toBe(1);
+  });
+
+  test('concurrent calls for the same username only fire one network request', async () => {
+    // Fire 5 concurrent resolutions for the same username
+    const promises = [
+      resolveAuthor('satoshi'),
+      resolveAuthor('satoshi'),
+      resolveAuthor('satoshi'),
+      resolveAuthor('SATOSHI'),  // case-insensitive dedup
+      resolveAuthor('Satoshi'),
+    ];
+
+    const results = await Promise.all(promises);
+
+    // All should resolve to the same pubkey
+    for (const result of results) {
+      expect(result.pubkeyHex).toBe('abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234');
+    }
+
+    // searchProfilesFullText should only be called ONCE
+    expect(searchCallCount).toBe(1);
+  });
+
+  test('different usernames fire separate requests', async () => {
+    const promises = [
+      resolveAuthor('alice'),
+      resolveAuthor('bob'),
+    ];
+
+    await Promise.all(promises);
+
+    // Two different usernames = two separate calls
+    expect(searchCallCount).toBe(2);
+  });
+
+  test('npub input decodes directly without network call', async () => {
+    const npub = 'npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc';
+    const result = await resolveAuthor(npub);
+
+    expect(result.pubkeyHex).toBeTruthy();
+    // Should NOT call searchProfilesFullText for npub input
+    expect(searchCallCount).toBe(0);
+  });
+
+  test('empty input returns null', async () => {
+    const result = await resolveAuthor('');
+    expect(result.pubkeyHex).toBeNull();
+    expect(searchCallCount).toBe(0);
+  });
+});

--- a/src/lib/profile/index.ts
+++ b/src/lib/profile/index.ts
@@ -23,9 +23,10 @@ export {
   setCachedNip05Result, 
   invalidateNip05Cache
 } from './cache';
-export { 
+export {
   getCachedUsername,
-  setCachedUsername
+  setCachedUsername,
+  warmUsernameCache
 } from './username-cache';
 export {
   getCachedLightningFlag,

--- a/src/lib/profile/resolver.ts
+++ b/src/lib/profile/resolver.ts
@@ -6,6 +6,9 @@ import { getCachedUsername, setCachedUsername } from './username-cache';
 import { getCachedProfileEvent, setCachedProfileEvent } from './profile-event-cache';
 import { searchProfilesFullText } from './search';
 
+// In-flight promise deduplication for username resolution (mirrors nip05.ts pattern)
+const usernameInFlight = new Map<string, Promise<{ pubkeyHex: string | null; profileEvent: NDKEvent | null }>>();
+
 // Unified author resolver: npub | nip05 | username -> pubkey (hex) and an optional profile event
 export async function resolveAuthor(authorInput: string): Promise<{ pubkeyHex: string | null; profileEvent: NDKEvent | null }> {
   try {
@@ -57,20 +60,33 @@ export async function resolveAuthor(authorInput: string): Promise<{ pubkeyHex: s
       return { pubkeyHex, profileEvent: cachedProfile };
     }
 
-    let profileEvt: NDKEvent | null = null;
+    // Dedupe concurrent resolutions for the same username (mirrors nip05.ts pattern)
+    const inFlight = usernameInFlight.get(usernameLower);
+    if (inFlight) return inFlight;
+
+    const promise = (async (): Promise<{ pubkeyHex: string | null; profileEvent: NDKEvent | null }> => {
+      let profileEvt: NDKEvent | null = null;
+      try {
+        const profiles = await searchProfilesFullText(input, 1);
+        profileEvt = profiles[0] || null;
+      } catch {}
+
+      setCachedUsername(usernameLower, profileEvt);
+      if (profileEvt?.pubkey) setCachedProfileEvent(profileEvt.pubkey, profileEvt, { username: usernameLower });
+
+      if (!profileEvt) {
+        return { pubkeyHex: null, profileEvent: null };
+      }
+      const pubkeyHex = profileEvt.author?.pubkey || profileEvt.pubkey || null;
+      return { pubkeyHex, profileEvent: profileEvt };
+    })();
+
+    usernameInFlight.set(usernameLower, promise);
     try {
-      const profiles = await searchProfilesFullText(input, 1);
-      profileEvt = profiles[0] || null;
-    } catch {}
-
-    setCachedUsername(usernameLower, profileEvt);
-    if (profileEvt?.pubkey) setCachedProfileEvent(profileEvt.pubkey, profileEvt, { username: usernameLower });
-
-    if (!profileEvt) {
-      return { pubkeyHex: null, profileEvent: null };
+      return await promise;
+    } finally {
+      usernameInFlight.delete(usernameLower);
     }
-    const pubkeyHex = profileEvt.author?.pubkey || profileEvt.pubkey || null;
-    return { pubkeyHex, profileEvent: profileEvt };
   } catch {
     return { pubkeyHex: null, profileEvent: null };
   }

--- a/src/lib/profile/search.ts
+++ b/src/lib/profile/search.ts
@@ -15,6 +15,7 @@ import {
   LIGHTNING_FLAGS 
 } from './lightning';
 import { PROFILE_SEARCH_MAX_RESULTS } from '../constants';
+import { warmUsernameCache } from './username-cache';
 
 type ProfileSearchCacheEntry = { events: NDKEvent[]; timestamp: number };
 
@@ -71,7 +72,9 @@ export async function searchProfilesFullText(term: string, limit: number = PROFI
   }
 
   // Step 1: fetch candidate profiles from NIP-50 capable relay(s)
-  const candidates = await subscribeAndCollectProfiles({ kinds: [0], search: query, limit: Math.max(limit, 200) });
+  // Use a shorter timeout for single-author resolution (limit=1) since we only need one match
+  const relayTimeout = limit === 1 ? 3000 : 8000;
+  const candidates = await subscribeAndCollectProfiles({ kinds: [0], search: query, limit: Math.max(limit, 200) }, relayTimeout);
   if (candidates.length === 0) {
     setCachedProfileSearch(cacheKey, []);
     return [];
@@ -223,6 +226,9 @@ export async function searchProfilesFullText(term: string, limit: number = PROFI
   for (const row of enriched) {
     pushIfNew(row.event);
   }
+
+  // Warm the username cache so future by: queries for these profiles are instant
+  warmUsernameCache(ordered);
 
   setCachedProfileSearch(cacheKey, ordered);
   return ordered.slice(0, limit);

--- a/src/lib/profile/username-cache.ts
+++ b/src/lib/profile/username-cache.ts
@@ -63,6 +63,38 @@ function loadUsernameCacheFromStorage(): void {
 // Initialize persistent username cache on module load (browser only)
 loadUsernameCacheFromStorage();
 
+// Warm the username cache from an array of kind-0 profile events.
+// Extracts name/display_name and populates the cache so future
+// resolveAuthor calls for these usernames are instant.
+export function warmUsernameCache(events: NDKEvent[]): void {
+  let changed = false;
+  for (const evt of events) {
+    try {
+      const content = JSON.parse(evt.content || '{}');
+      const names: string[] = [];
+      if (typeof content.name === 'string' && content.name.trim()) {
+        names.push(content.name.trim().toLowerCase());
+      }
+      if (typeof content.display_name === 'string' && content.display_name.trim()) {
+        names.push(content.display_name.trim().toLowerCase());
+      }
+      if (typeof content.displayName === 'string' && content.displayName.trim()) {
+        names.push(content.displayName.trim().toLowerCase());
+      }
+      for (const nameLower of names) {
+        // Only populate if not already cached (don't overwrite better results)
+        if (!USERNAME_CACHE.has(nameLower)) {
+          USERNAME_CACHE.set(nameLower, { profileEvent: evt, timestamp: Date.now() });
+          changed = true;
+        }
+      }
+    } catch {
+      // skip malformed events
+    }
+  }
+  if (changed) saveUsernameCacheToStorage();
+}
+
 export function clearUsernameCache(): void {
   USERNAME_CACHE.clear();
   saveUsernameCacheToStorage();


### PR DESCRIPTION
## Summary

Fixes https://github.com/dergigi/ants/issues/173

Queries with `by:<name>` are slow because profile resolution happens synchronously before the content search starts. Three improvements:

### Fix 1: In-flight promise deduplication
Concurrent `resolveAuthor("dergigi")` calls (which happen when multiple code paths resolve the same author) now share a single network request instead of firing duplicates.

### Fix 2: Warm username cache from search results
New `warmUsernameCache()` populates the username cache from profile events encountered during searches, so subsequent `by:` queries for the same author hit the warm cache instantly.

### Fix 3: Reduced relay timeout for single-author resolution
When `searchProfilesFullText` is called with `limit=1` (the `resolveAuthor` path), the relay subscription timeout is 3s instead of 8s since only one match is needed.

## Test plan
- [x] 5 new resolver tests including concurrent dedup verification
- [x] All 51 unit tests pass
- [x] No changes to public API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved profile search efficiency by eliminating duplicate concurrent requests for the same username.
  * Optimized search timeout for faster single-profile lookups.
  * Enhanced username cache mechanism to pre-load profiles for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->