### PR TITLE
feat: add nostrarchives + antiprimal search relays, list relays in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,13 @@ The `/t/` path supports multiple separators (comma, plus, and space).
 
 ## Relay Logic
 
-There are hardcoded relays for search (NIP-50) as well as for general use.
-
-**Default relays:** `relay.primal.net`, `relay.snort.social`, `relay.ditto.pub`
-
-**Search relays (NIP-50):** `search.nos.today`, `relay.nostr.band`, `relay.ditto.pub`, `relay.davidebtc.me`, `relay.gathr.gives`, `nostr.polyserv.xyz`, `nostr.azzamo.net`, `search.nostrarchives.com`, `antiprimal.net`
-
-**Profile search:** `purplepag.es`, `search.nos.today`, `relay.nostr.band`, `relay.ditto.pub`
+There are hardcoded relays for search[^search-relays] (NIP-50), general use[^default-relays], and profile lookups[^profile-relays].
 
 Upon login, we retrieve the user's relays as per NIP-51 (kind:10002) and remove any blocked relays (kind:10006). We also retrieve the user's search relays (kind:10007) and use them for search queries in addition to the hardcoded list of search relays.
+
+[^default-relays]: Default relays: `relay.primal.net`, `relay.snort.social`, `relay.ditto.pub`
+[^search-relays]: Search relays (NIP-50): `search.nos.today`, `relay.nostr.band`, `relay.ditto.pub`, `relay.davidebtc.me`, `relay.gathr.gives`, `nostr.polyserv.xyz`, `nostr.azzamo.net`, `search.nostrarchives.com`, `antiprimal.net`
+[^profile-relays]: Profile search relays: `purplepag.es`, `search.nos.today`, `relay.nostr.band`, `relay.ditto.pub`
 
 When connecting to a relay we retrieve the `supported_nips` as per NIP-11. The relay list as well as the supported NIPs are shown in the relay status indicator. Relays that returned one or more of the results that are currently shown on the page are shown in blue. Relays that support NIP-50 show a magnifying glass. The relay icon in the relay status display allows for relay-based client-side filtering of results.
 

--- a/README.md
+++ b/README.md
@@ -80,9 +80,15 @@ The `/t/` path supports multiple separators (comma, plus, and space).
 
 ## Relay Logic
 
-There is hardcoded relays for search (NIP-50) as well as for general use.
+There are hardcoded relays for search (NIP-50) as well as for general use.
 
-Upon login, we retrieve the user's relays as per NIP-51 (kind:10002) and remove any blocked relays (kind:10006). We also retrieve the user's search relays (kind:10007) and use them for search queries in addition it to the hardcoded list of search relays.
+**Default relays:** `relay.primal.net`, `relay.snort.social`, `relay.ditto.pub`
+
+**Search relays (NIP-50):** `search.nos.today`, `relay.nostr.band`, `relay.ditto.pub`, `relay.davidebtc.me`, `relay.gathr.gives`, `nostr.polyserv.xyz`, `nostr.azzamo.net`, `search.nostrarchives.com`, `antiprimal.net`
+
+**Profile search:** `purplepag.es`, `search.nos.today`, `relay.nostr.band`, `relay.ditto.pub`
+
+Upon login, we retrieve the user's relays as per NIP-51 (kind:10002) and remove any blocked relays (kind:10006). We also retrieve the user's search relays (kind:10007) and use them for search queries in addition to the hardcoded list of search relays.
 
 When connecting to a relay we retrieve the `supported_nips` as per NIP-11. The relay list as well as the supported NIPs are shown in the relay status indicator. Relays that returned one or more of the results that are currently shown on the page are shown in blue. Relays that support NIP-50 show a magnifying glass. The relay icon in the relay status display allows for relay-based client-side filtering of results.
 

--- a/src/lib/relayConfig.ts
+++ b/src/lib/relayConfig.ts
@@ -14,6 +14,8 @@ export const RELAYS = {
     'wss://relay.gathr.gives',
     'wss://nostr.polyserv.xyz',
     'wss://nostr.azzamo.net',
+    'wss://search.nostrarchives.com',
+    'wss://antiprimal.net',
   ],
   PROFILE_SEARCH: [
     'wss://purplepag.es',


### PR DESCRIPTION
Adds `search.nostrarchives.com` and `antiprimal.net` to the hardcoded search relay list, as [suggested by fiatjaf](https://ants.sh/e/nevent1qqs2ex9f4sk4yz2p4wwx668h6m5gyrqj8zyl9kqux4p5lcz7wa7djtqz507cv). Also lists all hardcoded relays (default, search, profile search) in the README relay logic section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified relay logic: explicitly lists three relay categories (default/general use, NIP-50 search relays, and profile lookup relays), corrected login/search wording, and documents the control flow for retrieving user relays, excluding blocked relays, and combining user-provided and hardcoded search relays. Added footnote relay definitions.
* **Configuration**
  * Expanded the search relay network with two additional endpoints to improve coverage and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->