### PR TITLE
fix: guard getBroadRelaySet() in id: lookup

### DIFF
--- a/src/lib/search/strategies/idSearchStrategy.ts
+++ b/src/lib/search/strategies/idSearchStrategy.ts
@@ -34,7 +34,13 @@ export async function handleIdLookup(
   if (eventIds.length === 0) return [];
 
   const filter: NDKFilter = { ids: eventIds };
-  const relaySet = await getBroadRelaySet();
+
+  let relaySet;
+  try {
+    relaySet = await getBroadRelaySet();
+  } catch {
+    return [];
+  }
 
   let results: NDKEvent[];
   try {


### PR DESCRIPTION
Follow-up to [202](https://github.com/dergigi/ants/pull/202) — addresses the [CodeRabbit review comment](https://github.com/dergigi/ants/pull/202#discussion_r2969971165).

`handleIdLookup()` calls `getBroadRelaySet()` without a try/catch. If all relays are dead, this throws an unhandled exception. Now wrapped in try/catch — returns empty results on failure instead of crashing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in the search feature to ensure graceful recovery from relay retrieval failures, enhancing overall search reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->