### PR TITLE
fix: clone relay set in author search strategy

### DIFF
--- a/src/lib/search/strategies/authorSearchStrategy.ts
+++ b/src/lib/search/strategies/authorSearchStrategy.ts
@@ -64,8 +64,9 @@ export async function tryHandleAuthorSearch(
     }
   }
 
-  // Get author-specific relays that support NIP-50 in parallel for all authors
-  const authorRelaySet = chosenRelaySet;
+  // Clone the shared relay set so author-specific outbox relays don't pollute
+  // the context used by other strategies (#227)
+  const authorRelaySet = new NDKRelaySet(new Set(chosenRelaySet.relays), ndk);
   try {
     const outboxResults = await Promise.allSettled(
       pubkeys.map(pk => getOutboxSearchCapableRelays(pk))


### PR DESCRIPTION
`authorRelaySet` was aliased directly to the shared `chosenRelaySet` from the search context. Adding outbox relays for author lookups mutated the shared set, polluting relay state for other strategies and subsequent searches.

Clones the relay set before adding author-specific relays so the shared context stays clean.

Closes #227


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved author search reliability by ensuring search operations don't inadvertently affect other search functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->