### PR TITLE
fix: improve relay view colors and status labels

### DIFF
--- a/src/components/RelayRow.tsx
+++ b/src/components/RelayRow.tsx
@@ -71,12 +71,12 @@ export default function RelayRow({
           )}
           {monitorEntry && (
             monitorEntry.isAlive ? (
-              <span className="text-green-400 ml-1"
+              <span className="text-blue-400 ml-1"
                 title={`Monitor: alive${monitorEntry.rttOpen ? `, RTT ${monitorEntry.rttOpen}ms` : ''}`}>
                 [{monitorEntry.rttOpen ? `${monitorEntry.rttOpen}ms` : 'alive'}]
               </span>
             ) : (
-              <span className="text-red-400 ml-1" title="Monitor: dead">[dead]</span>
+              <span className="text-gray-400 ml-1" title="Monitor: timed out">[timeout]</span>
             )
           )}
         </div>


### PR DESCRIPTION
Relay latency indicators now use blue instead of green, consistent with the rest of the UI. Non-responsive relays show `[timeout]` in gray instead of `[dead]` in red, since a timeout doesn't necessarily mean the relay is dead.

Closes #232


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relay monitor status indicators for clearer state distinction: alive status now displays in blue, and timeout conditions are represented with a gray indicator instead of a red dead label, better communicating the actual operational state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->