### PR TITLE
refactor: separate broadRelaySet and nip50RelaySet in SearchContext

### DIFF
--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -52,7 +52,7 @@ import { createNostrTokenRegex } from '@/lib/utils/nostrIdentifiers';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { trimImageUrl, isHashtagOnlyQuery, hashtagQueryToUrl } from '@/lib/utils';
 import { getRelayLists } from '@/lib/relayCounts';
-import { relaySets, getNip50SearchRelaySet, getQuickNip50SearchRelaySet } from '@/lib/relays';
+import { relaySets, getQuickNip50SearchRelaySet } from '@/lib/relays';
 import { NDKUser, NDKRelaySet } from '@nostr-dev-kit/ndk';
 import emojiRegex from 'emoji-regex';
 import { faExternalLink } from '@fortawesome/free-solid-svg-icons';
@@ -956,16 +956,15 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       const shouldScope = identifiers ? hasProfileScope(expanded, identifiers) : false;
       const scopedQuery = shouldScope ? ensureAuthorForBackend(expanded, currentProfileNpub) : expanded;
 
-      // Choose relay set based on query type
+      // Choose relay set: NIP-50 relays for text search, broad for direct lookups.
+      // searchEvents() builds both internally; we pass the NIP-50 set as the
+      // override for search queries so the quick (sync) set is used for instant
+      // results without waiting for async relay discovery.
       let relaySet: NDKRelaySet | undefined;
       if (isDirectQuery) {
-        // Direct queries (NIP-19): use all relays
         relaySet = await relaySets.default();
       } else {
-        // Search queries (NIP-50): use instant relay set (no async discovery)
         relaySet = getQuickNip50SearchRelaySet();
-        // Fire-and-forget full discovery to warm cache for subsequent searches
-        getNip50SearchRelaySet().catch(() => {});
       }
 
       // For NIP-50 text searches, stream results progressively

--- a/src/lib/relaySets.ts
+++ b/src/lib/relaySets.ts
@@ -141,8 +141,7 @@ export async function getNip50SearchRelaySet(): Promise<NDKRelaySet> {
     }
   }
 
-  const allRelays = await extendWithUserAndPremium(allSearchRelays);
-  return createRelaySet(await filterNip50Relays(allRelays));
+  return createRelaySet(await filterNip50Relays(allSearchRelays));
 }
 
 function hasCachedNip50Support(url: string): boolean {

--- a/src/lib/relaySets.ts
+++ b/src/lib/relaySets.ts
@@ -5,7 +5,7 @@ import { getUserRelayAdditions, getSearchLocalRelays } from './storage';
 import { RELAYS, normalizeRelayUrl, isPrivateRelay, addRelayToSet } from './relayConfig';
 import { discoverUserRelays, getUserRelayCacheEntry } from './relayDiscovery';
 import { relayInfoCache, checkNip50Support, RELAY_INFO_CACHE_DURATION } from './relayInfo';
-import { filterDeadRelays, getRelayMonitorEntry, getMonitoredNip50Relays } from './nip66';
+import { filterDeadRelays, getRelayMonitorEntry } from './nip66';
 
 /** Build a relay URL list enriched with user, manual, and premium relays */
 export async function extendWithUserAndPremium(
@@ -130,7 +130,7 @@ export async function getNip50RelaySet(relayUrls: string[]): Promise<NDKRelaySet
 
 export async function getNip50SearchRelaySet(): Promise<NDKRelaySet> {
   const pubkey = getStoredPubkey();
-  const allSearchRelays: string[] = [...RELAYS.SEARCH, ...getMonitoredNip50Relays()];
+  const allSearchRelays: string[] = [...RELAYS.SEARCH];
 
   if (pubkey) {
     try {
@@ -163,7 +163,7 @@ export function getQuickNip50SearchRelaySet(): NDKRelaySet {
   const relaySet = new Set<string>();
   const emptyBlocked = new Set<string>();
 
-  for (const url of [...RELAYS.SEARCH, ...getMonitoredNip50Relays()]) {
+  for (const url of RELAYS.SEARCH) {
     addRelayToSet(relaySet, url, emptyBlocked);
   }
 

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -77,18 +77,20 @@ export async function searchEvents(
   const nip50Extraction = extractNip50Extensions(query);
   const nip50Extensions = nip50Extraction.extensions;
 
-  // Build both relay sets: broad (for structured queries) and NIP-50 (for text search)
+  // Build both relay sets in parallel: broad (structured queries) and NIP-50 (text search)
   let nip50RelaySet: NDKRelaySet;
+  let broadRelaySet: NDKRelaySet;
   if (relaySetOverride) {
     nip50RelaySet = relaySetOverride;
+    broadRelaySet = await getBroadRelaySet();
   } else {
-    try {
-      nip50RelaySet = await getNip50SearchRelaySet();
-    } catch {
-      nip50RelaySet = await getBroadRelaySet();
-    }
+    const [nip50Result, broadResult] = await Promise.allSettled([
+      getNip50SearchRelaySet(),
+      getBroadRelaySet()
+    ]);
+    broadRelaySet = broadResult.status === 'fulfilled' ? broadResult.value : await getBroadRelaySet();
+    nip50RelaySet = nip50Result.status === 'fulfilled' ? nip50Result.value : broadRelaySet;
   }
-  const broadRelaySet = await getBroadRelaySet();
 
   const extCleanedQuery = stripRelayFilters(nip50Extraction.cleaned);
   const { applySimpleReplacements } = await import('./search/replacements');

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -77,16 +77,18 @@ export async function searchEvents(
   const nip50Extraction = extractNip50Extensions(query);
   const nip50Extensions = nip50Extraction.extensions;
 
-  let chosenRelaySet: NDKRelaySet;
+  // Build both relay sets: broad (for structured queries) and NIP-50 (for text search)
+  let nip50RelaySet: NDKRelaySet;
   if (relaySetOverride) {
-    chosenRelaySet = relaySetOverride;
+    nip50RelaySet = relaySetOverride;
   } else {
     try {
-      chosenRelaySet = await getNip50SearchRelaySet();
+      nip50RelaySet = await getNip50SearchRelaySet();
     } catch {
-      chosenRelaySet = await getBroadRelaySet();
+      nip50RelaySet = await getBroadRelaySet();
     }
   }
+  const broadRelaySet = await getBroadRelaySet();
 
   const extCleanedQuery = stripRelayFilters(nip50Extraction.cleaned);
   const { applySimpleReplacements } = await import('./search/replacements');
@@ -96,14 +98,14 @@ export async function searchEvents(
   const { cleanedQuery, effectiveKinds, dateFilter, hasTopLevelOr, topLevelOrParts, extensionFilters } = parsedQuery;
 
   const searchContext: SearchContext = {
-    effectiveKinds, dateFilter, nip50Extensions, chosenRelaySet,
+    effectiveKinds, dateFilter, nip50Extensions, broadRelaySet, nip50RelaySet,
     relaySetOverride, isStreaming: isStreaming || false, streamingOptions,
     abortSignal, limit, extensionFilters
   };
 
   // 1. Try parenthesized OR expansion: "(GM OR GN) by:dergigi"
   const parenOrResult = await handleParenthesizedOr(
-    cleanedQuery, effectiveKinds, dateFilter, nip50Extensions, chosenRelaySet, abortSignal, limit
+    cleanedQuery, effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, limit
   );
   if (parenOrResult) return parenOrResult;
 
@@ -117,7 +119,7 @@ export async function searchEvents(
   if (hasTopLevelOr) {
     const topOrResult = await handleTopLevelOr(
       topLevelOrParts, effectiveKinds, dateFilter, nip50Extensions,
-      chosenRelaySet, relaySetOverride, abortSignal, limit
+      nip50RelaySet, broadRelaySet, abortSignal, limit
     );
     if (topOrResult) return topOrResult;
   }
@@ -137,10 +139,10 @@ export async function searchEvents(
           timeoutMs: streamingOptions?.timeoutMs || 30000,
           maxResults: streamingOptions?.maxResults || 1000,
           onResults: streamingOptions?.onResults,
-          relaySet: chosenRelaySet,
+          relaySet: nip50RelaySet,
           abortSignal
         })
-      : await subscribeAndCollect(searchFilter, 8000, chosenRelaySet, abortSignal);
+      : await subscribeAndCollect(searchFilter, 8000, nip50RelaySet, abortSignal);
 
     // Dedupe by event id
     const seen = new Set<string>();

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -89,7 +89,14 @@ export async function searchEvents(
       getBroadRelaySet()
     ]);
     broadRelaySet = broadResult.status === 'fulfilled' ? broadResult.value : await getBroadRelaySet();
-    nip50RelaySet = nip50Result.status === 'fulfilled' ? nip50Result.value : broadRelaySet;
+    if (nip50Result.status === 'fulfilled') {
+      nip50RelaySet = nip50Result.value;
+    } else {
+      // NIP-50 relay discovery failed. Use an empty set so text searches
+      // return nothing instead of hitting non-NIP-50 relays with garbage results.
+      console.warn('[search] NIP-50 relay set construction failed, text searches will return empty');
+      nip50RelaySet = NDKRelaySet.fromRelayUrls([], ndk);
+    }
   }
 
   const extCleanedQuery = stripRelayFilters(nip50Extraction.cleaned);

--- a/src/lib/search/orExpansion.ts
+++ b/src/lib/search/orExpansion.ts
@@ -4,7 +4,6 @@ import { buildSearchQueryWithExtensions, Nip50Extensions } from './searchUtils';
 import { extractKindFilter, applyDateFilter, normalizeResidualSearchText } from './queryParsing';
 import { expandParenthesizedOr } from './queryTransforms';
 import { subscribeAndCollect } from './subscriptions';
-import { getBroadRelaySet } from './relayManagement';
 import { searchByAnyTerms } from './termSearch';
 import { resolveAuthorTokens } from './authorResolve';
 import { applyContentFilter } from './contentFilter';
@@ -24,7 +23,7 @@ export function extractNonByContent(seed: string): string {
 /** Optimize pure by: OR queries into a single multi-author filter. Returns null if not applicable. */
 export async function maybeOptimizeByOnlyOrSeeds(
   seeds: string[], effectiveKinds: number[], dateFilter: { since?: number; until?: number },
-  nip50Extensions: Nip50Extensions | undefined, chosenRelaySet: NDKRelaySet,
+  nip50Extensions: Nip50Extensions | undefined, broadRelaySet: NDKRelaySet,
   abortSignal: AbortSignal | undefined, limit: number
 ): Promise<NDKEvent[] | null> {
   const trimmedSeeds = seeds.map((s) => s.trim()).filter(Boolean);
@@ -47,14 +46,15 @@ export async function maybeOptimizeByOnlyOrSeeds(
     dateFilter
   ) as NDKFilter;
 
-  const results = await subscribeAndCollect(filter, 10000, chosenRelaySet, abortSignal);
+  // Pure author query: no search text, use broad relays
+  const results = await subscribeAndCollect(filter, 10000, broadRelaySet, abortSignal);
   return sortEventsNewestFirst(results).slice(0, limit);
 }
 
 /** Handle parenthesized OR expansion: "(GM OR GN) by:dergigi" => multiple seeds. */
 export async function handleParenthesizedOr(
   cleanedQuery: string, effectiveKinds: number[], dateFilter: { since?: number; until?: number },
-  nip50Extensions: Nip50Extensions | undefined, chosenRelaySet: NDKRelaySet,
+  nip50Extensions: Nip50Extensions | undefined, nip50RelaySet: NDKRelaySet, broadRelaySet: NDKRelaySet,
   abortSignal: AbortSignal | undefined, limit: number
 ): Promise<NDKEvent[] | null> {
   const expandedSeeds = expandParenthesizedOr(cleanedQuery)
@@ -68,9 +68,9 @@ export async function handleParenthesizedOr(
     return handleProfileSeeds(expandedSeeds, limit);
   }
 
-  // Pure by: OR queries
+  // Pure by: OR queries (no search text, use broad relays)
   const byOnlyResults = await maybeOptimizeByOnlyOrSeeds(
-    expandedSeeds, effectiveKinds, dateFilter, nip50Extensions, chosenRelaySet, abortSignal, limit
+    expandedSeeds, effectiveKinds, dateFilter, nip50Extensions, broadRelaySet, abortSignal, limit
   );
   if (byOnlyResults !== null) return byOnlyResults;
 
@@ -81,14 +81,14 @@ export async function handleParenthesizedOr(
 
   if (allSameNonBy && allHaveBy && expandedSeeds.length > 1) {
     const result = await handleSameContentMultiAuthor(
-      expandedSeeds, firstNonBy, effectiveKinds, dateFilter, nip50Extensions, chosenRelaySet, abortSignal, cleanedQuery, limit
+      expandedSeeds, firstNonBy, effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, cleanedQuery, limit
     );
     if (result) return result;
   }
 
   // Combined hashtag + author patterns
   const tagAuthorResult = await handleTagAuthorCombination(
-    expandedSeeds, effectiveKinds, dateFilter, nip50Extensions, chosenRelaySet, abortSignal, cleanedQuery, limit
+    expandedSeeds, effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, cleanedQuery, limit
   );
   if (tagAuthorResult) return tagAuthorResult;
 
@@ -101,9 +101,9 @@ export async function handleParenthesizedOr(
   });
 
   const seedResults = await searchByAnyTerms(
-    translatedSeeds, Math.max(limit, 500), chosenRelaySet, abortSignal,
+    translatedSeeds, Math.max(limit, 500), nip50RelaySet, abortSignal,
     nip50Extensions, applyDateFilter({ kinds: effectiveKinds }, dateFilter),
-    () => getBroadRelaySet()
+    () => Promise.resolve(broadRelaySet)
   );
 
   // No global content filter — per-seed filtering happens inside termSearch
@@ -130,10 +130,10 @@ export async function handleProfileSeeds(pSeeds: string[], limit: number): Promi
 
 /** Build filter, subscribe, apply content filter, and return sorted results. */
 async function collectAndFilter(
-  filter: NDKFilter, chosenRelaySet: NDKRelaySet,
+  filter: NDKFilter, relaySet: NDKRelaySet,
   abortSignal: AbortSignal | undefined, cleanedQuery: string, limit: number
 ): Promise<NDKEvent[]> {
-  const results = await subscribeAndCollect(filter, 10000, chosenRelaySet, abortSignal);
+  const results = await subscribeAndCollect(filter, 10000, relaySet, abortSignal);
   return sortEventsNewestFirst(applyContentFilter(results, cleanedQuery)).slice(0, limit);
 }
 
@@ -147,7 +147,7 @@ function extractResidual(preprocessed: string, normalize = false): string {
 async function handleSameContentMultiAuthor(
   expandedSeeds: string[], baseQuery: string,
   effectiveKinds: number[], dateFilter: { since?: number; until?: number },
-  nip50Extensions: Nip50Extensions | undefined, chosenRelaySet: NDKRelaySet,
+  nip50Extensions: Nip50Extensions | undefined, nip50RelaySet: NDKRelaySet, broadRelaySet: NDKRelaySet,
   abortSignal: AbortSignal | undefined, cleanedQuery: string, limit: number
 ): Promise<NDKEvent[] | null> {
   const resolvedPubkeys = await resolveAuthorTokens(
@@ -167,13 +167,14 @@ async function handleSameContentMultiAuthor(
   const residual = extractResidual(preprocessed);
   if (residual) filter.search = nip50Extensions ? buildSearchQueryWithExtensions(residual, nip50Extensions) : residual;
 
-  return collectAndFilter(filter, chosenRelaySet, abortSignal, cleanedQuery, limit);
+  const relaySet = filter.search ? nip50RelaySet : broadRelaySet;
+  return collectAndFilter(filter, relaySet, abortSignal, cleanedQuery, limit);
 }
 
 async function handleTagAuthorCombination(
   expandedSeeds: string[], effectiveKinds: number[],
   dateFilter: { since?: number; until?: number }, nip50Extensions: Nip50Extensions | undefined,
-  chosenRelaySet: NDKRelaySet, abortSignal: AbortSignal | undefined,
+  nip50RelaySet: NDKRelaySet, broadRelaySet: NDKRelaySet, abortSignal: AbortSignal | undefined,
   cleanedQuery: string, limit: number
 ): Promise<NDKEvent[] | null> {
   const extractTags = (s: string): string[] =>
@@ -204,5 +205,6 @@ async function handleTagAuthorCombination(
   const residual = extractResidual(preprocessed, true);
   if (residual) filter.search = nip50Extensions ? buildSearchQueryWithExtensions(residual, nip50Extensions) : residual;
 
-  return collectAndFilter(filter, chosenRelaySet, abortSignal, cleanedQuery, limit);
+  const relaySet = filter.search ? nip50RelaySet : broadRelaySet;
+  return collectAndFilter(filter, relaySet, abortSignal, cleanedQuery, limit);
 }

--- a/src/lib/search/orExpansion.ts
+++ b/src/lib/search/orExpansion.ts
@@ -137,9 +137,13 @@ export async function handleProfileSeeds(pSeeds: string[], limit: number): Promi
 async function collectAndFilter(
   filter: NDKFilter, relaySet: NDKRelaySet, abortSignal: AbortSignal | undefined, cleanedQuery: string, limit: number
 ): Promise<NDKEvent[]> {
-  return sortEventsNewestFirst(
-    applyContentFilter(dedupeEvents(await subscribeAndCollect(filter, 10000, relaySet, abortSignal)), cleanedQuery)
-  ).slice(0, limit);
+  let raw: NDKEvent[];
+  try {
+    raw = await subscribeAndCollect(filter, 10000, relaySet, abortSignal);
+  } catch {
+    return [];
+  }
+  return sortEventsNewestFirst(applyContentFilter(dedupeEvents(raw), cleanedQuery)).slice(0, limit);
 }
 
 /** Strip kind/hashtag tokens to get residual search text */

--- a/src/lib/search/orExpansion.ts
+++ b/src/lib/search/orExpansion.ts
@@ -8,6 +8,15 @@ import { searchByAnyTerms } from './termSearch';
 import { resolveAuthorTokens } from './authorResolve';
 import { applyContentFilter } from './contentFilter';
 import { searchProfilesFullText } from '../vertex';
+/** Deduplicate events by id */
+function dedupeEvents(events: NDKEvent[]): NDKEvent[] {
+  const seen = new Set<string>();
+  return events.filter((e) => {
+    if (seen.has(e.id)) return false;
+    seen.add(e.id);
+    return true;
+  });
+}
 
 /** Extract all by: tokens from a seed string */
 export function extractByTokens(seed: string): string[] {
@@ -20,12 +29,11 @@ export function extractNonByContent(seed: string): string {
   return seed.replace(/\bby:\S+/gi, '').replace(/\s+/g, ' ').trim();
 }
 
-/** Optimize pure by: OR queries into a single multi-author filter. Returns null if not applicable. */
+/** Optimize pure by: OR queries into a single multi-author filter. */
 export async function maybeOptimizeByOnlyOrSeeds(
   seeds: string[], effectiveKinds: number[], dateFilter: { since?: number; until?: number },
-  nip50Extensions: Nip50Extensions | undefined, broadRelaySet: NDKRelaySet,
-  abortSignal: AbortSignal | undefined, limit: number
-): Promise<NDKEvent[] | null> {
+  _nip50Extensions: Nip50Extensions | undefined, broadRelaySet: NDKRelaySet,
+  abortSignal: AbortSignal | undefined, limit: number): Promise<NDKEvent[] | null> {
   const trimmedSeeds = seeds.map((s) => s.trim()).filter(Boolean);
   if (trimmedSeeds.length < 2) return null;
 
@@ -47,16 +55,21 @@ export async function maybeOptimizeByOnlyOrSeeds(
   ) as NDKFilter;
 
   // Pure author query: no search text, use broad relays
-  const results = await subscribeAndCollect(filter, 10000, broadRelaySet, abortSignal);
-  return sortEventsNewestFirst(results).slice(0, limit);
+  let results: NDKEvent[];
+  try {
+    results = await subscribeAndCollect(filter, 10000, broadRelaySet, abortSignal);
+  } catch {
+    return null; // Let caller fall back to searchByAnyTerms
+  }
+
+  return sortEventsNewestFirst(dedupeEvents(results)).slice(0, limit);
 }
 
 /** Handle parenthesized OR expansion: "(GM OR GN) by:dergigi" => multiple seeds. */
 export async function handleParenthesizedOr(
   cleanedQuery: string, effectiveKinds: number[], dateFilter: { since?: number; until?: number },
-  nip50Extensions: Nip50Extensions | undefined, nip50RelaySet: NDKRelaySet, broadRelaySet: NDKRelaySet,
-  abortSignal: AbortSignal | undefined, limit: number
-): Promise<NDKEvent[] | null> {
+  nip50Extensions: Nip50Extensions | undefined, nip50RelaySet: NDKRelaySet,
+  broadRelaySet: NDKRelaySet, abortSignal: AbortSignal | undefined, limit: number): Promise<NDKEvent[] | null> {
   const expandedSeeds = expandParenthesizedOr(cleanedQuery)
     .map((seed) => seed.trim())
     .filter(Boolean);
@@ -74,10 +87,9 @@ export async function handleParenthesizedOr(
   );
   if (byOnlyResults !== null) return byOnlyResults;
 
-  // Same non-by content with different authors
   const firstNonBy = extractNonByContent(expandedSeeds[0]);
-  const allSameNonBy = expandedSeeds.every((seed) => extractNonByContent(seed) === firstNonBy);
-  const allHaveBy = expandedSeeds.every((seed) => /\bby:\S+/i.test(seed));
+  const allSameNonBy = expandedSeeds.every((s) => extractNonByContent(s) === firstNonBy);
+  const allHaveBy = expandedSeeds.every((s) => /\bby:\S+/i.test(s));
 
   if (allSameNonBy && allHaveBy && expandedSeeds.length > 1) {
     const result = await handleSameContentMultiAuthor(
@@ -92,12 +104,11 @@ export async function handleParenthesizedOr(
   );
   if (tagAuthorResult) return tagAuthorResult;
 
-  // Fallback: search each seed via searchByAnyTerms
+  // Fallback: search each seed via searchByAnyTerms, prepend kind tokens if missing
+  const kindPrefix = effectiveKinds.map((k) => `kind:${k}`).join(' ');
   const translatedSeeds = expandedSeeds.map((seed) => {
-    const existingKind = extractKindFilter(seed);
-    if (existingKind.kinds && existingKind.kinds.length > 0) return seed;
-    const kindTokens = effectiveKinds.map((k) => `kind:${k}`).join(' ');
-    return kindTokens ? `${kindTokens} ${seed}`.trim() : seed;
+    if (extractKindFilter(seed).kinds?.length) return seed;
+    return kindPrefix ? `${kindPrefix} ${seed}`.trim() : seed;
   });
 
   const seedResults = await searchByAnyTerms(
@@ -112,32 +123,26 @@ export async function handleParenthesizedOr(
 
 export async function handleProfileSeeds(pSeeds: string[], limit: number): Promise<NDKEvent[]> {
   const pTerms = pSeeds.map((s) => s.replace(/^p:/i, '').trim()).filter(Boolean);
-  const profileResults = await Promise.allSettled(pTerms.map((term) => searchProfilesFullText(term)));
-  const mergedProfiles: NDKEvent[] = [];
-  const seenPubkeys = new Set<string>();
-  for (const result of profileResults) {
-    if (result.status !== 'fulfilled') continue;
-    for (const evt of result.value) {
+  const results = await Promise.allSettled(pTerms.map((t) => searchProfilesFullText(t)));
+  const seen = new Set<string>();
+  const merged = results.flatMap((r) => r.status === 'fulfilled' ? r.value : [])
+    .filter((evt) => {
       const pk = evt.pubkey || evt.author?.pubkey || '';
-      if (pk && !seenPubkeys.has(pk)) {
-        seenPubkeys.add(pk);
-        mergedProfiles.push(evt);
-      }
-    }
-  }
-  return sortEventsNewestFirst(mergedProfiles).slice(0, limit);
+      return pk && !seen.has(pk) && (seen.add(pk), true);
+    });
+  return sortEventsNewestFirst(merged).slice(0, limit);
 }
 
-/** Build filter, subscribe, apply content filter, and return sorted results. */
+/** Subscribe, dedupe, content-filter, sort, and slice. */
 async function collectAndFilter(
-  filter: NDKFilter, relaySet: NDKRelaySet,
-  abortSignal: AbortSignal | undefined, cleanedQuery: string, limit: number
+  filter: NDKFilter, relaySet: NDKRelaySet, abortSignal: AbortSignal | undefined, cleanedQuery: string, limit: number
 ): Promise<NDKEvent[]> {
-  const results = await subscribeAndCollect(filter, 10000, relaySet, abortSignal);
-  return sortEventsNewestFirst(applyContentFilter(results, cleanedQuery)).slice(0, limit);
+  return sortEventsNewestFirst(
+    applyContentFilter(dedupeEvents(await subscribeAndCollect(filter, 10000, relaySet, abortSignal)), cleanedQuery)
+  ).slice(0, limit);
 }
 
-/** Strip kind/hashtag tokens from preprocessed query to get residual search text */
+/** Strip kind/hashtag tokens to get residual search text */
 function extractResidual(preprocessed: string, normalize = false): string {
   const raw = preprocessed.replace(/\bkind:[^\s]+/gi, ' ').replace(/\bkinds:[^\s]+/gi, ' ')
     .replace(/#[A-Za-z0-9_]+/g, ' ').replace(/\s+/g, ' ').trim();
@@ -145,11 +150,10 @@ function extractResidual(preprocessed: string, normalize = false): string {
 }
 
 async function handleSameContentMultiAuthor(
-  expandedSeeds: string[], baseQuery: string,
-  effectiveKinds: number[], dateFilter: { since?: number; until?: number },
-  nip50Extensions: Nip50Extensions | undefined, nip50RelaySet: NDKRelaySet, broadRelaySet: NDKRelaySet,
-  abortSignal: AbortSignal | undefined, cleanedQuery: string, limit: number
-): Promise<NDKEvent[] | null> {
+  expandedSeeds: string[], baseQuery: string, effectiveKinds: number[],
+  dateFilter: { since?: number; until?: number }, nip50Extensions: Nip50Extensions | undefined,
+  nip50RelaySet: NDKRelaySet, broadRelaySet: NDKRelaySet,
+  abortSignal: AbortSignal | undefined, cleanedQuery: string, limit: number): Promise<NDKEvent[] | null> {
   const resolvedPubkeys = await resolveAuthorTokens(
     Array.from(new Set(expandedSeeds.flatMap(extractByTokens)))
   );
@@ -174,9 +178,8 @@ async function handleSameContentMultiAuthor(
 async function handleTagAuthorCombination(
   expandedSeeds: string[], effectiveKinds: number[],
   dateFilter: { since?: number; until?: number }, nip50Extensions: Nip50Extensions | undefined,
-  nip50RelaySet: NDKRelaySet, broadRelaySet: NDKRelaySet, abortSignal: AbortSignal | undefined,
-  cleanedQuery: string, limit: number
-): Promise<NDKEvent[] | null> {
+  nip50RelaySet: NDKRelaySet, broadRelaySet: NDKRelaySet,
+  abortSignal: AbortSignal | undefined, cleanedQuery: string, limit: number): Promise<NDKEvent[] | null> {
   const extractTags = (s: string): string[] =>
     Array.from(s.matchAll(/#[A-Za-z0-9_]+/gi)).map((m) => (m[0] || '').slice(1).toLowerCase()).filter(Boolean);
   const extractCore = (s: string): string =>

--- a/src/lib/search/searchOrchestrator.ts
+++ b/src/lib/search/searchOrchestrator.ts
@@ -24,7 +24,7 @@ export async function runSearchStrategies(
   cleanedQuery: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { isStreaming, streamingOptions, chosenRelaySet, abortSignal, effectiveKinds, nip50Extensions, limit } = context;
+  const { isStreaming, streamingOptions, nip50RelaySet, abortSignal, effectiveKinds, nip50Extensions, limit } = context;
 
   // Note: id: lookups are handled early in search.ts, before the orchestrator.
 
@@ -36,7 +36,7 @@ export async function runSearchStrategies(
     limit,
     isStreaming || false,
     streamingOptions,
-    chosenRelaySet,
+    nip50RelaySet,
     abortSignal
   );
   if (urlResults) return urlResults;

--- a/src/lib/search/strategies/aTagSearchStrategy.ts
+++ b/src/lib/search/strategies/aTagSearchStrategy.ts
@@ -1,7 +1,6 @@
 import { NDKEvent } from '@nostr-dev-kit/ndk';
 import { applyDateFilter } from '../queryParsing';
 import { subscribeAndStream, subscribeAndCollect } from '../subscriptions';
-import { getBroadRelaySet } from '../relayManagement';
 import { sortEventsNewestFirst } from '../../utils/searchUtils';
 import { SearchContext, TagTFilter } from '../types';
 
@@ -13,7 +12,7 @@ export async function tryHandleATagSearch(
   query: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { effectiveKinds, dateFilter, limit, isStreaming, streamingOptions, abortSignal, extensionFilters } = context;
+  const { effectiveKinds, dateFilter, limit, isStreaming, streamingOptions, abortSignal, extensionFilters, broadRelaySet } = context;
   
   const aTagMatch = query.match(/^a:(.+)$/i);
   if (aTagMatch) {
@@ -21,8 +20,8 @@ export async function tryHandleATagSearch(
     if (aTagValue) {
       const aTagFilter: TagTFilter = applyDateFilter({ kinds: effectiveKinds, '#a': [aTagValue], limit: Math.max(limit, 500) }, dateFilter) as TagTFilter;
       
-      // Use broader relay set for a tag searches
-      const aTagRelaySet = await getBroadRelaySet();
+      // #a tag searches are structural, no NIP-50 needed
+      const aTagRelaySet = broadRelaySet;
 
       const results = isStreaming
         ? await subscribeAndStream(aTagFilter, {

--- a/src/lib/search/strategies/authorSearchStrategy.ts
+++ b/src/lib/search/strategies/authorSearchStrategy.ts
@@ -1,6 +1,6 @@
 import { NDKEvent, NDKFilter, NDKRelaySet, NDKRelay } from '@nostr-dev-kit/ndk';
 import { ndk } from '../../ndk';
-import { RELAYS } from '../../relays';
+
 import { applyDateFilter } from '../queryParsing';
 import { buildSearchQueryWithExtensions } from '../searchUtils';
 import { expandParenthesizedOr } from '../queryTransforms';
@@ -142,8 +142,6 @@ export async function tryHandleAuthorSearch(
     // Direct query (authors + kinds + tags, no search text): all relays are fine.
     res = await subscribeAndCollect(filters, 8000, authorRelaySet, abortSignal);
     if (res.length === 0) {
-      const broadRelays = Array.from(new Set<string>([...RELAYS.DEFAULT, ...RELAYS.SEARCH]));
-      const broadRelaySet = NDKRelaySet.fromRelayUrls(broadRelays, ndk);
       res = await subscribeAndCollect(filters, 10000, broadRelaySet, abortSignal);
     }
   }

--- a/src/lib/search/strategies/authorSearchStrategy.ts
+++ b/src/lib/search/strategies/authorSearchStrategy.ts
@@ -64,6 +64,9 @@ export async function tryHandleAuthorSearch(
     }
   }
 
+  // Determine whether this query needs NIP-50 search support
+  const needsNip50 = searchText.length > 0;
+
   // Pick the right base relay set: NIP-50 for text search, broad for structured queries.
   // Clone so author-specific outbox relays don't pollute the shared set (#227).
   const baseRelaySet = needsNip50 ? nip50RelaySet : broadRelaySet;
@@ -87,7 +90,6 @@ export async function tryHandleAuthorSearch(
   // Search queries (has searchText) → NIP-50 relays only.
   // Direct queries (no searchText, just authors/kinds/tags) → all relays.
   let res: NDKEvent[] = [];
-  const needsNip50 = searchText.length > 0;
 
   if (needsNip50) {
     // Text + author query: only use NIP-50 search relays (they honor the search field)

--- a/src/lib/search/strategies/authorSearchStrategy.ts
+++ b/src/lib/search/strategies/authorSearchStrategy.ts
@@ -21,7 +21,7 @@ export async function tryHandleAuthorSearch(
   cleanedQuery: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { effectiveKinds, dateFilter, nip50Extensions, chosenRelaySet, abortSignal, limit } = context;
+  const { effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, limit } = context;
 
   // Extract ALL by: tokens with a global regex
   const byMatches = Array.from(cleanedQuery.matchAll(/\bby:(\S+)/gi));
@@ -64,9 +64,10 @@ export async function tryHandleAuthorSearch(
     }
   }
 
-  // Clone the shared relay set so author-specific outbox relays don't pollute
-  // the context used by other strategies (#227)
-  const authorRelaySet = new NDKRelaySet(new Set(chosenRelaySet.relays), ndk);
+  // Pick the right base relay set: NIP-50 for text search, broad for structured queries.
+  // Clone so author-specific outbox relays don't pollute the shared set (#227).
+  const baseRelaySet = needsNip50 ? nip50RelaySet : broadRelaySet;
+  const authorRelaySet = new NDKRelaySet(new Set(baseRelaySet.relays), ndk);
   try {
     const outboxResults = await Promise.allSettled(
       pubkeys.map(pk => getOutboxSearchCapableRelays(pk))

--- a/src/lib/search/strategies/dTagSearchStrategy.ts
+++ b/src/lib/search/strategies/dTagSearchStrategy.ts
@@ -15,7 +15,7 @@ export async function tryHandleDTagSearch(
   cleanedQuery: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { effectiveKinds, dateFilter, nip50Extensions, chosenRelaySet, abortSignal, limit } = context;
+  const { effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, limit } = context;
 
   const matches = Array.from(cleanedQuery.matchAll(/\bd:(\S+)/gi));
   if (matches.length === 0) return null;
@@ -33,5 +33,5 @@ export async function tryHandleDTagSearch(
 
   if (search) (filter as NDKFilter).search = search;
 
-  return fetchDedupeAndSort(filter, chosenRelaySet, Boolean(search), abortSignal, limit);
+  return fetchDedupeAndSort(filter, nip50RelaySet, broadRelaySet, Boolean(search), abortSignal, limit);
 }

--- a/src/lib/search/strategies/hashtagSearchStrategy.ts
+++ b/src/lib/search/strategies/hashtagSearchStrategy.ts
@@ -1,7 +1,6 @@
 import { NDKEvent } from '@nostr-dev-kit/ndk';
 import { applyDateFilter } from '../queryParsing';
 import { subscribeAndStream, subscribeAndCollect } from '../subscriptions';
-import { getBroadRelaySet } from '../relayManagement';
 import { sortEventsNewestFirst } from '../../utils/searchUtils';
 import { SearchContext, TagTFilter } from '../types';
 
@@ -13,7 +12,7 @@ export async function tryHandleHashtagSearch(
   query: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { effectiveKinds, dateFilter, limit, isStreaming, streamingOptions, abortSignal, extensionFilters } = context;
+  const { effectiveKinds, dateFilter, limit, isStreaming, streamingOptions, abortSignal, extensionFilters, broadRelaySet } = context;
   
   const hashtagMatches = query.match(/#[A-Za-z0-9_]+/g) || [];
   const nonHashtagRemainder = query.replace(/#[A-Za-z0-9_]+/g, '').trim();
@@ -22,8 +21,8 @@ export async function tryHandleHashtagSearch(
     const tags = Array.from(new Set(hashtagMatches.map((h) => h.slice(1).toLowerCase())));
     const tagFilter: TagTFilter = applyDateFilter({ kinds: effectiveKinds, '#t': tags, limit: Math.max(limit, 500) }, dateFilter) as TagTFilter;
 
-    // Use broader relay set for hashtag searches - include all available relays
-    const tagRelaySet = await getBroadRelaySet();
+    // Hashtag searches use structured #t tag filters, no NIP-50 needed
+    const tagRelaySet = broadRelaySet;
 
     const results = isStreaming
       ? await subscribeAndStream(tagFilter, {

--- a/src/lib/search/strategies/identitySearchStrategy.ts
+++ b/src/lib/search/strategies/identitySearchStrategy.ts
@@ -14,7 +14,7 @@ export async function tryHandleIdentitySearch(
   cleanedQuery: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { effectiveKinds, dateFilter, chosenRelaySet, abortSignal, limit } = context;
+  const { effectiveKinds, dateFilter, broadRelaySet, abortSignal, limit } = context;
 
   // Check if the query is a direct npub
   if (isNpub(cleanedQuery)) {
@@ -26,7 +26,7 @@ export async function tryHandleIdentitySearch(
         kinds: effectiveKinds,
         authors: [pubkey],
         limit: Math.max(limit, 200)
-      }, dateFilter) as NDKFilter, 8000, chosenRelaySet, abortSignal);
+      }, dateFilter) as NDKFilter, 8000, broadRelaySet, abortSignal);
       return sortEventsNewestFirst(res).slice(0, limit);
     } catch (error) {
       console.error('Error processing npub query:', error);

--- a/src/lib/search/strategies/licenseSearchStrategy.ts
+++ b/src/lib/search/strategies/licenseSearchStrategy.ts
@@ -1,7 +1,6 @@
 import { NDKEvent } from '@nostr-dev-kit/ndk';
 import { applyDateFilter } from '../queryParsing';
 import { subscribeAndStream, subscribeAndCollect } from '../subscriptions';
-import { getBroadRelaySet } from '../relayManagement';
 import { sortEventsNewestFirst } from '../../utils/searchUtils';
 import { SearchContext, TagTFilter } from '../types';
 
@@ -13,7 +12,7 @@ export async function tryHandleLicenseSearch(
   query: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { effectiveKinds, dateFilter, limit, isStreaming, streamingOptions, abortSignal, extensionFilters } = context;
+  const { effectiveKinds, dateFilter, limit, isStreaming, streamingOptions, abortSignal, extensionFilters, broadRelaySet } = context;
   
   const licenseMatches = Array.from(query.match(/\blicense:([^\s)]+)\b/gi) || []).map((m) => m.split(':')[1]?.trim()).filter(Boolean) as string[];
   const nonLicenseRemainder = query.replace(/\blicense:[^\s)]+/gi, '').trim();
@@ -21,7 +20,8 @@ export async function tryHandleLicenseSearch(
   if (licenseMatches.length > 0 && nonLicenseRemainder.length === 0) {
     const licenses = Array.from(new Set(licenseMatches.map((v) => v.toUpperCase())));
     const licenseFilter: TagTFilter = applyDateFilter({ kinds: effectiveKinds, '#license': licenses, limit: Math.max(limit, 500) }, dateFilter) as TagTFilter;
-    const tagRelaySet = await getBroadRelaySet();
+    // License tag searches are structural, no NIP-50 needed
+    const tagRelaySet = broadRelaySet;
     const results = isStreaming
       ? await subscribeAndStream(licenseFilter, {
           timeoutMs: streamingOptions?.timeoutMs || 30000,

--- a/src/lib/search/strategies/linkSearchStrategy.ts
+++ b/src/lib/search/strategies/linkSearchStrategy.ts
@@ -15,7 +15,7 @@ export async function tryHandleLinkSearch(
   cleanedQuery: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { effectiveKinds, dateFilter, nip50Extensions, chosenRelaySet, abortSignal, limit } = context;
+  const { effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, limit } = context;
 
   const matches = Array.from(cleanedQuery.matchAll(/\blink:(\S+)/gi));
   if (matches.length === 0) return null;
@@ -33,5 +33,5 @@ export async function tryHandleLinkSearch(
 
   if (search) (filter as NDKFilter).search = search;
 
-  return fetchDedupeAndSort(filter, chosenRelaySet, Boolean(search), abortSignal, limit);
+  return fetchDedupeAndSort(filter, nip50RelaySet, broadRelaySet, Boolean(search), abortSignal, limit);
 }

--- a/src/lib/search/strategies/mentionsSearchStrategy.ts
+++ b/src/lib/search/strategies/mentionsSearchStrategy.ts
@@ -3,7 +3,7 @@ import { applyDateFilter } from '../queryParsing';
 import { buildSearchQueryWithExtensions } from '../searchUtils';
 import { subscribeAndCollect } from '../subscriptions';
 import { resolveAuthorTokens } from '../authorResolve';
-import { getBroadRelaySet } from '../relayManagement';
+
 import { sortEventsNewestFirst } from '../../utils/searchUtils';
 import { SearchContext } from '../types';
 
@@ -19,7 +19,7 @@ export async function tryHandleMentionsSearch(
   cleanedQuery: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { effectiveKinds, dateFilter, nip50Extensions, chosenRelaySet, abortSignal, limit } = context;
+  const { effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, limit } = context;
 
   const mentionsMatches = Array.from(cleanedQuery.matchAll(/\bmentions:(\S+)/gi));
   if (mentionsMatches.length === 0) {
@@ -68,18 +68,18 @@ export async function tryHandleMentionsSearch(
     }
   }
 
-  // When a search term is present, use NIP-50 relays (chosenRelaySet) so the
-  // `search` field is actually evaluated. Non-NIP-50 relays silently ignore it
-  // and return all #p matches, polluting results.
+  // When a search term is present, use NIP-50 relays so the `search` field is
+  // actually evaluated. Non-NIP-50 relays silently ignore it and return all
+  // #p matches, polluting results.
   const hasSearchTerm = Boolean((filters as NDKFilter).search);
-  const primaryRelaySet = hasSearchTerm ? chosenRelaySet : await getBroadRelaySet();
+  const primaryRelaySet = hasSearchTerm ? nip50RelaySet : broadRelaySet;
 
   let res: NDKEvent[];
   try {
     res = await subscribeAndCollect(filters, 10000, primaryRelaySet, abortSignal);
   } catch (error) {
-    // Fallback to chosen relay set (already NIP-50 capable)
-    res = await subscribeAndCollect(filters, 10000, chosenRelaySet, abortSignal);
+    // Fallback to NIP-50 relay set
+    res = await subscribeAndCollect(filters, 10000, nip50RelaySet, abortSignal);
   }
 
   // Dedupe

--- a/src/lib/search/strategies/mentionsSearchStrategy.ts
+++ b/src/lib/search/strategies/mentionsSearchStrategy.ts
@@ -77,9 +77,8 @@ export async function tryHandleMentionsSearch(
   let res: NDKEvent[];
   try {
     res = await subscribeAndCollect(filters, 10000, primaryRelaySet, abortSignal);
-  } catch (error) {
-    // Fallback to NIP-50 relay set
-    res = await subscribeAndCollect(filters, 10000, nip50RelaySet, abortSignal);
+  } catch {
+    res = [];
   }
 
   // Dedupe

--- a/src/lib/search/strategies/refSearchStrategy.ts
+++ b/src/lib/search/strategies/refSearchStrategy.ts
@@ -29,7 +29,7 @@ export async function tryHandleRefSearch(
   cleanedQuery: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { effectiveKinds, dateFilter, nip50Extensions, chosenRelaySet, abortSignal, limit } = context;
+  const { effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, limit } = context;
 
   const matches = Array.from(cleanedQuery.matchAll(/\bref:(\S+)/gi));
   if (matches.length === 0) return null;
@@ -48,5 +48,5 @@ export async function tryHandleRefSearch(
 
   if (search) (filter as NDKFilter).search = search;
 
-  return fetchDedupeAndSort(filter, chosenRelaySet, Boolean(search), abortSignal, limit);
+  return fetchDedupeAndSort(filter, nip50RelaySet, broadRelaySet, Boolean(search), abortSignal, limit);
 }

--- a/src/lib/search/strategies/replySearchStrategy.ts
+++ b/src/lib/search/strategies/replySearchStrategy.ts
@@ -27,7 +27,7 @@ export async function tryHandleReplySearch(
   cleanedQuery: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { effectiveKinds, dateFilter, nip50Extensions, chosenRelaySet, abortSignal, limit } = context;
+  const { effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, limit } = context;
 
   const matches = Array.from(cleanedQuery.matchAll(/\breply:(\S+)/gi));
   if (matches.length === 0) return null;
@@ -46,5 +46,5 @@ export async function tryHandleReplySearch(
 
   if (search) (filter as NDKFilter).search = search;
 
-  return fetchDedupeAndSort(filter, chosenRelaySet, Boolean(search), abortSignal, limit);
+  return fetchDedupeAndSort(filter, nip50RelaySet, broadRelaySet, Boolean(search), abortSignal, limit);
 }

--- a/src/lib/search/strategies/strategyUtils.ts
+++ b/src/lib/search/strategies/strategyUtils.ts
@@ -1,6 +1,5 @@
 import { NDKEvent, NDKFilter, NDKRelaySet } from '@nostr-dev-kit/ndk';
 import { subscribeAndCollect } from '../subscriptions';
-import { getBroadRelaySet } from '../relayManagement';
 import { resolveAuthorTokens } from '../authorResolve';
 import { buildSearchQueryWithExtensions, Nip50Extensions } from '../searchUtils';
 import { sortEventsNewestFirst } from '../../utils/searchUtils';
@@ -11,31 +10,19 @@ import { sortEventsNewestFirst } from '../../utils/searchUtils';
  */
 export async function fetchDedupeAndSort(
   filter: NDKFilter,
-  chosenRelaySet: NDKRelaySet,
+  nip50RelaySet: NDKRelaySet,
+  broadRelaySet: NDKRelaySet,
   hasSearchTerm: boolean,
   abortSignal: AbortSignal | undefined,
   limit: number
 ): Promise<NDKEvent[]> {
-  let relaySet: NDKRelaySet;
-  try {
-    relaySet = hasSearchTerm ? chosenRelaySet : await getBroadRelaySet();
-  } catch {
-    relaySet = chosenRelaySet;
-  }
+  const relaySet = hasSearchTerm ? nip50RelaySet : broadRelaySet;
 
   let results: NDKEvent[];
   try {
     results = await subscribeAndCollect(filter, 10000, relaySet, abortSignal);
   } catch {
-    if (relaySet !== chosenRelaySet) {
-      try {
-        results = await subscribeAndCollect(filter, 10000, chosenRelaySet, abortSignal);
-      } catch {
-        results = [];
-      }
-    } else {
-      results = [];
-    }
+    results = [];
   }
 
   const dedupe = new Map<string, NDKEvent>();

--- a/src/lib/search/strategies/urlSearchStrategy.ts
+++ b/src/lib/search/strategies/urlSearchStrategy.ts
@@ -14,7 +14,7 @@ export async function tryHandleUrlSearch(
   limit: number,
   isStreaming: boolean,
   streamingOptions: StreamingSearchOptions | undefined,
-  chosenRelaySet: NDKRelaySet,
+  nip50RelaySet: NDKRelaySet,
   abortSignal?: AbortSignal
 ): Promise<NDKEvent[] | null> {
   try {
@@ -28,7 +28,7 @@ export async function tryHandleUrlSearch(
         limit,
         isStreaming,
         streamingOptions,
-        chosenRelaySet,
+        nip50RelaySet,
         abortSignal
       );
     }

--- a/src/lib/search/topLevelOr.ts
+++ b/src/lib/search/topLevelOr.ts
@@ -3,7 +3,6 @@ import { sortEventsNewestFirst } from '../utils/searchUtils';
 import { Nip50Extensions } from './searchUtils';
 import { applyDateFilter } from './queryParsing';
 import { expandParenthesizedOr } from './queryTransforms';
-import { getBroadRelaySet } from './relayManagement';
 import { searchByAnyTerms } from './termSearch';
 import { maybeOptimizeByOnlyOrSeeds, handleProfileSeeds } from './orExpansion';
 
@@ -16,8 +15,8 @@ export async function handleTopLevelOr(
   effectiveKinds: number[],
   dateFilter: { since?: number; until?: number },
   nip50Extensions: Nip50Extensions | undefined,
-  chosenRelaySet: NDKRelaySet,
-  relaySetOverride: NDKRelaySet | undefined,
+  nip50RelaySet: NDKRelaySet,
+  broadRelaySet: NDKRelaySet,
   abortSignal: AbortSignal | undefined,
   limit: number
 ): Promise<NDKEvent[] | null> {
@@ -34,9 +33,9 @@ export async function handleTopLevelOr(
       return acc;
     }, []);
 
-  // Try optimizing pure by: OR queries
+  // Try optimizing pure by: OR queries (no search text, use broad relays)
   const byOnlyResults = await maybeOptimizeByOnlyOrSeeds(
-    normalizedParts, effectiveKinds, dateFilter, nip50Extensions, chosenRelaySet, abortSignal, limit
+    normalizedParts, effectiveKinds, dateFilter, nip50Extensions, broadRelaySet, abortSignal, limit
   );
   if (byOnlyResults !== null) return byOnlyResults;
 
@@ -47,20 +46,11 @@ export async function handleTopLevelOr(
   }
 
   // General OR search via searchByAnyTerms
-  let orResults = await searchByAnyTerms(
-    normalizedParts, Math.max(limit, 500), chosenRelaySet, abortSignal,
+  const orResults = await searchByAnyTerms(
+    normalizedParts, Math.max(limit, 500), nip50RelaySet, abortSignal,
     nip50Extensions, applyDateFilter({ kinds: effectiveKinds }, dateFilter),
-    () => getBroadRelaySet()
+    () => Promise.resolve(broadRelaySet)
   );
-
-  // Retry with broader relay set if no results
-  if (orResults.length === 0 && !relaySetOverride) {
-    const broadRelaySet = await getBroadRelaySet();
-    orResults = await searchByAnyTerms(
-      normalizedParts, Math.max(limit, 500), broadRelaySet, abortSignal,
-      nip50Extensions, applyDateFilter({ kinds: effectiveKinds }, dateFilter)
-    );
-  }
 
   const filtered = orResults.filter((evt) => effectiveKinds.length === 0 || effectiveKinds.includes(evt.kind));
   return sortEventsNewestFirst(filtered).slice(0, limit);

--- a/src/lib/search/types.ts
+++ b/src/lib/search/types.ts
@@ -15,7 +15,10 @@ export interface SearchContext {
   effectiveKinds: number[];
   dateFilter?: { since?: number; until?: number };
   nip50Extensions?: Nip50Extensions;
-  chosenRelaySet: NDKRelaySet;
+  /** All reachable relays (default + user + premium + manual). For structured queries. */
+  broadRelaySet: NDKRelaySet;
+  /** Curated NIP-50 relays only. For any query containing free-text search terms. */
+  nip50RelaySet: NDKRelaySet;
   relaySetOverride?: NDKRelaySet;
   isStreaming: boolean;
   streamingOptions?: StreamingSearchOptions;

--- a/src/lib/search/urlSearch.ts
+++ b/src/lib/search/urlSearch.ts
@@ -23,7 +23,7 @@ export async function searchUrlEvents(
   limit: number,
   isStreaming: boolean,
   streamingOptions: StreamingSearchOptions | undefined,
-  chosenRelaySet: NDKRelaySet,
+  nip50RelaySet: NDKRelaySet,
   abortSignal?: AbortSignal
 ): Promise<NDKEvent[]> {
   // Search for the URL content (protocol stripping now handled by replacement rules)
@@ -37,14 +37,14 @@ export async function searchUrlEvents(
         timeoutMs: streamingOptions?.timeoutMs || 30000,
         maxResults: streamingOptions?.maxResults || 1000,
         onResults: streamingOptions?.onResults,
-        relaySet: chosenRelaySet,
+        relaySet: nip50RelaySet,
         abortSignal
       })
     : await subscribeAndCollect({
         kinds: effectiveKinds,
         search: searchQuery,
         limit: Math.max(limit, 200)
-      }, 8000, chosenRelaySet, abortSignal);
+      }, 8000, nip50RelaySet, abortSignal);
   
   return sortEventsNewestFirst(results).slice(0, limit);
 }


### PR DESCRIPTION
Replaces the ambiguous `chosenRelaySet` in `SearchContext` with two explicit relay sets: `broadRelaySet` for structured queries (authors, tags, kinds, ids) and `nip50RelaySet` for text search queries that need NIP-50 support. Every strategy now picks the right one based on whether it has free-text search terms, instead of trusting that `chosenRelaySet` happens to be the correct type.

Also removes `getMonitoredNip50Relays()` from search relay set construction. NIP-66 monitor data was injecting every relay it had ever seen with NIP-50 support into the search set, including relays with stale or broken NIP-50 implementations that would ignore the `search` field and return unfiltered results. NIP-66 now serves its intended role: filtering dead relays and caching NIP support info for faster probes.

- `SearchContext` carries `broadRelaySet` + `nip50RelaySet` instead of `chosenRelaySet`
- `fetchDedupeAndSort` takes both sets and picks based on `hasSearchTerm`
- Author strategy picks relay set before cloning, based on whether search text is present
- Hashtag, aTag, license strategies use `context.broadRelaySet` directly instead of calling `getBroadRelaySet()` at runtime
- OR handlers (`orExpansion.ts`, `topLevelOr.ts`) pass both sets through and pick per-branch
- Removes the fire-and-forget `getNip50SearchRelaySet()` call from SearchView that could cause mid-search relay set mutations

Closes #237, closes #238.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Search now uses two distinct relay sets: a curated NIP-50 set for free-text searches and a broader set for structured queries.
  * Removed background async discovery/cache-warming for NIP-50 searches and simplified retry/fallback behavior.
  * Improved result deduplication to reduce duplicate items in search results while leaving streaming and final result application unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->