### PR TITLE
fix(search): use correct kinds in NIP-45 COUNT filter

### DIFF
--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { connect, nextExample, ndk, ConnectionStatus, addConnectionStatusListener, removeConnectionStatusListener, getRecentlyActiveRelays } from '@/lib/ndk';
 import { createSlashCommandRunner, executeClearCommand, type SlashCommand } from '@/lib/slashCommands';
-import { getIsKindRules } from '@/lib/search/replacements';
+import { getIsKindRules, applySimpleReplacements } from '@/lib/search/replacements';
 import { fetchSpellSummaries } from '@/lib/spellDiscovery';
 import { extractNip50Extensions, extractKindFilter, extractDateFilter, stripRelayFilters } from '@/lib/search/queryParsing';
 import { resolveAuthorToNpub } from '@/lib/vertex';
@@ -868,9 +868,19 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
 
     // Fire NIP-45 COUNT immediately at T+0 — before relay discovery, author resolution, etc.
     // Uses hardcoded RELAYS.SEARCH to avoid waiting for async relay set building.
-    const countFilter = { search: searchQuery, kinds: SEARCH_DEFAULT_KINDS } as import('@nostr-dev-kit/ndk').NDKFilter;
-    fireNip45Count(countFilter, [...RELAYS.SEARCH], { timeoutMs: 5000, abortSignal: abortController.signal })
-      .then((aggregate) => {
+    // Expand is: shortcuts (e.g. is:highlight → kind:9802) so the COUNT filter
+    // uses the correct kinds instead of always sending SEARCH_DEFAULT_KINDS.
+    applySimpleReplacements(searchQuery).then((expandedQuery) => {
+      const { kinds: parsedKinds, cleaned } = extractKindFilter(expandedQuery);
+      const countKinds = (parsedKinds && parsedKinds.length > 0) ? parsedKinds : SEARCH_DEFAULT_KINDS;
+      // Use the cleaned query (without kind: tokens) as the search text
+      const searchText = cleaned.trim() || undefined;
+      const countFilter = {
+        ...(searchText ? { search: searchText } : {}),
+        kinds: countKinds,
+      } as import('@nostr-dev-kit/ndk').NDKFilter;
+      return fireNip45Count(countFilter, [...RELAYS.SEARCH], { timeoutMs: 5000, abortSignal: abortController.signal });
+    }).then((aggregate) => {
         if (NIP45_BENCHMARK_LOG) console.log(`[NIP-45 UI] ${new Date().toISOString()} count callback: total=${aggregate.total}, totalMs=${Math.round(aggregate.totalMs)}ms`);
         if (currentSearchId.current === searchId) {
           setRelayCount(aggregate);


### PR DESCRIPTION
## Summary

Fixes https://github.com/dergigi/ants/issues/178

The NIP-45 COUNT filter always sent `SEARCH_DEFAULT_KINDS` (7 kinds) regardless of the actual query. For `is:highlight` (→ `kind:9802`), the COUNT was:

```json
{"search": "kind:9802", "kinds": [1, 20, 21, 22, 9802, 30023, 39089]}
```

Relays correctly count all events matching those 7 kinds and ignore the `search` field, returning inflated counts (~28M from relay.ditto.pub).

### Fix

Expand `is:` shortcuts via `applySimpleReplacements` before building the COUNT filter, then extract actual kinds with `extractKindFilter`. The COUNT now sends:

```json
{"kinds": [9802]}
```

For queries without explicit kinds (e.g. `nostr`), falls back to `SEARCH_DEFAULT_KINDS` as before.

## Test plan
- [ ] `is:highlight` — COUNT should show a reasonable number, not ~28M
- [ ] `nostr` — COUNT should still work with default kinds
- [ ] `kind:1 bitcoin` — COUNT should use `kinds: [1]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for kind: filtering in search queries to refine results by content type.

* **Improvements**
  * Search queries are now expanded asynchronously before processing for more accurate interpretation.
  * Count requests use parsed kinds when present and omit empty text queries, improving accuracy and responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->