### PR TITLE
Remove confusing NIP-45 relay count from results counter

### DIFF
--- a/src/components/FilterCollapsed.tsx
+++ b/src/components/FilterCollapsed.tsx
@@ -8,7 +8,6 @@ interface FilterCollapsedProps {
   hasActiveFilters: boolean;
   filteredCount: number;
   resultCount: number;
-  relayCount?: { total: number } | null;
   onExpand: () => void;
   isExpanded?: boolean;
 }
@@ -18,24 +17,12 @@ export default function FilterCollapsed({
   hasActiveFilters,
   filteredCount,
   resultCount,
-  relayCount,
   onExpand,
   isExpanded = false
 }: FilterCollapsedProps) {
-  // Build count display:
-  //   "200"                 — no relay count (today's behavior)
-  //   "200 / ~203,873"     — with relay count
-  //   "50/200 / ~203,873"  — with active filters + relay count
-  let countText: string;
-  if (hasActiveFilters) {
-    countText = `${filteredCount}/${resultCount}`;
-  } else {
-    countText = `${resultCount}`;
-  }
-
-  if (relayCount && relayCount.total > resultCount) {
-    countText += ` / ~${relayCount.total.toLocaleString()}`;
-  }
+  const countText = hasActiveFilters
+    ? `${filteredCount}/${resultCount}`
+    : `${resultCount}`;
 
   return (
     <button

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -9,9 +9,7 @@ import { extractNip50Extensions, extractKindFilter, extractDateFilter, stripRela
 import { resolveAuthorToNpub } from '@/lib/vertex';
 import { NDKEvent } from '@nostr-dev-kit/ndk';
 import { searchEvents } from '@/lib/search';
-import { fireNip45Count } from '@/lib/search/nip45Count';
 import { extractContentSearchTerms, filterByContent } from '@/lib/search/contentFilter';
-import type { AggregateCount } from '@/lib/search/nip45Count';
 import { RELAYS } from '@/lib/relays';
 import { extractRelaySourcesFromEvent, createRelaySet } from '@/lib/urlUtils';
 import { applyContentFilters, isEmojiSearch } from '@/lib/contentAnalysis';
@@ -126,7 +124,6 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
   const [recentlyActive, setRecentlyActive] = useState<string[]>([]);
   const [successfulPreviews, setSuccessfulPreviews] = useState<Set<string>>(new Set());
   const [showExternalButton, setShowExternalButton] = useState(false);
-  const [relayCount, setRelayCount] = useState<AggregateCount | null>(null);
   const [filterSettings, setFilterSettings] = useState<FilterSettings>({ maxEmojis: 3, maxHashtags: 3, maxMentions: 6, hideLinks: false, hideBridged: true, resultFilter: '', verifiedOnly: false, fuzzyEnabled: true, hideBots: false, hideNsfw: false, filterMode: 'intelligently' });
   const [visibleCount, setVisibleCount] = useState(50);
   const lastPaginationQueryRef = useRef<string>('');
@@ -862,32 +859,8 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       setShowExternalButton(false);
     }
     clearResults();
-    setRelayCount(null);
     setLoading(true);
     if (NIP45_BENCHMARK_LOG) console.log(`[NIP-45 UI] search started at ${new Date().toISOString()}`);
-
-    // Fire NIP-45 COUNT immediately at T+0 — before relay discovery, author resolution, etc.
-    // Uses hardcoded RELAYS.SEARCH to avoid waiting for async relay set building.
-    // Expand is: shortcuts (e.g. is:highlight → kind:9802) so the COUNT filter
-    // uses the correct kinds instead of always sending SEARCH_DEFAULT_KINDS.
-    applySimpleReplacements(searchQuery).then((expandedQuery) => {
-      const { kinds: parsedKinds, cleaned } = extractKindFilter(expandedQuery);
-      const countKinds = (parsedKinds && parsedKinds.length > 0) ? parsedKinds : SEARCH_DEFAULT_KINDS;
-      // Use the cleaned query (without kind: tokens) as the search text
-      const searchText = cleaned.trim() || undefined;
-      const countFilter = {
-        ...(searchText ? { search: searchText } : {}),
-        kinds: countKinds,
-      } as import('@nostr-dev-kit/ndk').NDKFilter;
-      return fireNip45Count(countFilter, [...RELAYS.SEARCH], { timeoutMs: 5000, abortSignal: abortController.signal });
-    }).then((aggregate) => {
-        if (NIP45_BENCHMARK_LOG) console.log(`[NIP-45 UI] ${new Date().toISOString()} count callback: total=${aggregate.total}, totalMs=${Math.round(aggregate.totalMs)}ms`);
-        if (currentSearchId.current === searchId) {
-          setRelayCount(aggregate);
-        }
-      })
-      .catch(() => {});
-
 
     // Ensure loading animation is visible for direct lookups
     const isDirectLookup = !manageUrl && initialQuery === searchQuery;
@@ -1867,7 +1840,6 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
                 hasActiveFilters={filterSettings.maxEmojis !== null || filterSettings.maxHashtags !== null || filterSettings.maxMentions !== null || filterSettings.hideLinks || filterSettings.hideBridged || filterSettings.hideBots || filterSettings.hideNsfw || filterSettings.verifiedOnly || (filterSettings.fuzzyEnabled && (filterSettings.resultFilter || '').trim().length > 0)}
                 filteredCount={fuseFilteredResults.length}
                 resultCount={results.length}
-                relayCount={relayCount}
                 onExpand={() => setShowFilterDetails(!showFilterDetails)}
                 isExpanded={showFilterDetails}
               />


### PR DESCRIPTION
The `~N` number shown next to the filter count was the approximate total hits reported by relays via NIP-45 COUNT. Users had no way to know what it meant and it added no actionable information. This removes the NIP-45 COUNT request, the `relayCount` state, and the relay count display from the results counter. The filter bar now only shows filtered/total loaded results.

- Removed the `fireNip45Count` call and `AggregateCount` type import from `SearchView`
- Removed the `relayCount` prop and `~N` display logic from `FilterCollapsed`
- Counter now shows `filtered/total` or just `total` with no trailing relay estimate

Closes #161


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified filter summary display in search results by removing relay count information
  * Optimized search request flow to reduce unnecessary preliminary requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->