### PR TITLE
fix(security): defend /api/og against SSRF via DNS resolution

### DIFF
--- a/src/app/api/og/fetch-og.ts
+++ b/src/app/api/og/fetch-og.ts
@@ -1,0 +1,132 @@
+import axios from 'axios';
+import { decode } from 'html-entities';
+import { validateAndResolveIp, createPinnedAgent, validateRedirectTarget } from './ssrf';
+
+export type OgResult = {
+  url: string;
+  title?: string;
+  description?: string;
+  image?: string;
+  siteName?: string;
+  type?: string;
+  favicon?: string;
+};
+
+export function isHttpUrl(u: URL): boolean {
+  return u.protocol === 'http:' || u.protocol === 'https:';
+}
+
+function resolveUrlMaybe(base: URL, value?: string | null): string | undefined {
+  if (!value) return undefined;
+  try {
+    const absolute = new URL(value, base);
+    if (!isHttpUrl(absolute)) return undefined;
+    return absolute.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+/** Parse OG / meta tags from raw HTML (mirrors fetch-opengraph parsing). */
+function parseOgTags(html: string, url: string): Record<string, string | null> {
+  let siteTitle = '';
+  const tagTitle = html.match(/<title[^>]*>[\r\n\t\s]*([^<]+)[\r\n\t\s]*<\/title>/gim);
+  if (tagTitle?.[0]) {
+    siteTitle = tagTitle[0].replace(/<title[^>]*>[\r\n\t\s]*([^<]+)[\r\n\t\s]*<\/title>/gim, '$1');
+  }
+
+  const og: { name: string; value: string | null }[] = [];
+  const metas = html.match(/<meta[^>]+>/gim);
+  if (metas) {
+    for (let meta of metas) {
+      meta = meta.replace(/\s*\/?>$/, ' />');
+      const zname = meta.replace(/[\s\S]*(property|name)\s*=\s*([\s\S]+)/, '$2');
+      const name = /^["']/.test(zname)
+        ? zname.substring(1, 1 + zname.slice(1).indexOf(zname[0]))
+        : zname.substring(0, zname.search(/[\s\t]/g));
+      const zcontent = meta.replace(/[\s\S]*(content)\s*=\s*([\s\S]+)/, '$2');
+      const content = /^["']/.test(zcontent)
+        ? zcontent.substring(1, 1 + zcontent.slice(1).indexOf(zcontent[0]))
+        : zcontent.substring(0, zcontent.search(/[\s\t]/g));
+      if (content !== 'undefined') {
+        og.push({ name, value: decode(content) });
+      }
+    }
+  }
+
+  const result: Record<string, string | null> = { url };
+  for (const { name, value } of og) result[name] = value;
+  result['title'] = result['og:title'] || siteTitle || null;
+  result['description'] = result['og:description'] || result['description'] || null;
+  result['image'] = result['og:image'] || null;
+  return result;
+}
+
+async function resolveFavicon(urlObj: URL): Promise<string | undefined> {
+  const candidatePaths = ['/favicon.ico', '/favicon.png', '/favicon-32x32.png',
+    '/apple-touch-icon.png', '/apple-touch-icon-precomposed.png', '/icons/icon-192x192.png'];
+  for (const path of candidatePaths) {
+    const href = resolveUrlMaybe(urlObj, path);
+    if (!href) continue;
+    try {
+      const head = await globalThis.fetch(href, { method: 'HEAD', cache: 'no-store', redirect: 'manual' });
+      if (head.ok) return href;
+    } catch { /* ignore */ }
+  }
+  return `https://icons.duckduckgo.com/ip3/${urlObj.hostname}.ico`;
+}
+
+/**
+ * Fetch HTML with SSRF-safe constraints:
+ * - DNS is pinned to the pre-validated IP (no TOCTOU)
+ * - Redirects are not auto-followed; each hop is validated
+ */
+async function safeFetchHtml(url: string, pinnedIp: string): Promise<string> {
+  const urlObj = new URL(url);
+  const agent = createPinnedAgent(urlObj.protocol, pinnedIp);
+  const maxHops = 5;
+  let currentUrl = url;
+  let currentAgent = agent;
+
+  for (let hop = 0; hop <= maxHops; hop++) {
+    const res = await axios.get<string>(currentUrl, {
+      maxRedirects: 0,
+      validateStatus: (s) => s < 400 || (s >= 300 && s < 400),
+      httpAgent: currentAgent,
+      httpsAgent: currentAgent,
+      headers: { 'User-Agent': 'OpenGraph', 'Cache-Control': 'no-cache', Accept: '*/*' },
+      responseType: 'text',
+      timeout: 10_000,
+    });
+
+    if (res.status >= 300 && res.status < 400) {
+      const location = res.headers['location'] as string | undefined;
+      if (!location) throw new Error('Redirect without Location header');
+      const absolute = new URL(location, currentUrl).toString();
+      await validateRedirectTarget(absolute);
+      const nextUrl = new URL(absolute);
+      const nextIp = await validateAndResolveIp(nextUrl.hostname);
+      currentAgent = createPinnedAgent(nextUrl.protocol, nextIp);
+      currentUrl = absolute;
+      continue;
+    }
+
+    return typeof res.data === 'string' ? res.data : String(res.data);
+  }
+  throw new Error('Too many redirects');
+}
+
+export async function fetchOgData(url: string, pinnedIp: string): Promise<OgResult> {
+  const html = await safeFetchHtml(url, pinnedIp);
+  const tags = parseOgTags(html, url);
+  const urlObj = new URL(url);
+
+  const title = tags['og:title'] || tags['twitter:title'] || tags['title'] || undefined;
+  const description = tags['og:description'] || tags['twitter:description'] || tags['description'] || undefined;
+  const image = tags['og:image'] || tags['twitter:image'] || tags['image'] || undefined;
+  const siteName = tags['og:site_name'] || urlObj.hostname;
+  const type = tags['og:type'] || undefined;
+  const favicon = await resolveFavicon(urlObj);
+
+  return { url: tags['url'] || url, title, description, image, siteName, type, favicon };
+}

--- a/src/app/api/og/route.ts
+++ b/src/app/api/og/route.ts
@@ -1,59 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { fetch as fetchOpengraph } from 'fetch-opengraph';
-import { isIP } from 'net';
+import { validateAndResolveIp } from './ssrf';
+import { fetchOgData, isHttpUrl, type OgResult } from './fetch-og';
 
 // Runtime hint: nodejs for network requests
 export const runtime = 'nodejs';
-
-type OgResult = {
-  url: string;
-  title?: string;
-  description?: string;
-  image?: string;
-  siteName?: string;
-  type?: string;
-  favicon?: string;
-};
-
-function isHttpUrl(u: URL): boolean {
-  return u.protocol === 'http:' || u.protocol === 'https:';
-}
 
 function isBlockedHostname(hostname: string): boolean {
   const lower = hostname.toLowerCase();
   if (lower === 'localhost' || lower.endsWith('.localhost') || lower.endsWith('.local')) return true;
   if (lower === '0.0.0.0') return true;
   return false;
-}
-
-function isPrivateIp(ip: string): boolean {
-  // IPv4 ranges
-  const parts = ip.split('.').map((x) => parseInt(x, 10));
-  if (parts.length === 4 && parts.every((n) => !Number.isNaN(n))) {
-    const [a, b] = parts;
-    if (a === 10) return true; // 10.0.0.0/8
-    if (a === 127) return true; // 127.0.0.0/8 loopback
-    if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
-    if (a === 192 && b === 168) return true; // 192.168.0.0/16
-    if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local
-    if (a === 0) return true; // 0.0.0.0/8
-  }
-  // IPv6
-  if (ip === '::1') return true; // loopback
-  if (ip.startsWith('fe80:') || ip.startsWith('fe80::')) return true; // link-local
-  if (ip.startsWith('fc') || ip.startsWith('fd')) return true; // unique local
-  return false;
-}
-
-function resolveUrlMaybe(base: URL, value?: string | null): string | undefined {
-  if (!value) return undefined;
-  try {
-    const absolute = new URL(value, base);
-    if (!isHttpUrl(absolute)) return undefined;
-    return absolute.toString();
-  } catch {
-    return undefined;
-  }
 }
 
 function getYouTubeIdFromUrl(urlString: string): string | null {
@@ -65,7 +21,6 @@ function getYouTubeIdFromUrl(urlString: string): string | null {
       return /^[A-Za-z0-9_-]{6,}$/.test(id) ? id : null;
     }
     if (host.endsWith('youtube.com')) {
-      // /watch?v=, /shorts/<id>, /embed/<id>
       if (u.searchParams.get('v')) {
         const id = u.searchParams.get('v') || '';
         return /^[A-Za-z0-9_-]{6,}$/.test(id) ? id : null;
@@ -85,7 +40,6 @@ function getYouTubeIdFromUrl(urlString: string): string | null {
 async function fetchYouTubeOg(url: string): Promise<OgResult> {
   const id = getYouTubeIdFromUrl(url);
   const siteName = 'YouTube';
-  // Try oEmbed first for title/author/thumbnail
   try {
     const oembedUrl = `https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`;
     const res = await globalThis.fetch(oembedUrl, { cache: 'no-store' });
@@ -104,8 +58,6 @@ async function fetchYouTubeOg(url: string): Promise<OgResult> {
   } catch {
     // ignore and fall back
   }
-
-  // Fallback: construct minimal preview if ID known
   if (id) {
     return {
       url,
@@ -117,55 +69,6 @@ async function fetchYouTubeOg(url: string): Promise<OgResult> {
     };
   }
   throw new Error('YouTube metadata unavailable');
-}
-
-async function resolveFavicon(urlObj: URL): Promise<string | undefined> {
-  // Try common favicon locations first with a lightweight HEAD request
-  const candidatePaths = [
-    '/favicon.ico',
-    '/favicon.png',
-    '/favicon-32x32.png',
-    '/apple-touch-icon.png',
-    '/apple-touch-icon-precomposed.png',
-    '/icons/icon-192x192.png',
-  ];
-  for (const path of candidatePaths) {
-    const href = resolveUrlMaybe(urlObj, path);
-    if (!href) continue;
-    try {
-      const head = await globalThis.fetch(href, { method: 'HEAD', cache: 'no-store' });
-      if (head.ok) return href;
-    } catch {
-      // ignore and try next
-    }
-  }
-  // Fallback to a reliable favicon service
-  return `https://icons.duckduckgo.com/ip3/${urlObj.hostname}.ico`;
-}
-
-async function fetchOgData(url: string): Promise<OgResult> {
-  const ogData = await fetchOpengraph(url);
-  const urlObj = new URL(url);
-  
-  // Extract data from fetch-opengraph response
-  const title = ogData['og:title'] || ogData['twitter:title'] || ogData.title || undefined;
-  const description = ogData['og:description'] || ogData['twitter:description'] || ogData.description || undefined;
-  const image = ogData['og:image'] || ogData['twitter:image:src'] || ogData.image || undefined;
-  const siteName = ogData['og:site_name'] || urlObj.hostname;
-  const type = ogData['og:type'] || undefined;
-  
-  // Resolve favicon with fallbacks
-  const favicon = await resolveFavicon(urlObj);
-  
-  return {
-    url: ogData.url || url,
-    title,
-    description,
-    image,
-    siteName,
-    type,
-    favicon
-  };
 }
 
 export async function GET(req: NextRequest) {
@@ -185,8 +88,12 @@ export async function GET(req: NextRequest) {
   if (isBlockedHostname(u.hostname)) {
     return NextResponse.json({ error: 'Blocked host' }, { status: 400 });
   }
-  if (isIP(u.hostname) && isPrivateIp(u.hostname)) {
-    return NextResponse.json({ error: 'Blocked IP' }, { status: 400 });
+
+  let pinnedIp: string;
+  try {
+    pinnedIp = await validateAndResolveIp(u.hostname);
+  } catch {
+    return NextResponse.json({ error: 'Blocked host' }, { status: 400 });
   }
 
   try {
@@ -196,19 +103,15 @@ export async function GET(req: NextRequest) {
       try {
         data = await fetchYouTubeOg(u.toString());
       } catch {
-        data = await fetchOgData(u.toString());
+        data = await fetchOgData(u.toString(), pinnedIp);
       }
     } else {
-      data = await fetchOgData(u.toString());
+      data = await fetchOgData(u.toString(), pinnedIp);
     }
-    // Short cache headers (10 minutes) to reduce repeated fetches
     const res = NextResponse.json(data, { status: 200 });
     res.headers.set('Cache-Control', 'public, max-age=600, s-maxage=600, stale-while-revalidate=86400');
     return res;
-  } catch (e: unknown) {
-    const errorMessage = e instanceof Error ? e.message : 'Fetch failed';
-    return NextResponse.json({ error: errorMessage }, { status: 502 });
+  } catch {
+    return NextResponse.json({ error: 'Failed to fetch metadata' }, { status: 502 });
   }
 }
-
-

--- a/src/app/api/og/ssrf.ts
+++ b/src/app/api/og/ssrf.ts
@@ -1,0 +1,128 @@
+import { isIP } from 'net';
+import { lookup } from 'dns/promises';
+import http from 'http';
+import https from 'https';
+
+/**
+ * Check whether an IP address belongs to a private, loopback, or otherwise
+ * internal range that must never be reached by the OG-metadata proxy.
+ *
+ * Handles:
+ *  - Standard IPv4 private ranges (RFC 1918, loopback, link-local, etc.)
+ *  - IPv6 loopback, link-local, unique-local
+ *  - IPv6-mapped IPv4 in both dotted-quad (::ffff:127.0.0.1) and
+ *    hex form (::ffff:7f00:1) — the latter is what Node's WHATWG URL
+ *    parser produces.
+ */
+export function isPrivateIp(ip: string): boolean {
+  // IPv4 ranges
+  const parts = ip.split('.').map((x) => parseInt(x, 10));
+  if (parts.length === 4 && parts.every((n) => !Number.isNaN(n))) {
+    const [a, b] = parts;
+    if (a === 10) return true; // 10.0.0.0/8
+    if (a === 127) return true; // 127.0.0.0/8 loopback
+    if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+    if (a === 192 && b === 168) return true; // 192.168.0.0/16
+    if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local / cloud metadata
+    if (a === 0) return true; // 0.0.0.0/8
+  }
+
+  // IPv6
+  const lower = ip.toLowerCase();
+  if (lower === '::1') return true; // loopback
+  if (lower.startsWith('fe80:') || lower.startsWith('fe80::')) return true; // link-local
+  if (lower.startsWith('fc') || lower.startsWith('fd')) return true; // unique local
+
+  // IPv6-mapped IPv4 — dotted-quad form (e.g. ::ffff:127.0.0.1)
+  const v4mappedDotted = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (v4mappedDotted) return isPrivateIp(v4mappedDotted[1]);
+
+  // IPv6-mapped IPv4 — hex form (e.g. ::ffff:7f00:1 for 127.0.0.1)
+  // Node's WHATWG URL parser normalises [::ffff:A.B.C.D] to ::ffff:XXYY:ZZWW
+  const v4mappedHex = lower.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (v4mappedHex) {
+    const hi = parseInt(v4mappedHex[1], 16);
+    const lo = parseInt(v4mappedHex[2], 16);
+    const a = (hi >> 8) & 0xff;
+    const b = hi & 0xff;
+    const c = (lo >> 8) & 0xff;
+    const d = lo & 0xff;
+    return isPrivateIp(`${a}.${b}.${c}.${d}`);
+  }
+
+  return false;
+}
+
+/**
+ * Resolve a hostname to an IP, validate it is not private/internal, and
+ * return the validated address so callers can pin subsequent requests to it.
+ *
+ * This closes the TOCTOU gap: the same IP that was validated is the one
+ * used for the outbound connection (via {@link createPinnedAgent}).
+ */
+export async function validateAndResolveIp(hostname: string): Promise<string> {
+  if (isIP(hostname)) {
+    if (isPrivateIp(hostname)) throw new Error('Blocked IP');
+    return hostname;
+  }
+  try {
+    const { address } = await lookup(hostname);
+    if (isPrivateIp(address)) {
+      throw new Error('Blocked IP');
+    }
+    return address;
+  } catch (e) {
+    if (e instanceof Error && e.message === 'Blocked IP') throw e;
+    throw new Error('DNS resolution failed');
+  }
+}
+
+/**
+ * Build an http(s).Agent whose `lookup` callback always returns the
+ * pre-validated IP address, preventing the runtime from re-resolving DNS
+ * (which would re-open a TOCTOU / rebinding window).
+ */
+export function createPinnedAgent(
+  protocol: string,
+  pinnedIp: string,
+): http.Agent | https.Agent {
+  const opts = {
+    lookup: (
+      _hostname: string,
+      _options: object,
+      cb: (err: NodeJS.ErrnoException | null, address: string, family: number) => void,
+    ) => {
+      const family = pinnedIp.includes(':') ? 6 : 4;
+      cb(null, pinnedIp, family);
+    },
+  };
+  return protocol === 'https:'
+    ? new https.Agent(opts)
+    : new http.Agent(opts);
+}
+
+/**
+ * Validate a redirect target URL against the same SSRF rules.
+ * Throws if the redirect is not safe.
+ */
+export async function validateRedirectTarget(location: string): Promise<void> {
+  let target: URL;
+  try {
+    target = new URL(location);
+  } catch {
+    throw new Error('Invalid redirect URL');
+  }
+  if (target.protocol !== 'http:' && target.protocol !== 'https:') {
+    throw new Error('Blocked redirect protocol');
+  }
+  const blockedNames = ['localhost', '0.0.0.0'];
+  const lower = target.hostname.toLowerCase();
+  if (
+    blockedNames.includes(lower) ||
+    lower.endsWith('.localhost') ||
+    lower.endsWith('.local')
+  ) {
+    throw new Error('Blocked redirect host');
+  }
+  await validateAndResolveIp(target.hostname);
+}


### PR DESCRIPTION
## Summary

Fixes #182

- Resolve hostname to actual IP via `dns.lookup()` before allowing outbound fetch in `/api/og`, blocking DNS rebinding attacks where a domain resolves to private/internal IPs (e.g. `127.0.0.1`, `169.254.169.254` cloud metadata)
- Block IPv6-mapped IPv4 addresses (`::ffff:127.0.0.1`) that previously bypassed the IPv4-only check
- Use `redirect: 'manual'` on favicon HEAD requests to prevent redirect-based SSRF
- Return generic error messages instead of leaking internal error details

## Background

The existing SSRF protection in `/api/og` validates the **hostname string** against a blocklist. This can be bypassed with DNS rebinding — an attacker controls a domain (e.g. `evil.attacker.com`) that initially looks like a normal public domain but resolves to `127.0.0.1` or `169.254.169.254` (cloud metadata endpoint). The hostname check sees a normal domain name and allows it through, then the server fetches from its own internal network.

The fix follows the OWASP-recommended approach: **resolve the hostname to an IP first, then validate the resolved IP**.

## References

- [OWASP SSRF Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html)
- [OWASP SSRF Prevention in Node.js](https://owasp.org/www-community/pages/controls/SSRF_Prevention_in_Nodejs)
- [MDN — Server Side Request Forgery](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/SSRF)
- [OWASP Top 10 A10:2021 — SSRF](https://owasp.org/Top10/2021/A10_2021-Server-Side_Request_Forgery_(SSRF)/)
- [Snyk — Preventing SSRF in Node.js](https://snyk.io/blog/preventing-server-side-request-forgery-node-js/)
- [Intigriti — SSRF in Next.js Targets](https://www.intigriti.com/researchers/blog/hacking-tools/ssrf-vulnerabilities-in-nextjs-targets)

## Test plan

- [ ] Verify normal URL previews still work (`/api/og?url=https://example.com`)
- [ ] Verify YouTube previews still work
- [ ] Confirm `localhost`, `127.0.0.1`, `192.168.x.x` URLs are blocked
- [ ] Confirm DNS rebinding domain (e.g. `7f000001.nip.io`) is blocked
- [ ] Confirm IPv6-mapped IPv4 (`::ffff:127.0.0.1`) is blocked
- [ ] Confirm error responses don't leak internal details

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Open Graph/metadata extraction with better title, description, image, site info, and enhanced favicon discovery with a reliable fallback.

* **Bug Fixes**
  * Stronger SSRF protection: blocks unsafe hosts and resolved private IPs, and enforces safer redirect handling.

* **Improvements**
  * Consistent error responses for metadata fetch failures and unified metadata fetching flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->