### PR TITLE
fix(ui): trim article image URLs to prevent crash

### DIFF
--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -146,7 +146,7 @@ function ArticleBody({
       {meta.image && !imgError && (
         <div className="rounded overflow-hidden">
           <Image
-            src={meta.image}
+            src={meta.image.trim()}
             alt={meta.title || 'Article cover'}
             width={800}
             height={256}


### PR DESCRIPTION
## Summary

Fixes https://github.com/dergigi/ants/issues/177

Relay data sometimes includes image URLs with trailing whitespace (e.g. `"https://...jpg "`). Next.js `<Image>` throws a runtime error on these, crashing the entire page.

### Fix

`.trim()` on `meta.image` before passing to `<Image src={...}>` in `ArticleCard.tsx`.

### Reproduction

Search for `"proof of work"` — any article result with a malformed image URL triggers the crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed article card cover images that may not have displayed correctly due to whitespace in image metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->