### PR TITLE
fix(ui): guard against whitespace-only image URLs

### DIFF
--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -139,14 +139,15 @@ function ArticleBody({
   setExpanded: (v: boolean) => void;
 }) {
   const [imgError, setImgError] = useState(false);
+  const trimmedImage = meta.image.trim();
 
   return (
     <>
       {/* Cover image */}
-      {meta.image && !imgError && (
+      {trimmedImage && !imgError && (
         <div className="rounded overflow-hidden">
           <Image
-            src={meta.image.trim()}
+            src={trimmedImage}
             alt={meta.title || 'Article cover'}
             width={800}
             height={256}


### PR DESCRIPTION
Follow-up to #180 — addresses the CodeRabbit review comment.

If `meta.image` is only whitespace (e.g. `"  "`), the previous truthy check would pass, `.trim()` would return `""`, and Next.js `<Image>` would throw.

Fix: extract `trimmedImage` upfront and use it in both the conditional and `src` prop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where article cover images may not display correctly due to whitespace handling in image URLs. Images now render reliably when metadata contains spacing in the image field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->