### PR TITLE
fix(search): strip non-visible text from content filter matching

### DIFF
--- a/src/lib/search/__tests__/contentFilter.test.ts
+++ b/src/lib/search/__tests__/contentFilter.test.ts
@@ -163,4 +163,39 @@ describe('filterByContent', () => {
     // no content, no matching tags => filtered out
     expect(result).toHaveLength(0);
   });
+
+  it('does not match nostr: protocol references as visible text', () => {
+    const events = [
+      makeEvent('replying to nostr:npub1abc123 with a meme'),
+      makeEvent('check this out nostr:nevent1xyz789'),
+      makeEvent('I love nostr, the protocol!'),
+    ];
+    const result = filterByContent(events, ['nostr']);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe('I love nostr, the protocol!');
+  });
+
+  it('does not match terms found only in URLs', () => {
+    const events = [
+      makeEvent('https://i.nostr.build/xhveCTCBuX1jf8og.jpg'),
+      makeEvent('Check out https://image.nostr.build/abc.png cool right'),
+      makeEvent('I love nostr and here is a pic https://example.com/img.jpg'),
+    ];
+    const result = filterByContent(events, ['nostr']);
+    // First: only URL with "nostr" in domain — filtered out
+    // Second: text has no "nostr" outside the URL — filtered out
+    // Third: "nostr" appears in visible text — kept
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe('I love nostr and here is a pic https://example.com/img.jpg');
+  });
+
+  it('does not match terms found only in URLs within tag values', () => {
+    const event = {
+      content: 'hard #nipples of the day',
+      kind: 1,
+      tags: [['alt', 'A short note: hard #nipples of the day\n\nhttps://cdn.nostrcheck.me/abc.webp']],
+    } as unknown as NDKEvent;
+    const result = filterByContent([event], ['nostr']);
+    expect(result).toHaveLength(0);
+  });
 });

--- a/src/lib/search/contentFilter.ts
+++ b/src/lib/search/contentFilter.ts
@@ -39,6 +39,14 @@ export function extractContentSearchTerms(query: string): string[] | null {
 }
 
 /**
+ * Strip URLs and nostr: protocol references — they render as
+ * embedded media/links/profiles, not visible text.
+ */
+function stripNonVisible(text: string): string {
+  return text.replace(/https?:\/\/\S+/gi, ' ').replace(/nostr:[a-z0-9]+/gi, ' ');
+}
+
+/**
  * Convenience: extract content terms from a query and filter results.
  * Returns results unchanged if no content terms exist in the query.
  */
@@ -68,10 +76,10 @@ export function filterByContent(events: NDKEvent[], terms: string[]): NDKEvent[]
   return events.filter((event) => {
     // Build searchable text from content + visible tag values
     const parts: string[] = [];
-    if (event.content) parts.push(event.content);
+    if (event.content) parts.push(stripNonVisible(event.content));
     for (const tag of event.tags || []) {
       if (tag[0] === 'description' || tag[0] === 'title' || tag[0] === 'summary' || tag[0] === 'alt' || tag[0] === 'name') {
-        if (tag[1]) parts.push(tag[1]);
+        if (tag[1]) parts.push(stripNonVisible(tag[1]));
       }
     }
 


### PR DESCRIPTION
## Summary

Fixes #188

- Strip URLs (e.g., `https://i.nostr.build/...`, `https://cdn.nostrcheck.me/...`) from content and tag values before matching search terms
- Strip `nostr:` protocol references (`nostr:npub1...`, `nostr:nevent1...`) from content and tag values before matching
- These render as embedded media/links/profiles in the UI, not as visible text — matching against them produces false-positive search results (e.g., searching "nostr" returned every post with a `nostr.build` image or a `nostr:npub` mention)

## Test plan

- [x] Unit tests pass (23/23, 3 new tests added)
- [x] Manual: `/?q=nostr` no longer returns image-only posts hosted on `nostr.build` or posts whose only match is a `nostr:npub1` reference
- [ ] Manual: verify on production after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search filtering now ignores URLs and protocol reference tokens when matching content, so results reflect visible text rather than links or protocol identifiers.

* **Tests**
  * Expanded test coverage for search behavior, including cases where the term appears only as protocol references, only inside URLs, or only within URL-containing tag values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->