### PR TITLE
feat: add pp:<provider> keyword to force profile lookup provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ants.dergigi.com",
-  "version": "0.2.11",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ants.dergigi.com",
-      "version": "0.2.11",
+      "version": "0.3.5",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
         "@fortawesome/free-brands-svg-icons": "^6.7.2",
@@ -10090,6 +10090,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/components/QueryTranslation.tsx
+++ b/src/components/QueryTranslation.tsx
@@ -85,7 +85,7 @@ export default function QueryTranslation({ query, onAuthorResolved }: QueryTrans
       const immediateResult = await generateTranslation(query, true);
       if (!cancelled) setTranslation(immediateResult);
 
-      if (query.includes('by:')) {
+      if (/(^|\s)by:/i.test(query)) {
         const resolvedResult = await generateTranslation(query, false);
         if (!cancelled) {
           setTranslation(resolvedResult);

--- a/src/components/QueryTranslation.tsx
+++ b/src/components/QueryTranslation.tsx
@@ -55,8 +55,13 @@ export default function QueryTranslation({ query, onAuthorResolved }: QueryTrans
 
   const generateTranslation = useCallback(async (query: string, skipAuthorResolution = false): Promise<string> => {
     try {
+      // 0) Strip pp:<provider> keyword (shown separately, not part of query translation)
+      const ppMatch = query.match(/(?:^|\s)pp:(vertex|relatr|relay)(?:\s|$)/i);
+      const ppProvider = ppMatch ? ppMatch[1]?.toLowerCase() : null;
+      const withoutPp = query.replace(/(?:^|\s)pp:(vertex|relatr|relay)(?:\s|$)/gi, ' ').trim();
+
       // 1) Resolve relative dates (since:2w → since:2026-03-06) then apply replacements
-      const { resolved: dateResolved } = resolveRelativeDates(query);
+      const { resolved: dateResolved } = resolveRelativeDates(withoutPp);
       const afterReplacements = await applySimpleReplacements(dateResolved);
 
       // 2) Recursive OR substitution (distribute parentheses)
@@ -89,7 +94,7 @@ export default function QueryTranslation({ query, onAuthorResolved }: QueryTrans
               replacement = authorResolutionCache.current.get(core) || core;
             } else {
               try {
-                const npub = await resolveAuthorToNpub(core);
+                const npub = await resolveAuthorToNpub(core, ppProvider ?? undefined);
                 if (npub) {
                   replacement = npub;
                   authorResolutionCache.current.set(core, npub);
@@ -151,7 +156,8 @@ export default function QueryTranslation({ query, onAuthorResolved }: QueryTrans
       // Don't split further if we already have multiple distributed queries
       if (distributed.length > 1) {
         // We have parenthesized OR expansion - show all expanded queries
-        const preview = withPResolved.join('\n');
+        let preview = withPResolved.join('\n');
+        if (ppProvider) preview = `[pp:${ppProvider}] ${preview}`;
         return preview;
       }
 
@@ -168,7 +174,8 @@ export default function QueryTranslation({ query, onAuthorResolved }: QueryTrans
       const finalQueries = Array.from(finalQueriesSet);
 
       // Format compact preview
-      const preview = finalQueries.length > 0 ? finalQueries.join('\n') : afterReplacements;
+      let preview = finalQueries.length > 0 ? finalQueries.join('\n') : afterReplacements;
+      if (ppProvider) preview = `[pp:${ppProvider}] ${preview}`;
       return preview;
     } catch {
       return '';

--- a/src/components/QueryTranslation.tsx
+++ b/src/components/QueryTranslation.tsx
@@ -4,12 +4,14 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faEquals, faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
 import { expandParenthesizedOr, parseOrQuery } from '@/lib/search';
-import { resolveAuthorToNpub } from '@/lib/vertex';
 import { applySimpleReplacements } from '@/lib/search/replacements';
 import { resolveRelativeDates } from '@/lib/search/relativeDates';
-import { nip19 } from 'nostr-tools';
-import { getStoredPubkey } from '@/lib/nip07';
 import { getLastReducedFilters } from '@/lib/ndk';
+import {
+  getAdaptiveDebounceMs,
+  resolveByTokensInQuery,
+  resolvePTokensInQuery
+} from '@/lib/queryTranslationHelpers';
 
 interface QueryTranslationProps {
   query: string;
@@ -25,155 +27,41 @@ export default function QueryTranslation({ query, onAuthorResolved }: QueryTrans
   const resolutionTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const hasTriggeredSearchRef = useRef<boolean>(false);
 
-  // Determine an adaptive debounce based on device/network characteristics
-  const getAdaptiveDebounceMs = useCallback((): number => {
-    let delay = 700;
+  const generateTranslation = useCallback(async (q: string, skipAuthorResolution = false): Promise<string> => {
     try {
-      const nav: unknown = typeof navigator !== 'undefined' ? navigator : undefined;
-      // Hardware concurrency: fewer cores → longer debounce
-      const cores = (nav as { hardwareConcurrency?: number })?.hardwareConcurrency;
-      if (typeof cores === 'number') {
-        if (cores <= 2) delay += 300; // very low-end
-        else if (cores <= 4) delay += 150; // low-end
-      }
-      // Device memory: low memory → longer debounce
-      const deviceMemory = (nav as { deviceMemory?: number })?.deviceMemory as number | undefined;
-      if (typeof deviceMemory === 'number' && deviceMemory > 0 && deviceMemory <= 4) {
-        delay += 100;
-      }
-      // Network quality: slower connections → slightly longer debounce
-      const anyNav = nav as { connection?: { effectiveType?: string } } | undefined;
-      const effectiveType = anyNav?.connection?.effectiveType || '';
-      if (typeof effectiveType === 'string') {
-        if (effectiveType.includes('2g') || effectiveType === 'slow-2g') delay += 200;
-        else if (effectiveType.includes('3g')) delay += 100;
-      }
-    } catch {}
-    // Clamp to 700–1000ms range
-    return Math.min(1000, Math.max(700, delay));
-  }, []);
-
-  const generateTranslation = useCallback(async (query: string, skipAuthorResolution = false): Promise<string> => {
-    try {
-      // 0) Strip pp:<provider> keyword (shown separately, not part of query translation)
-      const ppMatch = query.match(/(?:^|\s)pp:(vertex|relatr|relay)(?:\s|$)/i);
+      const ppMatch = q.match(/(?:^|\s)pp:(vertex|relatr|relay)(?:\s|$)/i);
       const ppProvider = ppMatch ? ppMatch[1]?.toLowerCase() : null;
-      const withoutPp = query.replace(/(?:^|\s)pp:(vertex|relatr|relay)(?:\s|$)/gi, ' ').trim();
+      const withoutPp = q.replace(/(?:^|\s)pp:(vertex|relatr|relay)(?:\s|$)/gi, ' ').trim();
 
-      // 1) Resolve relative dates (since:2w → since:2026-03-06) then apply replacements
       const { resolved: dateResolved } = resolveRelativeDates(withoutPp);
       const afterReplacements = await applySimpleReplacements(dateResolved);
-
-      // 2) Recursive OR substitution (distribute parentheses)
       const distributed = expandParenthesizedOr(afterReplacements);
 
-      // Helper: resolve all by:<author> tokens within a single query string
-      const resolveByTokensInQuery = async (q: string): Promise<string> => {
-        const rx = /(^|\s)by:(\S+)/gi;
-        let result = '';
-        let lastIndex = 0;
-        let m: RegExpExecArray | null;
-        while ((m = rx.exec(q)) !== null) {
-          const full = m[0];
-          const pre = m[1] || '';
-          const raw = m[2] || '';
-          const match = raw.match(/^([^),.;]+)([),.;]*)$/);
-          const core = (match && match[1]) || raw;
-          const suffix = (match && match[2]) || '';
-          let replacement = core;
-          
-          // Resolve @me to the logged-in user's npub directly
-          if (/^@me$/i.test(core)) {
-            const pk = getStoredPubkey();
-            if (pk) replacement = nip19.npubEncode(pk);
-          } else if (/^@contacts$/i.test(core)) {
-            // Preserve @contacts as-is (expanded at search time to full follow list)
-          } else if (!skipAuthorResolution && !/^npub1[0-9a-z]+$/i.test(core)) {
-            // Check cache first
-            if (authorResolutionCache.current.has(core)) {
-              replacement = authorResolutionCache.current.get(core) || core;
-            } else {
-              try {
-                const npub = await resolveAuthorToNpub(core, ppProvider ?? undefined);
-                if (npub) {
-                  replacement = npub;
-                  authorResolutionCache.current.set(core, npub);
-                }
-              } catch {}
-            }
-          }
-          result += q.slice(lastIndex, m.index);
-          result += `${pre}by:${replacement}${suffix}`;
-          lastIndex = m.index + full.length;
-        }
-        result += q.slice(lastIndex);
-        return result;
-      };
+      const resolvedDistributed = skipAuthorResolution
+        ? distributed
+        : await Promise.all(distributed.map((s) =>
+            resolveByTokensInQuery(s, false, authorResolutionCache.current, ppProvider)
+          ));
 
-      // Helper: normalize p:<token> where token may be hex, npub or nprofile
-      const resolvePTokensInQuery = (q: string): string => {
-        const rx = /(^|\s)p:(\S+)/gi;
-        let result = '';
-        let lastIndex = 0;
-        let m: RegExpExecArray | null;
-        while ((m = rx.exec(q)) !== null) {
-          const full = m[0];
-          const pre = m[1] || '';
-          const raw = m[2] || '';
-          const match = raw.match(/^([^),.;]+)([),.;]*)$/);
-          const core = (match && match[1]) || raw;
-          const suffix = (match && match[2]) || '';
-          let replacement = core;
-          if (/^[0-9a-fA-F]{64}$/.test(core)) {
-            try { replacement = nip19.npubEncode(core.toLowerCase()); } catch {}
-          } else if (/^npub1[0-9a-z]+$/i.test(core)) {
-            replacement = core;
-          } else if (/^nprofile1[0-9a-z]+$/i.test(core)) {
-            try {
-              const decoded = nip19.decode(core);
-              if (decoded?.type === 'nprofile') {
-                const pk = (decoded.data as { pubkey: string }).pubkey;
-                replacement = nip19.npubEncode(pk);
-              }
-            } catch {}
-          }
-          result += q.slice(lastIndex, m.index);
-          result += `${pre}p:${replacement}${suffix}`;
-          lastIndex = m.index + full.length;
-        }
-        result += q.slice(lastIndex);
-        return result;
-      };
+      const withPResolved = resolvedDistributed.map((s) => resolvePTokensInQuery(s));
 
-      // 3) Resolve authors inside each distributed branch (if not skipping)
-      const resolvedDistributed = skipAuthorResolution 
-        ? distributed 
-        : await Promise.all(distributed.map((q) => resolveByTokensInQuery(q)));
-
-      const withPResolved = resolvedDistributed.map((q) => resolvePTokensInQuery(q));
-
-      // 4) For parenthesized OR expansion, show all expanded queries
-      // Don't split further if we already have multiple distributed queries
       if (distributed.length > 1) {
-        // We have parenthesized OR expansion - show all expanded queries
         let preview = withPResolved.join('\n');
         if (ppProvider) preview = `[pp:${ppProvider}] ${preview}`;
         return preview;
       }
 
-      // 5) Split into multiple queries if top-level OR exists (for non-parenthesized OR)
       const finalQueriesSet = new Set<string>();
-      for (const q of withPResolved) {
-        const parts = parseOrQuery(q);
+      for (const s of withPResolved) {
+        const parts = parseOrQuery(s);
         if (parts.length > 1) {
-          parts.forEach((p) => { const s = p.trim(); if (s) finalQueriesSet.add(s); });
+          parts.forEach((p) => { const t = p.trim(); if (t) finalQueriesSet.add(t); });
         } else {
-          const s = q.trim(); if (s) finalQueriesSet.add(s);
+          const t = s.trim(); if (t) finalQueriesSet.add(t);
         }
       }
       const finalQueries = Array.from(finalQueriesSet);
 
-      // Format compact preview
       let preview = finalQueries.length > 0 ? finalQueries.join('\n') : afterReplacements;
       if (ppProvider) preview = `[pp:${ppProvider}] ${preview}`;
       return preview;
@@ -182,66 +70,48 @@ export default function QueryTranslation({ query, onAuthorResolved }: QueryTrans
     }
   }, [authorResolutionCache]);
 
-  // Generate translation when query changes
   useEffect(() => {
     let cancelled = false;
     let debounceId: ReturnType<typeof setTimeout> | null = null;
-    
+
     if (!query.trim()) {
       setTranslation('');
       return;
     }
 
     const generateAndSetTranslation = async () => {
-      // Reset search trigger flag for new query
       hasTriggeredSearchRef.current = false;
-      
-      // Phase 1: Show expanded queries immediately (without author resolution)
-      const immediateResult = await generateTranslation(query, true);
-      if (!cancelled) {
-        setTranslation(immediateResult);
-      }
 
-      // Phase 2: Update with resolved authors (if any by: tokens exist)
+      const immediateResult = await generateTranslation(query, true);
+      if (!cancelled) setTranslation(immediateResult);
+
       if (query.includes('by:')) {
         const resolvedResult = await generateTranslation(query, false);
         if (!cancelled) {
           setTranslation(resolvedResult);
-          
-          // Clear any existing timeout
-          if (resolutionTimeoutRef.current) {
-            clearTimeout(resolutionTimeoutRef.current);
-          }
-          
-          // Set a timeout to trigger search after resolution stabilizes
-          // This allows time for NIP-05 verification and re-ranking to complete
+          if (resolutionTimeoutRef.current) clearTimeout(resolutionTimeoutRef.current);
           resolutionTimeoutRef.current = setTimeout(() => {
             if (lastResolvedQueryRef.current !== query && !hasTriggeredSearchRef.current) {
               lastResolvedQueryRef.current = query;
               hasTriggeredSearchRef.current = true;
               onAuthorResolved?.();
             }
-          }, 2000); // Wait 2 seconds for final resolution
+          }, 2000);
         }
       }
     };
 
-    debounceId = setTimeout(() => {
-      generateAndSetTranslation();
-    }, getAdaptiveDebounceMs()); // Adaptive debounce to reduce typing lag on slower devices
+    debounceId = setTimeout(generateAndSetTranslation, getAdaptiveDebounceMs());
 
-    return () => { 
+    return () => {
       cancelled = true;
-      if (debounceId) {
-        clearTimeout(debounceId);
-        debounceId = null;
-      }
+      if (debounceId) clearTimeout(debounceId);
       if (resolutionTimeoutRef.current) {
         clearTimeout(resolutionTimeoutRef.current);
         resolutionTimeoutRef.current = null;
       }
     };
-  }, [query, generateTranslation, onAuthorResolved, getAdaptiveDebounceMs]);
+  }, [query, generateTranslation, onAuthorResolved]);
 
   const filtersJson = (() => {
     try {
@@ -259,26 +129,17 @@ export default function QueryTranslation({ query, onAuthorResolved }: QueryTrans
   const isLongTranslation = translation.split('\n').length > 4;
 
   return (
-    <div 
-      id="search-explanation" 
+    <div
+      id="search-explanation"
       className={`mt-1 text-[11px] text-gray-400 font-mono break-all whitespace-pre-wrap flex items-start gap-2 ${
         isLongTranslation ? 'cursor-pointer hover:bg-gray-800/20 rounded px-1 py-0.5 -mx-1 -my-0.5' : ''
       }`}
-      onClick={() => {
-        if (isLongTranslation) {
-          setIsExplanationExpanded(!isExplanationExpanded);
-        }
-      }}
+      onClick={() => { if (isLongTranslation) setIsExplanationExpanded(!isExplanationExpanded); }}
     >
       <button
         type="button"
         className="mt-0.5 flex-shrink-0 text-xs text-gray-500 hover:text-gray-200"
-        onClick={(e) => {
-          e.stopPropagation();
-          if (filtersJson) {
-            setShowFilters((prev) => !prev);
-          }
-        }}
+        onClick={(e) => { e.stopPropagation(); if (filtersJson) setShowFilters((prev) => !prev); }}
         aria-label="Show effective filters"
         aria-expanded={showFilters}
       >
@@ -287,7 +148,7 @@ export default function QueryTranslation({ query, onAuthorResolved }: QueryTrans
       <div className="flex-1 min-w-0">
         {isLongTranslation && !isExplanationExpanded ? (
           <>
-            <div className="overflow-hidden" style={{ 
+            <div className="overflow-hidden" style={{
               display: '-webkit-box',
               WebkitLineClamp: 4,
               WebkitBoxOrient: 'vertical'

--- a/src/lib/profile/providers.ts
+++ b/src/lib/profile/providers.ts
@@ -91,12 +91,20 @@ export async function queryProviderProfiles(
 
 // Try all configured providers in order; returns first successful result or null.
 // When forcedProvider is set (via pp: keyword), only that provider is tried.
+// pp:relay skips aggregators entirely, falling through to NIP-50 relay search.
 export async function tryQueryProviders(
   query: string,
   limit: number,
   loggedIn: boolean,
   forcedProvider?: string
 ): Promise<NDKEvent[] | null> {
+  const validProviders: ProfileLookupProvider[] = ['vertex', 'relatr', 'relay'];
+  if (forcedProvider && !validProviders.includes(forcedProvider as ProfileLookupProvider)) {
+    console.warn(`[pp] Invalid profile provider "${forcedProvider}", ignoring`);
+    forcedProvider = undefined;
+  }
+  // pp:relay means "skip all aggregators, use relay-based search only"
+  if (forcedProvider === 'relay') return null;
   const providerOrder = forcedProvider
     ? [forcedProvider as ProfileLookupProvider]
     : getProfileLookupProviderOrder(loggedIn);

--- a/src/lib/profile/providers.ts
+++ b/src/lib/profile/providers.ts
@@ -89,13 +89,17 @@ export async function queryProviderProfiles(
   return { events, provider };
 }
 
-// Try all configured providers in order; returns first successful result or null
+// Try all configured providers in order; returns first successful result or null.
+// When forcedProvider is set (via pp: keyword), only that provider is tried.
 export async function tryQueryProviders(
   query: string,
   limit: number,
-  loggedIn: boolean
+  loggedIn: boolean,
+  forcedProvider?: string
 ): Promise<NDKEvent[] | null> {
-  const providerOrder = getProfileLookupProviderOrder(loggedIn);
+  const providerOrder = forcedProvider
+    ? [forcedProvider as ProfileLookupProvider]
+    : getProfileLookupProviderOrder(loggedIn);
   for (const provider of providerOrder) {
     if (provider === 'relay') break;
     try {

--- a/src/lib/profile/resolver.ts
+++ b/src/lib/profile/resolver.ts
@@ -6,8 +6,9 @@ import { getCachedUsername, setCachedUsername } from './username-cache';
 import { getCachedProfileEvent, setCachedProfileEvent } from './profile-event-cache';
 import { searchProfilesFullText } from './search';
 
-// Unified author resolver: npub | nip05 | username -> pubkey (hex) and an optional profile event
-export async function resolveAuthor(authorInput: string): Promise<{ pubkeyHex: string | null; profileEvent: NDKEvent | null }> {
+// Unified author resolver: npub | nip05 | username -> pubkey (hex) and an optional profile event.
+// Optional forcedProvider (from pp: keyword) is forwarded to searchProfilesFullText.
+export async function resolveAuthor(authorInput: string, forcedProvider?: string): Promise<{ pubkeyHex: string | null; profileEvent: NDKEvent | null }> {
   try {
     const input = (authorInput || '').trim();
     if (!input) return { pubkeyHex: null, profileEvent: null };
@@ -59,7 +60,7 @@ export async function resolveAuthor(authorInput: string): Promise<{ pubkeyHex: s
 
     let profileEvt: NDKEvent | null = null;
     try {
-      const profiles = await searchProfilesFullText(input, 1);
+      const profiles = await searchProfilesFullText(input, 1, forcedProvider);
       profileEvt = profiles[0] || null;
     } catch {}
 
@@ -79,7 +80,7 @@ export async function resolveAuthor(authorInput: string): Promise<{ pubkeyHex: s
 // Resolve a by:<author> token value (username, nip05, or npub) to an npub.
 // Returns the original input if it's already an npub, otherwise attempts Vertex DVM
 // and falls back to a NIP-50 profile search. Hard timebox externally when needed.
-export async function resolveAuthorToNpub(author: string): Promise<string | null> {
+export async function resolveAuthorToNpub(author: string, forcedProvider?: string): Promise<string | null> {
   try {
     const input = (author || '').trim();
     if (!input) return null;
@@ -87,7 +88,7 @@ export async function resolveAuthorToNpub(author: string): Promise<string | null
     if (/^[0-9a-fA-F]{64}$/.test(input)) {
       try { return nip19.npubEncode(input.toLowerCase()); } catch { return null; }
     }
-    const { pubkeyHex } = await resolveAuthor(input);
+    const { pubkeyHex } = await resolveAuthor(input, forcedProvider);
     if (!pubkeyHex) return null;
     try { return nip19.npubEncode(pubkeyHex); } catch { return null; }
   } catch {

--- a/src/lib/profile/search.ts
+++ b/src/lib/profile/search.ts
@@ -28,7 +28,7 @@ export async function searchProfilesFullText(term: string, limit: number = PROFI
 
   const storedPubkey = getStoredPubkey();
   const loggedIn = Boolean(storedPubkey);
-  const cacheKey = makeProfileSearchCacheKey(query, loggedIn);
+  const cacheKey = makeProfileSearchCacheKey(query, loggedIn) + (forcedProvider ? `:${forcedProvider}` : '');
   const cached = getCachedProfileSearch(cacheKey);
   if (cached) return cached.slice(0, limit);
 

--- a/src/lib/profile/search.ts
+++ b/src/lib/profile/search.ts
@@ -22,7 +22,7 @@ import {
 } from './search-cache';
 
 // Full-text profile search with ranking
-export async function searchProfilesFullText(term: string, limit: number = PROFILE_SEARCH_MAX_RESULTS): Promise<NDKEvent[]> {
+export async function searchProfilesFullText(term: string, limit: number = PROFILE_SEARCH_MAX_RESULTS, forcedProvider?: string): Promise<NDKEvent[]> {
   const query = term.trim();
   if (!query) return [];
 
@@ -33,7 +33,7 @@ export async function searchProfilesFullText(term: string, limit: number = PROFI
   if (cached) return cached.slice(0, limit);
 
   // Step 0: try configured providers before relay-based ranking
-  const providerResult = await tryQueryProviders(query, limit, loggedIn);
+  const providerResult = await tryQueryProviders(query, limit, loggedIn, forcedProvider);
   if (providerResult) {
     setCachedProfileSearch(cacheKey, providerResult);
     return providerResult.slice(0, limit);

--- a/src/lib/queryTranslationHelpers.ts
+++ b/src/lib/queryTranslationHelpers.ts
@@ -52,14 +52,15 @@ export async function resolveByTokensInQuery(
     } else if (/^@contacts$/i.test(core)) {
       // Preserve as-is (expanded at search time)
     } else if (!skipAuthorResolution && !/^npub1[0-9a-z]+$/i.test(core)) {
-      if (authorResolutionCache.has(core)) {
-        replacement = authorResolutionCache.get(core) || core;
+      const cacheKey = `${ppProvider ?? 'default'}:${core.toLowerCase()}`;
+      if (authorResolutionCache.has(cacheKey)) {
+        replacement = authorResolutionCache.get(cacheKey) || core;
       } else {
         try {
           const npub = await resolveAuthorToNpub(core, ppProvider ?? undefined);
           if (npub) {
             replacement = npub;
-            authorResolutionCache.set(core, npub);
+            authorResolutionCache.set(cacheKey, npub);
           }
         } catch {}
       }

--- a/src/lib/queryTranslationHelpers.ts
+++ b/src/lib/queryTranslationHelpers.ts
@@ -1,0 +1,108 @@
+import { nip19 } from 'nostr-tools';
+import { getStoredPubkey } from './nip07';
+import { resolveAuthorToNpub } from './vertex';
+
+/** Determine an adaptive debounce based on device/network characteristics */
+export function getAdaptiveDebounceMs(): number {
+  let delay = 700;
+  try {
+    const nav: unknown = typeof navigator !== 'undefined' ? navigator : undefined;
+    const cores = (nav as { hardwareConcurrency?: number })?.hardwareConcurrency;
+    if (typeof cores === 'number') {
+      if (cores <= 2) delay += 300;
+      else if (cores <= 4) delay += 150;
+    }
+    const deviceMemory = (nav as { deviceMemory?: number })?.deviceMemory as number | undefined;
+    if (typeof deviceMemory === 'number' && deviceMemory > 0 && deviceMemory <= 4) {
+      delay += 100;
+    }
+    const anyNav = nav as { connection?: { effectiveType?: string } } | undefined;
+    const effectiveType = anyNav?.connection?.effectiveType || '';
+    if (typeof effectiveType === 'string') {
+      if (effectiveType.includes('2g') || effectiveType === 'slow-2g') delay += 200;
+      else if (effectiveType.includes('3g')) delay += 100;
+    }
+  } catch {}
+  return Math.min(1000, Math.max(700, delay));
+}
+
+/** Resolve all by:<author> tokens within a single query string */
+export async function resolveByTokensInQuery(
+  q: string,
+  skipAuthorResolution: boolean,
+  authorResolutionCache: Map<string, string>,
+  ppProvider: string | null
+): Promise<string> {
+  const rx = /(^|\s)by:(\S+)/gi;
+  let result = '';
+  let lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = rx.exec(q)) !== null) {
+    const full = m[0];
+    const pre = m[1] || '';
+    const raw = m[2] || '';
+    const match = raw.match(/^([^),.;]+)([),.;]*)$/);
+    const core = (match && match[1]) || raw;
+    const suffix = (match && match[2]) || '';
+    let replacement = core;
+
+    if (/^@me$/i.test(core)) {
+      const pk = getStoredPubkey();
+      if (pk) replacement = nip19.npubEncode(pk);
+    } else if (/^@contacts$/i.test(core)) {
+      // Preserve as-is (expanded at search time)
+    } else if (!skipAuthorResolution && !/^npub1[0-9a-z]+$/i.test(core)) {
+      if (authorResolutionCache.has(core)) {
+        replacement = authorResolutionCache.get(core) || core;
+      } else {
+        try {
+          const npub = await resolveAuthorToNpub(core, ppProvider ?? undefined);
+          if (npub) {
+            replacement = npub;
+            authorResolutionCache.set(core, npub);
+          }
+        } catch {}
+      }
+    }
+    result += q.slice(lastIndex, m.index);
+    result += `${pre}by:${replacement}${suffix}`;
+    lastIndex = m.index + full.length;
+  }
+  result += q.slice(lastIndex);
+  return result;
+}
+
+/** Normalize p:<token> where token may be hex, npub or nprofile */
+export function resolvePTokensInQuery(q: string): string {
+  const rx = /(^|\s)p:(\S+)/gi;
+  let result = '';
+  let lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = rx.exec(q)) !== null) {
+    const full = m[0];
+    const pre = m[1] || '';
+    const raw = m[2] || '';
+    const match = raw.match(/^([^),.;]+)([),.;]*)$/);
+    const core = (match && match[1]) || raw;
+    const suffix = (match && match[2]) || '';
+    let replacement = core;
+    if (/^[0-9a-fA-F]{64}$/.test(core)) {
+      try { replacement = nip19.npubEncode(core.toLowerCase()); } catch {}
+    } else if (/^npub1[0-9a-z]+$/i.test(core)) {
+      replacement = core;
+    } else if (/^nprofile1[0-9a-z]+$/i.test(core)) {
+      try {
+        const decoded = nip19.decode(core);
+        if (decoded?.type === 'nprofile') {
+          const pk = (decoded.data as { pubkey: string }).pubkey;
+          replacement = nip19.npubEncode(pk);
+        }
+      } catch {}
+    }
+    result += q.slice(lastIndex, m.index);
+    result += `${pre}p:${replacement}${suffix}`;
+    lastIndex = m.index + full.length;
+  }
+  result += q.slice(lastIndex);
+  return result;
+}

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -104,12 +104,12 @@ export async function searchEvents(
   const preprocessedQuery = await applySimpleReplacements(extCleanedQuery);
 
   const parsedQuery = parseSearchQuery(preprocessedQuery, SEARCH_DEFAULT_KINDS);
-  const { cleanedQuery, effectiveKinds, dateFilter, hasTopLevelOr, topLevelOrParts, extensionFilters } = parsedQuery;
+  const { cleanedQuery, effectiveKinds, dateFilter, hasTopLevelOr, topLevelOrParts, extensionFilters, profileProvider } = parsedQuery;
 
   const searchContext: SearchContext = {
     effectiveKinds, dateFilter, nip50Extensions, broadRelaySet, nip50RelaySet,
     relaySetOverride, isStreaming: isStreaming || false, streamingOptions,
-    abortSignal, limit, extensionFilters
+    abortSignal, limit, extensionFilters, profileProvider
   };
 
   // 1. Try parenthesized OR expansion: "(GM OR GN) by:dergigi"

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -114,7 +114,7 @@ export async function searchEvents(
 
   // 1. Try parenthesized OR expansion: "(GM OR GN) by:dergigi"
   const parenOrResult = await handleParenthesizedOr(
-    cleanedQuery, effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, limit
+    cleanedQuery, effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, limit, profileProvider
   );
   if (parenOrResult) return parenOrResult;
 
@@ -128,7 +128,7 @@ export async function searchEvents(
   if (hasTopLevelOr) {
     const topOrResult = await handleTopLevelOr(
       topLevelOrParts, effectiveKinds, dateFilter, nip50Extensions,
-      nip50RelaySet, broadRelaySet, abortSignal, limit
+      nip50RelaySet, broadRelaySet, abortSignal, limit, profileProvider
     );
     if (topOrResult) return topOrResult;
   }

--- a/src/lib/search/authorResolve.ts
+++ b/src/lib/search/authorResolve.ts
@@ -7,7 +7,7 @@ import { getContactPubkeys } from '../contacts';
  * @contacts expands to the logged-in user's kind:3 follow list.
  * Invalid or unresolvable tokens are silently dropped with a warning.
  */
-export async function resolveAuthorTokens(tokens: string[]): Promise<string[]> {
+export async function resolveAuthorTokens(tokens: string[], forcedProvider?: string): Promise<string[]> {
   const results = await Promise.all(
     tokens.map(async (authorToken) => {
       try {
@@ -17,7 +17,7 @@ export async function resolveAuthorTokens(tokens: string[]): Promise<string[]> {
         if (/^npub1[0-9a-z]+$/i.test(authorToken)) {
           return [nip19.decode(authorToken).data as string];
         }
-        const resolved = await resolveAuthor(authorToken);
+        const resolved = await resolveAuthor(authorToken, forcedProvider);
         return resolved.pubkeyHex ? [resolved.pubkeyHex] : [];
       } catch (error) {
         console.warn(`Failed to resolve author ${authorToken}:`, error);

--- a/src/lib/search/orExpansion.ts
+++ b/src/lib/search/orExpansion.ts
@@ -115,7 +115,7 @@ export async function handleParenthesizedOr(
   const seedResults = await searchByAnyTerms(
     translatedSeeds, Math.max(limit, 500), nip50RelaySet, abortSignal,
     nip50Extensions, applyDateFilter({ kinds: effectiveKinds }, dateFilter),
-    () => Promise.resolve(broadRelaySet)
+    () => Promise.resolve(broadRelaySet), profileProvider
   );
 
   // No global content filter — per-seed filtering happens inside termSearch

--- a/src/lib/search/orExpansion.ts
+++ b/src/lib/search/orExpansion.ts
@@ -6,6 +6,7 @@ import { expandParenthesizedOr } from './queryTransforms';
 import { subscribeAndCollect } from './subscriptions';
 import { searchByAnyTerms } from './termSearch';
 import { resolveAuthorTokens } from './authorResolve';
+import { extractByTokens } from './tokenExtractors';
 import {
   dedupeEvents,
   handleProfileSeeds,
@@ -15,12 +16,7 @@ import {
 
 // Re-export for consumers
 export { dedupeEvents, handleProfileSeeds } from './orHelpers';
-
-/** Extract all by: tokens from a seed string */
-export function extractByTokens(seed: string): string[] {
-  const matches = Array.from(seed.matchAll(/\bby:(\S+)/gi));
-  return matches.map((m) => m[1] || '').filter(Boolean);
-}
+export { extractByTokens } from './tokenExtractors';
 
 /** Extract content of a seed after removing all by: clauses */
 export function extractNonByContent(seed: string): string {

--- a/src/lib/search/orExpansion.ts
+++ b/src/lib/search/orExpansion.ts
@@ -1,22 +1,20 @@
 import { NDKEvent, NDKFilter, NDKRelaySet } from '@nostr-dev-kit/ndk';
 import { sortEventsNewestFirst } from '../utils/searchUtils';
-import { buildSearchQueryWithExtensions, Nip50Extensions } from './searchUtils';
-import { extractKindFilter, applyDateFilter, normalizeResidualSearchText } from './queryParsing';
+import { Nip50Extensions } from './searchUtils';
+import { extractKindFilter, applyDateFilter } from './queryParsing';
 import { expandParenthesizedOr } from './queryTransforms';
 import { subscribeAndCollect } from './subscriptions';
 import { searchByAnyTerms } from './termSearch';
 import { resolveAuthorTokens } from './authorResolve';
-import { applyContentFilter } from './contentFilter';
-import { searchProfilesFullText } from '../vertex';
-/** Deduplicate events by id */
-function dedupeEvents(events: NDKEvent[]): NDKEvent[] {
-  const seen = new Set<string>();
-  return events.filter((e) => {
-    if (seen.has(e.id)) return false;
-    seen.add(e.id);
-    return true;
-  });
-}
+import {
+  dedupeEvents,
+  handleProfileSeeds,
+  handleSameContentMultiAuthor,
+  handleTagAuthorCombination
+} from './orHelpers';
+
+// Re-export for consumers
+export { dedupeEvents, handleProfileSeeds } from './orHelpers';
 
 /** Extract all by: tokens from a seed string */
 export function extractByTokens(seed: string): string[] {
@@ -33,7 +31,8 @@ export function extractNonByContent(seed: string): string {
 export async function maybeOptimizeByOnlyOrSeeds(
   seeds: string[], effectiveKinds: number[], dateFilter: { since?: number; until?: number },
   _nip50Extensions: Nip50Extensions | undefined, broadRelaySet: NDKRelaySet,
-  abortSignal: AbortSignal | undefined, limit: number, profileProvider?: string): Promise<NDKEvent[] | null> {
+  abortSignal: AbortSignal | undefined, limit: number, profileProvider?: string
+): Promise<NDKEvent[] | null> {
   const trimmedSeeds = seeds.map((s) => s.trim()).filter(Boolean);
   if (trimmedSeeds.length < 2) return null;
 
@@ -54,12 +53,11 @@ export async function maybeOptimizeByOnlyOrSeeds(
     dateFilter
   ) as NDKFilter;
 
-  // Pure author query: no search text, use broad relays
   let results: NDKEvent[];
   try {
     results = await subscribeAndCollect(filter, 10000, broadRelaySet, abortSignal);
   } catch {
-    return null; // Let caller fall back to searchByAnyTerms
+    return null;
   }
 
   return sortEventsNewestFirst(dedupeEvents(results)).slice(0, limit);
@@ -70,21 +68,21 @@ export async function handleParenthesizedOr(
   cleanedQuery: string, effectiveKinds: number[], dateFilter: { since?: number; until?: number },
   nip50Extensions: Nip50Extensions | undefined, nip50RelaySet: NDKRelaySet,
   broadRelaySet: NDKRelaySet, abortSignal: AbortSignal | undefined, limit: number,
-  profileProvider?: string): Promise<NDKEvent[] | null> {
+  profileProvider?: string
+): Promise<NDKEvent[] | null> {
   const expandedSeeds = expandParenthesizedOr(cleanedQuery)
     .map((seed) => seed.trim())
     .filter(Boolean);
   if (expandedSeeds.length <= 1) return null;
 
-  // Profile search seeds (p:term OR p:term)
   const isPSeed = (s: string) => /^p:\S+/i.test(s.trim());
   if (expandedSeeds.every(isPSeed)) {
     return handleProfileSeeds(expandedSeeds, limit, profileProvider);
   }
 
-  // Pure by: OR queries (no search text, use broad relays)
   const byOnlyResults = await maybeOptimizeByOnlyOrSeeds(
-    expandedSeeds, effectiveKinds, dateFilter, nip50Extensions, broadRelaySet, abortSignal, limit, profileProvider
+    expandedSeeds, effectiveKinds, dateFilter, nip50Extensions, broadRelaySet,
+    abortSignal, limit, profileProvider
   );
   if (byOnlyResults !== null) return byOnlyResults;
 
@@ -94,18 +92,18 @@ export async function handleParenthesizedOr(
 
   if (allSameNonBy && allHaveBy && expandedSeeds.length > 1) {
     const result = await handleSameContentMultiAuthor(
-      expandedSeeds, firstNonBy, effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, cleanedQuery, limit, profileProvider
+      expandedSeeds, firstNonBy, effectiveKinds, dateFilter, nip50Extensions,
+      nip50RelaySet, broadRelaySet, abortSignal, cleanedQuery, limit, profileProvider
     );
     if (result) return result;
   }
 
-  // Combined hashtag + author patterns
   const tagAuthorResult = await handleTagAuthorCombination(
-    expandedSeeds, effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, cleanedQuery, limit, profileProvider
+    expandedSeeds, effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet,
+    broadRelaySet, abortSignal, cleanedQuery, limit, profileProvider
   );
   if (tagAuthorResult) return tagAuthorResult;
 
-  // Fallback: search each seed via searchByAnyTerms, prepend kind tokens if missing
   const kindPrefix = effectiveKinds.map((k) => `kind:${k}`).join(' ');
   const translatedSeeds = expandedSeeds.map((seed) => {
     if (extractKindFilter(seed).kinds?.length) return seed;
@@ -118,103 +116,5 @@ export async function handleParenthesizedOr(
     () => Promise.resolve(broadRelaySet), profileProvider
   );
 
-  // No global content filter — per-seed filtering happens inside termSearch
   return sortEventsNewestFirst(seedResults).slice(0, limit);
-}
-
-export async function handleProfileSeeds(pSeeds: string[], limit: number, profileProvider?: string): Promise<NDKEvent[]> {
-  const pTerms = pSeeds.map((s) => s.replace(/^p:/i, '').trim()).filter(Boolean);
-  const results = await Promise.allSettled(pTerms.map((t) => searchProfilesFullText(t, undefined, profileProvider)));
-  const seen = new Set<string>();
-  const merged = results.flatMap((r) => r.status === 'fulfilled' ? r.value : [])
-    .filter((evt) => {
-      const pk = evt.pubkey || evt.author?.pubkey || '';
-      return pk && !seen.has(pk) && (seen.add(pk), true);
-    });
-  return sortEventsNewestFirst(merged).slice(0, limit);
-}
-
-/** Subscribe, dedupe, content-filter, sort, and slice. */
-async function collectAndFilter(
-  filter: NDKFilter, relaySet: NDKRelaySet, abortSignal: AbortSignal | undefined, cleanedQuery: string, limit: number
-): Promise<NDKEvent[]> {
-  let raw: NDKEvent[];
-  try {
-    raw = await subscribeAndCollect(filter, 10000, relaySet, abortSignal);
-  } catch {
-    return [];
-  }
-  return sortEventsNewestFirst(applyContentFilter(dedupeEvents(raw), cleanedQuery)).slice(0, limit);
-}
-
-/** Strip kind/hashtag tokens to get residual search text */
-function extractResidual(preprocessed: string, normalize = false): string {
-  const raw = preprocessed.replace(/\bkind:[^\s]+/gi, ' ').replace(/\bkinds:[^\s]+/gi, ' ')
-    .replace(/#[A-Za-z0-9_]+/g, ' ').replace(/\s+/g, ' ').trim();
-  return normalize ? normalizeResidualSearchText(raw) : raw;
-}
-
-async function handleSameContentMultiAuthor(
-  expandedSeeds: string[], baseQuery: string, effectiveKinds: number[],
-  dateFilter: { since?: number; until?: number }, nip50Extensions: Nip50Extensions | undefined,
-  nip50RelaySet: NDKRelaySet, broadRelaySet: NDKRelaySet,
-  abortSignal: AbortSignal | undefined, cleanedQuery: string, limit: number,
-  profileProvider?: string): Promise<NDKEvent[] | null> {
-  const resolvedPubkeys = await resolveAuthorTokens(
-    Array.from(new Set(expandedSeeds.flatMap(extractByTokens))), profileProvider
-  );
-  if (resolvedPubkeys.length === 0) return null;
-
-  const { applySimpleReplacements } = await import('./replacements');
-  const preprocessed = await applySimpleReplacements(baseQuery || '');
-  const tagMatches = Array.from(preprocessed.match(/#[A-Za-z0-9_]+/gi) || []).map((t) => t.slice(1).toLowerCase());
-
-  const filter: NDKFilter = applyDateFilter({
-    kinds: effectiveKinds, authors: resolvedPubkeys, limit: Math.max(limit, 500),
-    ...(tagMatches.length > 0 && { '#t': Array.from(new Set(tagMatches)) })
-  }, dateFilter) as NDKFilter;
-
-  const residual = extractResidual(preprocessed);
-  if (residual) filter.search = nip50Extensions ? buildSearchQueryWithExtensions(residual, nip50Extensions) : residual;
-
-  const relaySet = filter.search ? nip50RelaySet : broadRelaySet;
-  return collectAndFilter(filter, relaySet, abortSignal, cleanedQuery, limit);
-}
-
-async function handleTagAuthorCombination(
-  expandedSeeds: string[], effectiveKinds: number[],
-  dateFilter: { since?: number; until?: number }, nip50Extensions: Nip50Extensions | undefined,
-  nip50RelaySet: NDKRelaySet, broadRelaySet: NDKRelaySet,
-  abortSignal: AbortSignal | undefined, cleanedQuery: string, limit: number,
-  profileProvider?: string): Promise<NDKEvent[] | null> {
-  const extractTags = (s: string): string[] =>
-    Array.from(s.matchAll(/#[A-Za-z0-9_]+/gi)).map((m) => (m[0] || '').slice(1).toLowerCase()).filter(Boolean);
-  const extractCore = (s: string): string =>
-    s.replace(/\bby:\S+/gi, '').replace(/#[A-Za-z0-9_]+/g, '').replace(/\s+/g, ' ').trim();
-
-  const baseCore = extractCore(expandedSeeds[0]);
-  if (!expandedSeeds.every((s) => extractCore(s) === baseCore)) return null;
-  if (!expandedSeeds.every((s) => extractTags(s).length > 0 && extractByTokens(s).length > 0)) return null;
-
-  const allTags = new Set<string>();
-  const allByTokens: string[] = [];
-  for (const seed of expandedSeeds) {
-    extractTags(seed).forEach((t) => allTags.add(t));
-    allByTokens.push(...extractByTokens(seed));
-  }
-
-  const resolvedPubkeys = await resolveAuthorTokens(Array.from(new Set(allByTokens)), profileProvider);
-  if (resolvedPubkeys.length === 0 || allTags.size === 0) return null;
-
-  const { applySimpleReplacements } = await import('./replacements');
-  const preprocessed = await applySimpleReplacements(baseCore || '');
-  const filter: NDKFilter = applyDateFilter({
-    kinds: effectiveKinds, authors: resolvedPubkeys, '#t': Array.from(allTags), limit: Math.max(limit, 500)
-  }, dateFilter) as NDKFilter;
-
-  const residual = extractResidual(preprocessed, true);
-  if (residual) filter.search = nip50Extensions ? buildSearchQueryWithExtensions(residual, nip50Extensions) : residual;
-
-  const relaySet = filter.search ? nip50RelaySet : broadRelaySet;
-  return collectAndFilter(filter, relaySet, abortSignal, cleanedQuery, limit);
 }

--- a/src/lib/search/orExpansion.ts
+++ b/src/lib/search/orExpansion.ts
@@ -33,7 +33,7 @@ export function extractNonByContent(seed: string): string {
 export async function maybeOptimizeByOnlyOrSeeds(
   seeds: string[], effectiveKinds: number[], dateFilter: { since?: number; until?: number },
   _nip50Extensions: Nip50Extensions | undefined, broadRelaySet: NDKRelaySet,
-  abortSignal: AbortSignal | undefined, limit: number): Promise<NDKEvent[] | null> {
+  abortSignal: AbortSignal | undefined, limit: number, profileProvider?: string): Promise<NDKEvent[] | null> {
   const trimmedSeeds = seeds.map((s) => s.trim()).filter(Boolean);
   if (trimmedSeeds.length < 2) return null;
 
@@ -46,7 +46,7 @@ export async function maybeOptimizeByOnlyOrSeeds(
   const uniqueByTokens = Array.from(new Set(allByTokens));
   if (uniqueByTokens.length === 0) return null;
 
-  const resolvedPubkeys = await resolveAuthorTokens(uniqueByTokens);
+  const resolvedPubkeys = await resolveAuthorTokens(uniqueByTokens, profileProvider);
   if (resolvedPubkeys.length === 0) return null;
 
   const filter: NDKFilter = applyDateFilter(
@@ -69,7 +69,8 @@ export async function maybeOptimizeByOnlyOrSeeds(
 export async function handleParenthesizedOr(
   cleanedQuery: string, effectiveKinds: number[], dateFilter: { since?: number; until?: number },
   nip50Extensions: Nip50Extensions | undefined, nip50RelaySet: NDKRelaySet,
-  broadRelaySet: NDKRelaySet, abortSignal: AbortSignal | undefined, limit: number): Promise<NDKEvent[] | null> {
+  broadRelaySet: NDKRelaySet, abortSignal: AbortSignal | undefined, limit: number,
+  profileProvider?: string): Promise<NDKEvent[] | null> {
   const expandedSeeds = expandParenthesizedOr(cleanedQuery)
     .map((seed) => seed.trim())
     .filter(Boolean);
@@ -78,12 +79,12 @@ export async function handleParenthesizedOr(
   // Profile search seeds (p:term OR p:term)
   const isPSeed = (s: string) => /^p:\S+/i.test(s.trim());
   if (expandedSeeds.every(isPSeed)) {
-    return handleProfileSeeds(expandedSeeds, limit);
+    return handleProfileSeeds(expandedSeeds, limit, profileProvider);
   }
 
   // Pure by: OR queries (no search text, use broad relays)
   const byOnlyResults = await maybeOptimizeByOnlyOrSeeds(
-    expandedSeeds, effectiveKinds, dateFilter, nip50Extensions, broadRelaySet, abortSignal, limit
+    expandedSeeds, effectiveKinds, dateFilter, nip50Extensions, broadRelaySet, abortSignal, limit, profileProvider
   );
   if (byOnlyResults !== null) return byOnlyResults;
 
@@ -93,14 +94,14 @@ export async function handleParenthesizedOr(
 
   if (allSameNonBy && allHaveBy && expandedSeeds.length > 1) {
     const result = await handleSameContentMultiAuthor(
-      expandedSeeds, firstNonBy, effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, cleanedQuery, limit
+      expandedSeeds, firstNonBy, effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, cleanedQuery, limit, profileProvider
     );
     if (result) return result;
   }
 
   // Combined hashtag + author patterns
   const tagAuthorResult = await handleTagAuthorCombination(
-    expandedSeeds, effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, cleanedQuery, limit
+    expandedSeeds, effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, cleanedQuery, limit, profileProvider
   );
   if (tagAuthorResult) return tagAuthorResult;
 
@@ -121,9 +122,9 @@ export async function handleParenthesizedOr(
   return sortEventsNewestFirst(seedResults).slice(0, limit);
 }
 
-export async function handleProfileSeeds(pSeeds: string[], limit: number): Promise<NDKEvent[]> {
+export async function handleProfileSeeds(pSeeds: string[], limit: number, profileProvider?: string): Promise<NDKEvent[]> {
   const pTerms = pSeeds.map((s) => s.replace(/^p:/i, '').trim()).filter(Boolean);
-  const results = await Promise.allSettled(pTerms.map((t) => searchProfilesFullText(t)));
+  const results = await Promise.allSettled(pTerms.map((t) => searchProfilesFullText(t, undefined, profileProvider)));
   const seen = new Set<string>();
   const merged = results.flatMap((r) => r.status === 'fulfilled' ? r.value : [])
     .filter((evt) => {
@@ -157,9 +158,10 @@ async function handleSameContentMultiAuthor(
   expandedSeeds: string[], baseQuery: string, effectiveKinds: number[],
   dateFilter: { since?: number; until?: number }, nip50Extensions: Nip50Extensions | undefined,
   nip50RelaySet: NDKRelaySet, broadRelaySet: NDKRelaySet,
-  abortSignal: AbortSignal | undefined, cleanedQuery: string, limit: number): Promise<NDKEvent[] | null> {
+  abortSignal: AbortSignal | undefined, cleanedQuery: string, limit: number,
+  profileProvider?: string): Promise<NDKEvent[] | null> {
   const resolvedPubkeys = await resolveAuthorTokens(
-    Array.from(new Set(expandedSeeds.flatMap(extractByTokens)))
+    Array.from(new Set(expandedSeeds.flatMap(extractByTokens))), profileProvider
   );
   if (resolvedPubkeys.length === 0) return null;
 
@@ -183,7 +185,8 @@ async function handleTagAuthorCombination(
   expandedSeeds: string[], effectiveKinds: number[],
   dateFilter: { since?: number; until?: number }, nip50Extensions: Nip50Extensions | undefined,
   nip50RelaySet: NDKRelaySet, broadRelaySet: NDKRelaySet,
-  abortSignal: AbortSignal | undefined, cleanedQuery: string, limit: number): Promise<NDKEvent[] | null> {
+  abortSignal: AbortSignal | undefined, cleanedQuery: string, limit: number,
+  profileProvider?: string): Promise<NDKEvent[] | null> {
   const extractTags = (s: string): string[] =>
     Array.from(s.matchAll(/#[A-Za-z0-9_]+/gi)).map((m) => (m[0] || '').slice(1).toLowerCase()).filter(Boolean);
   const extractCore = (s: string): string =>
@@ -200,7 +203,7 @@ async function handleTagAuthorCombination(
     allByTokens.push(...extractByTokens(seed));
   }
 
-  const resolvedPubkeys = await resolveAuthorTokens(Array.from(new Set(allByTokens)));
+  const resolvedPubkeys = await resolveAuthorTokens(Array.from(new Set(allByTokens)), profileProvider);
   if (resolvedPubkeys.length === 0 || allTags.size === 0) return null;
 
   const { applySimpleReplacements } = await import('./replacements');

--- a/src/lib/search/orHelpers.ts
+++ b/src/lib/search/orHelpers.ts
@@ -6,7 +6,7 @@ import { subscribeAndCollect } from './subscriptions';
 import { resolveAuthorTokens } from './authorResolve';
 import { applyContentFilter } from './contentFilter';
 import { searchProfilesFullText } from '../vertex';
-import { extractByTokens } from './orExpansion';
+import { extractByTokens } from './tokenExtractors';
 
 /** Deduplicate events by id */
 export function dedupeEvents(events: NDKEvent[]): NDKEvent[] {

--- a/src/lib/search/orHelpers.ts
+++ b/src/lib/search/orHelpers.ts
@@ -85,7 +85,7 @@ export async function handleSameContentMultiAuthor(
     ...(tagMatches.length > 0 && { '#t': Array.from(new Set(tagMatches)) })
   }, dateFilter) as NDKFilter;
 
-  const residual = extractResidual(preprocessed);
+  const residual = extractResidual(preprocessed, true);
   if (residual) {
     filter.search = nip50Extensions
       ? buildSearchQueryWithExtensions(residual, nip50Extensions) : residual;

--- a/src/lib/search/orHelpers.ts
+++ b/src/lib/search/orHelpers.ts
@@ -1,0 +1,137 @@
+import { NDKEvent, NDKFilter, NDKRelaySet } from '@nostr-dev-kit/ndk';
+import { sortEventsNewestFirst } from '../utils/searchUtils';
+import { buildSearchQueryWithExtensions, Nip50Extensions } from './searchUtils';
+import { applyDateFilter, normalizeResidualSearchText } from './queryParsing';
+import { subscribeAndCollect } from './subscriptions';
+import { resolveAuthorTokens } from './authorResolve';
+import { applyContentFilter } from './contentFilter';
+import { searchProfilesFullText } from '../vertex';
+import { extractByTokens } from './orExpansion';
+
+/** Deduplicate events by id */
+export function dedupeEvents(events: NDKEvent[]): NDKEvent[] {
+  const seen = new Set<string>();
+  return events.filter((e) => {
+    if (seen.has(e.id)) return false;
+    seen.add(e.id);
+    return true;
+  });
+}
+
+/** Subscribe, dedupe, content-filter, sort, and slice. */
+export async function collectAndFilter(
+  filter: NDKFilter, relaySet: NDKRelaySet, abortSignal: AbortSignal | undefined,
+  cleanedQuery: string, limit: number
+): Promise<NDKEvent[]> {
+  let raw: NDKEvent[];
+  try {
+    raw = await subscribeAndCollect(filter, 10000, relaySet, abortSignal);
+  } catch {
+    return [];
+  }
+  return sortEventsNewestFirst(applyContentFilter(dedupeEvents(raw), cleanedQuery)).slice(0, limit);
+}
+
+/** Strip kind/hashtag tokens to get residual search text */
+function extractResidual(preprocessed: string, normalize = false): string {
+  const raw = preprocessed.replace(/\bkind:[^\s]+/gi, ' ').replace(/\bkinds:[^\s]+/gi, ' ')
+    .replace(/#[A-Za-z0-9_]+/g, ' ').replace(/\s+/g, ' ').trim();
+  return normalize ? normalizeResidualSearchText(raw) : raw;
+}
+
+/** Handle profile search seeds (p:term OR p:term) */
+export async function handleProfileSeeds(
+  pSeeds: string[], limit: number, profileProvider?: string
+): Promise<NDKEvent[]> {
+  const pTerms = pSeeds.map((s) => s.replace(/^p:/i, '').trim()).filter(Boolean);
+  const results = await Promise.allSettled(
+    pTerms.map((t) => searchProfilesFullText(t, undefined, profileProvider))
+  );
+  const seen = new Set<string>();
+  const merged = results.flatMap((r) => r.status === 'fulfilled' ? r.value : [])
+    .filter((evt) => {
+      const pk = evt.pubkey || evt.author?.pubkey || '';
+      return pk && !seen.has(pk) && (seen.add(pk), true);
+    });
+  return sortEventsNewestFirst(merged).slice(0, limit);
+}
+
+/** Handle same-content multi-author OR expansion */
+export async function handleSameContentMultiAuthor(
+  expandedSeeds: string[], baseQuery: string, effectiveKinds: number[],
+  dateFilter: { since?: number; until?: number }, nip50Extensions: Nip50Extensions | undefined,
+  nip50RelaySet: NDKRelaySet, broadRelaySet: NDKRelaySet,
+  abortSignal: AbortSignal | undefined, cleanedQuery: string, limit: number,
+  profileProvider?: string
+): Promise<NDKEvent[] | null> {
+  const resolvedPubkeys = await resolveAuthorTokens(
+    Array.from(new Set(expandedSeeds.flatMap(extractByTokens))), profileProvider
+  );
+  if (resolvedPubkeys.length === 0) return null;
+
+  const { applySimpleReplacements } = await import('./replacements');
+  const preprocessed = await applySimpleReplacements(baseQuery || '');
+  const tagMatches = Array.from(preprocessed.match(/#[A-Za-z0-9_]+/gi) || [])
+    .map((t) => t.slice(1).toLowerCase());
+
+  const filter: NDKFilter = applyDateFilter({
+    kinds: effectiveKinds, authors: resolvedPubkeys, limit: Math.max(limit, 500),
+    ...(tagMatches.length > 0 && { '#t': Array.from(new Set(tagMatches)) })
+  }, dateFilter) as NDKFilter;
+
+  const residual = extractResidual(preprocessed);
+  if (residual) {
+    filter.search = nip50Extensions
+      ? buildSearchQueryWithExtensions(residual, nip50Extensions) : residual;
+  }
+
+  const relaySet = filter.search ? nip50RelaySet : broadRelaySet;
+  return collectAndFilter(filter, relaySet, abortSignal, cleanedQuery, limit);
+}
+
+/** Handle combined hashtag + author OR patterns */
+export async function handleTagAuthorCombination(
+  expandedSeeds: string[], effectiveKinds: number[],
+  dateFilter: { since?: number; until?: number }, nip50Extensions: Nip50Extensions | undefined,
+  nip50RelaySet: NDKRelaySet, broadRelaySet: NDKRelaySet,
+  abortSignal: AbortSignal | undefined, cleanedQuery: string, limit: number,
+  profileProvider?: string
+): Promise<NDKEvent[] | null> {
+  const extractTags = (s: string): string[] =>
+    Array.from(s.matchAll(/#[A-Za-z0-9_]+/gi))
+      .map((m) => (m[0] || '').slice(1).toLowerCase()).filter(Boolean);
+  const extractCore = (s: string): string =>
+    s.replace(/\bby:\S+/gi, '').replace(/#[A-Za-z0-9_]+/g, '').replace(/\s+/g, ' ').trim();
+
+  const baseCore = extractCore(expandedSeeds[0]);
+  if (!expandedSeeds.every((s) => extractCore(s) === baseCore)) return null;
+  if (!expandedSeeds.every((s) => extractTags(s).length > 0 && extractByTokens(s).length > 0)) return null;
+
+  const allTags = new Set<string>();
+  const allByTokens: string[] = [];
+  for (const seed of expandedSeeds) {
+    extractTags(seed).forEach((t) => allTags.add(t));
+    allByTokens.push(...extractByTokens(seed));
+  }
+
+  const resolvedPubkeys = await resolveAuthorTokens(
+    Array.from(new Set(allByTokens)), profileProvider
+  );
+  if (resolvedPubkeys.length === 0 || allTags.size === 0) return null;
+
+  const { applySimpleReplacements } = await import('./replacements');
+  const preprocessed = await applySimpleReplacements(baseCore || '');
+  const filter: NDKFilter = applyDateFilter({
+    kinds: effectiveKinds, authors: resolvedPubkeys, '#t': Array.from(allTags),
+    limit: Math.max(limit, 500)
+  }, dateFilter) as NDKFilter;
+
+  const residual = extractResidual(preprocessed, true);
+  if (residual) {
+    filter.search = nip50Extensions
+      ? buildSearchQueryWithExtensions(residual, nip50Extensions) : residual;
+  }
+
+  const relaySet = filter.search ? nip50RelaySet : broadRelaySet;
+  return collectAndFilter(filter, relaySet, abortSignal, cleanedQuery, limit);
+}

--- a/src/lib/search/orHelpers.ts
+++ b/src/lib/search/orHelpers.ts
@@ -32,10 +32,16 @@ export async function collectAndFilter(
   return sortEventsNewestFirst(applyContentFilter(dedupeEvents(raw), cleanedQuery)).slice(0, limit);
 }
 
-/** Strip kind/hashtag tokens to get residual search text */
+/** Strip structured modifiers to get residual search text */
 function extractResidual(preprocessed: string, normalize = false): string {
-  const raw = preprocessed.replace(/\bkind:[^\s]+/gi, ' ').replace(/\bkinds:[^\s]+/gi, ' ')
-    .replace(/#[A-Za-z0-9_]+/g, ' ').replace(/\s+/g, ' ').trim();
+  const raw = preprocessed
+    .replace(/\bby:\S+/gi, ' ')
+    .replace(/\b(?:since|until):\d{4}-\d{2}-\d{2}\b/gi, ' ')
+    .replace(/\bkind:[^\s]+/gi, ' ')
+    .replace(/\bkinds:[^\s]+/gi, ' ')
+    .replace(/#[A-Za-z0-9_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
   return normalize ? normalizeResidualSearchText(raw) : raw;
 }
 

--- a/src/lib/search/queryParsing.ts
+++ b/src/lib/search/queryParsing.ts
@@ -1,129 +1,20 @@
 import { NDKFilter } from '@nostr-dev-kit/ndk';
-import { Nip50Extensions } from './searchUtils';
 import { parseOrQuery } from './queryTransforms';
 import { resolveRelativeDates } from './relativeDates';
+import {
+  extractKindFilter,
+  extractDateFilter,
+  extractProfileProvider
+} from './tokenExtractors';
 
-/**
- * Extract NIP-50 extensions from the raw query string
- * Removes extension tokens from the query and returns them separately
- */
-export function extractNip50Extensions(rawQuery: string): { cleaned: string; extensions: Nip50Extensions } {
-  let cleaned = rawQuery;
-  const extensions: Nip50Extensions = {};
-
-  // include:spam - turn off spam filtering
-  const includeSpamRegex = /(?:^|\s)include:spam(?:\s|$)/gi;
-  if (includeSpamRegex.test(cleaned)) {
-    extensions.includeSpam = true;
-    cleaned = cleaned.replace(includeSpamRegex, ' ');
-  }
-
-  // domain:<domain> - include only events from users whose valid nip05 domain matches the domain
-  const domainRegex = /(?:^|\s)domain:([^\s]+)(?:\s|$)/gi;
-  cleaned = cleaned.replace(domainRegex, (_, domain: string) => {
-    const value = (domain || '').trim();
-    if (value) extensions.domain = value;
-    return ' ';
-  });
-
-  // language:<two letter ISO 639-1 language code> - include only events of a specified language
-  const languageRegex = /(?:^|\s)language:([a-z]{2})(?:\s|$)/gi;
-  cleaned = cleaned.replace(languageRegex, (_, lang: string) => {
-    const value = (lang || '').trim().toLowerCase();
-    if (value && value.length === 2) extensions.language = value;
-    return ' ';
-  });
-
-  // sentiment:<negative/neutral/positive> - include only events of a specific sentiment
-  const sentimentRegex = /(?:^|\s)sentiment:(negative|neutral|positive)(?:\s|$)/gi;
-  cleaned = cleaned.replace(sentimentRegex, (_, sentiment: string) => {
-    const value = (sentiment || '').trim().toLowerCase();
-    if (['negative', 'neutral', 'positive'].includes(value)) {
-      extensions.sentiment = value as 'negative' | 'neutral' | 'positive';
-    }
-    return ' ';
-  });
-
-  // nsfw:<true/false> - include or exclude nsfw events (default: true)
-  const nsfwRegex = /(?:^|\s)nsfw:(true|false)(?:\s|$)/gi;
-  cleaned = cleaned.replace(nsfwRegex, (_, nsfw: string) => {
-    const value = (nsfw || '').trim().toLowerCase();
-    if (value === 'true') extensions.nsfw = true;
-    else if (value === 'false') extensions.nsfw = false;
-    return ' ';
-  });
-
-  return { cleaned: cleaned.trim(), extensions };
-}
-
-/**
- * Strip legacy relay filters from query (relay:..., relays:mine)
- */
-export function stripRelayFilters(rawQuery: string): string {
-  return rawQuery
-    .replace(/(?:^|\s)relay:[^\s]+(?:\s|$)/gi, ' ')
-    .replace(/(?:^|\s)relays:mine(?:\s|$)/gi, ' ')
-    .trim();
-}
-
-/**
- * Extract kind filter(s) from query string: supports comma-separated numbers
- */
-export function extractKindFilter(rawQuery: string): { cleaned: string; kinds?: number[] } {
-  let cleaned = rawQuery;
-  const kinds: number[] = [];
-  const kindRegex = /(?:^|\s)kind:([0-9,\s]+)(?=\s|$)/gi;
-  cleaned = cleaned.replace(kindRegex, (_, list: string) => {
-    (list || '')
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean)
-      .forEach((token) => {
-        const num = parseInt(token, 10);
-        if (!Number.isNaN(num)) kinds.push(num);
-      });
-    return ' ';
-  });
-  const uniqueKinds = Array.from(new Set(kinds));
-  return { cleaned: cleaned.trim(), kinds: uniqueKinds.length ? uniqueKinds : undefined };
-}
-
-/**
- * Extract date filter(s) from query string: since:YYYY-MM-DD and until:YYYY-MM-DD
- */
-export function extractDateFilter(rawQuery: string): { cleaned: string; since?: number; until?: number } {
-  let cleaned = rawQuery;
-  let since: number | undefined;
-  let until: number | undefined;
-
-  // Convert YYYY-MM-DD to Unix timestamp (start of day in UTC)
-  const dateToTimestamp = (dateStr: string): number => {
-    const date = new Date(dateStr + 'T00:00:00Z');
-    return Math.floor(date.getTime() / 1000);
-  };
-
-  // Extract since:YYYY-MM-DD
-  const sinceRegex = /(?:^|\s)since:([0-9]{4}-[0-9]{2}-[0-9]{2})(?=\s|$)/gi;
-  cleaned = cleaned.replace(sinceRegex, (_, dateStr: string) => {
-    since = dateToTimestamp(dateStr);
-    return ' ';
-  });
-
-  // Extract until:YYYY-MM-DD
-  const untilRegex = /(?:^|\s)until:([0-9]{4}-[0-9]{2}-[0-9]{2})(?=\s|$)/gi;
-  cleaned = cleaned.replace(untilRegex, (_, dateStr: string) => {
-    // For until, include entire day - add end of day timestamp
-    const startOfDay = dateToTimestamp(dateStr);
-    until = startOfDay + 86399; // Add 23:59:59 seconds
-    return ' ';
-  });
-
-  return {
-    cleaned: cleaned.trim(),
-    since,
-    until
-  };
-}
+// Re-export extractors so existing imports keep working
+export {
+  extractNip50Extensions,
+  stripRelayFilters,
+  extractKindFilter,
+  extractDateFilter,
+  extractProfileProvider
+} from './tokenExtractors';
 
 /**
  * Helper function to apply date filters to a filter object
@@ -141,8 +32,6 @@ export function normalizeResidualSearchText(input: string): string {
   const trimmed = (input || '').trim();
   if (!trimmed) return '';
 
-  // Remove only structural characters for inspection, but keep the original
-  // string for cases where there is meaningful content.
   const tokens = trimmed
     .replace(/[()"']/g, ' ')
     .split(/\s+/)
@@ -152,23 +41,7 @@ export function normalizeResidualSearchText(input: string): string {
   return hasMeaningfulToken ? trimmed : '';
 }
 
-/**
- * Extract pp:<provider> keyword from query string.
- * Forces a specific profile lookup provider for by:/mentions: resolution.
- * Valid values: vertex, relatr, relay
- */
-export function extractProfileProvider(rawQuery: string): { cleaned: string; profileProvider?: string } {
-  const regex = /(?:^|\s)pp:(vertex|relatr|relay)(?:\s|$)/gi;
-  const match = regex.exec(rawQuery);
-  if (!match) return { cleaned: rawQuery };
-  const provider = (match[1] || '').toLowerCase();
-  const cleaned = rawQuery.replace(regex, ' ').trim();
-  return { cleaned, profileProvider: provider };
-}
-
-/**
- * Parsed query structure containing all extracted information
- */
+/** Parsed query structure containing all extracted information */
 export interface ParsedQuery {
   cleanedQuery: string;
   effectiveKinds: number[];
@@ -181,45 +54,34 @@ export interface ParsedQuery {
 }
 
 /**
- * Parse a preprocessed search query into a structured ParsedQuery object
- * This consolidates all query parsing logic into a single helper
+ * Parse a preprocessed search query into a structured ParsedQuery object.
+ * Consolidates all query parsing logic into a single helper.
  */
 export function parseSearchQuery(
   preprocessedQuery: string,
   defaultKinds: number[]
 ): ParsedQuery {
-  // Extract pp:<provider> keyword before other parsing
   const ppExtraction = extractProfileProvider(preprocessedQuery);
   const profileProvider = ppExtraction.profileProvider;
 
-  // Extract kind filters and default to provided defaultKinds when not provided
   const kindExtraction = extractKindFilter(ppExtraction.cleaned);
   const kindCleanedQuery = kindExtraction.cleaned;
   const effectiveKinds: number[] = (kindExtraction.kinds && kindExtraction.kinds.length > 0)
     ? kindExtraction.kinds
     : defaultKinds;
-  
-  // Resolve relative dates (e.g., since:2w → since:2026-03-06) before parsing
+
   const { resolved: dateResolvedQuery, translation: dateTranslation } = resolveRelativeDates(kindCleanedQuery);
 
-  // Extract date filters
   const dateExtraction = extractDateFilter(dateResolvedQuery);
   const dateFilter = { since: dateExtraction.since, until: dateExtraction.until };
   const cleanedQuery = dateExtraction.cleaned;
-  
+
   const extensionFilters: Array<(content: string) => boolean> = [];
   const topLevelOrParts = parseOrQuery(cleanedQuery);
   const hasTopLevelOr = topLevelOrParts.length > 1;
 
   return {
-    cleanedQuery,
-    effectiveKinds,
-    dateFilter,
-    dateTranslation,
-    hasTopLevelOr,
-    topLevelOrParts,
-    extensionFilters,
-    profileProvider
+    cleanedQuery, effectiveKinds, dateFilter, dateTranslation,
+    hasTopLevelOr, topLevelOrParts, extensionFilters, profileProvider
   };
 }
-

--- a/src/lib/search/queryParsing.ts
+++ b/src/lib/search/queryParsing.ts
@@ -153,6 +153,20 @@ export function normalizeResidualSearchText(input: string): string {
 }
 
 /**
+ * Extract pp:<provider> keyword from query string.
+ * Forces a specific profile lookup provider for by:/mentions: resolution.
+ * Valid values: vertex, relatr, relay
+ */
+export function extractProfileProvider(rawQuery: string): { cleaned: string; profileProvider?: string } {
+  const regex = /(?:^|\s)pp:(vertex|relatr|relay)(?:\s|$)/gi;
+  const match = regex.exec(rawQuery);
+  if (!match) return { cleaned: rawQuery };
+  const provider = (match[1] || '').toLowerCase();
+  const cleaned = rawQuery.replace(regex, ' ').trim();
+  return { cleaned, profileProvider: provider };
+}
+
+/**
  * Parsed query structure containing all extracted information
  */
 export interface ParsedQuery {
@@ -163,6 +177,7 @@ export interface ParsedQuery {
   hasTopLevelOr: boolean;
   topLevelOrParts: string[];
   extensionFilters: Array<(content: string) => boolean>;
+  profileProvider?: string;
 }
 
 /**
@@ -173,8 +188,12 @@ export function parseSearchQuery(
   preprocessedQuery: string,
   defaultKinds: number[]
 ): ParsedQuery {
+  // Extract pp:<provider> keyword before other parsing
+  const ppExtraction = extractProfileProvider(preprocessedQuery);
+  const profileProvider = ppExtraction.profileProvider;
+
   // Extract kind filters and default to provided defaultKinds when not provided
-  const kindExtraction = extractKindFilter(preprocessedQuery);
+  const kindExtraction = extractKindFilter(ppExtraction.cleaned);
   const kindCleanedQuery = kindExtraction.cleaned;
   const effectiveKinds: number[] = (kindExtraction.kinds && kindExtraction.kinds.length > 0)
     ? kindExtraction.kinds
@@ -199,7 +218,8 @@ export function parseSearchQuery(
     dateTranslation,
     hasTopLevelOr,
     topLevelOrParts,
-    extensionFilters
+    extensionFilters,
+    profileProvider
   };
 }
 

--- a/src/lib/search/strategies/authorSearchStrategy.ts
+++ b/src/lib/search/strategies/authorSearchStrategy.ts
@@ -131,7 +131,8 @@ export async function tryHandleAuthorSearch(
       try {
         const seeded = await searchByAnyTerms(
           seedTerms, limit, authorRelaySet, abortSignal, nip50Extensions,
-          applyDateFilter({ authors: pubkeys, kinds: effectiveKinds }, dateFilter)
+          applyDateFilter({ authors: pubkeys, kinds: effectiveKinds }, dateFilter),
+          () => Promise.resolve(authorRelaySet), profileProvider
         );
         res = [...res, ...seeded];
       } catch (err) {

--- a/src/lib/search/strategies/authorSearchStrategy.ts
+++ b/src/lib/search/strategies/authorSearchStrategy.ts
@@ -21,7 +21,7 @@ export async function tryHandleAuthorSearch(
   cleanedQuery: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, limit } = context;
+  const { effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, limit, profileProvider } = context;
 
   // Extract ALL by: tokens with a global regex
   const byMatches = Array.from(cleanedQuery.matchAll(/\bby:(\S+)/gi));
@@ -34,7 +34,7 @@ export async function tryHandleAuthorSearch(
   const terms = cleanedQuery.replace(/\bby:\S+/gi, '').replace(/\s+/g, ' ').trim();
 
   // Resolve deduplicated author tokens to hex pubkeys in parallel
-  const pubkeys = await resolveAuthorTokens(authorTokens);
+  const pubkeys = await resolveAuthorTokens(authorTokens, profileProvider);
 
   if (pubkeys.length === 0) {
     return [];

--- a/src/lib/search/strategies/dTagSearchStrategy.ts
+++ b/src/lib/search/strategies/dTagSearchStrategy.ts
@@ -15,7 +15,7 @@ export async function tryHandleDTagSearch(
   cleanedQuery: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, limit } = context;
+  const { effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, limit, profileProvider } = context;
 
   const matches = Array.from(cleanedQuery.matchAll(/\bd:(\S+)/gi));
   if (matches.length === 0) return null;
@@ -24,7 +24,7 @@ export async function tryHandleDTagSearch(
   if (identifiers.length === 0) return [];
 
   const residual = cleanedQuery.replace(/\bd:\S+/gi, '').replace(/\s+/g, ' ').trim();
-  const { authors, search } = await parseResidual(residual, nip50Extensions);
+  const { authors, search } = await parseResidual(residual, nip50Extensions, profileProvider);
 
   const filter: TagDFilter = applyDateFilter({
     kinds: effectiveKinds, '#d': identifiers, limit: Math.max(limit, 500),

--- a/src/lib/search/strategies/linkSearchStrategy.ts
+++ b/src/lib/search/strategies/linkSearchStrategy.ts
@@ -15,7 +15,7 @@ export async function tryHandleLinkSearch(
   cleanedQuery: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, limit } = context;
+  const { effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, limit, profileProvider } = context;
 
   const matches = Array.from(cleanedQuery.matchAll(/\blink:(\S+)/gi));
   if (matches.length === 0) return null;
@@ -24,7 +24,7 @@ export async function tryHandleLinkSearch(
   if (urls.length === 0) return [];
 
   const residual = cleanedQuery.replace(/\blink:\S+/gi, '').replace(/\s+/g, ' ').trim();
-  const { authors, search } = await parseResidual(residual, nip50Extensions);
+  const { authors, search } = await parseResidual(residual, nip50Extensions, profileProvider);
 
   const filter: TagRFilter = applyDateFilter({
     kinds: effectiveKinds, '#r': urls, limit: Math.max(limit, 500),

--- a/src/lib/search/strategies/mentionsSearchStrategy.ts
+++ b/src/lib/search/strategies/mentionsSearchStrategy.ts
@@ -19,7 +19,7 @@ export async function tryHandleMentionsSearch(
   cleanedQuery: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, limit } = context;
+  const { effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, limit, profileProvider } = context;
 
   const mentionsMatches = Array.from(cleanedQuery.matchAll(/\bmentions:(\S+)/gi));
   if (mentionsMatches.length === 0) {
@@ -29,7 +29,7 @@ export async function tryHandleMentionsSearch(
   const mentionTokens = Array.from(new Set(mentionsMatches.map(m => m[1]).filter(Boolean)));
   const terms = cleanedQuery.replace(/\bmentions:\S+/gi, '').replace(/\s+/g, ' ').trim();
 
-  const pubkeys = await resolveAuthorTokens(mentionTokens);
+  const pubkeys = await resolveAuthorTokens(mentionTokens, profileProvider);
 
   if (pubkeys.length === 0) {
     return [];
@@ -53,7 +53,7 @@ export async function tryHandleMentionsSearch(
   const byMatches = Array.from(terms.matchAll(/\bby:(\S+)/gi));
   if (byMatches.length > 0) {
     const authorTokens = Array.from(new Set(byMatches.map(m => m[1]).filter(Boolean)));
-    const authorPubkeys = await resolveAuthorTokens(authorTokens);
+    const authorPubkeys = await resolveAuthorTokens(authorTokens, profileProvider);
     if (authorPubkeys.length > 0) {
       (filters as NDKFilter).authors = authorPubkeys;
     }

--- a/src/lib/search/strategies/profileSearchStrategy.ts
+++ b/src/lib/search/strategies/profileSearchStrategy.ts
@@ -13,8 +13,7 @@ export async function tryHandleProfileSearch(
   query: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  // Context parameter kept for strategy interface consistency
-  void context;
+  const { profileProvider } = context;
   const fullProfileMatch = query.match(/^p:(.+)$/i);
   if (fullProfileMatch) {
     const term = (fullProfileMatch[1] || '').trim();
@@ -56,7 +55,7 @@ export async function tryHandleProfileSearch(
     const domainLike = /^[^\s@]+\.[^\s@]+$/.test(term);
     if (domainLike) {
       try {
-        const profiles = await searchProfilesFullText(term);
+        const profiles = await searchProfilesFullText(term, undefined, profileProvider);
         if (profiles.length === 0) return [];
 
         const domainLower = term.toLowerCase();
@@ -75,7 +74,7 @@ export async function tryHandleProfileSearch(
 
     // Otherwise, do a general full-text profile search
     try {
-      const profiles = await searchProfilesFullText(term);
+      const profiles = await searchProfilesFullText(term, undefined, profileProvider);
       return profiles;
     } catch (error) {
       console.warn('Full-text profile search failed:', error);

--- a/src/lib/search/strategies/refSearchStrategy.ts
+++ b/src/lib/search/strategies/refSearchStrategy.ts
@@ -29,7 +29,7 @@ export async function tryHandleRefSearch(
   cleanedQuery: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, limit } = context;
+  const { effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, limit, profileProvider } = context;
 
   const matches = Array.from(cleanedQuery.matchAll(/\bref:(\S+)/gi));
   if (matches.length === 0) return null;
@@ -39,7 +39,7 @@ export async function tryHandleRefSearch(
   if (coords.length === 0) return [];
 
   const residual = cleanedQuery.replace(/\bref:\S+/gi, '').replace(/\s+/g, ' ').trim();
-  const { authors, search } = await parseResidual(residual, nip50Extensions);
+  const { authors, search } = await parseResidual(residual, nip50Extensions, profileProvider);
 
   const filter: TagAFilter = applyDateFilter({
     kinds: effectiveKinds, '#a': coords, limit: Math.max(limit, 500),

--- a/src/lib/search/strategies/replySearchStrategy.ts
+++ b/src/lib/search/strategies/replySearchStrategy.ts
@@ -27,7 +27,7 @@ export async function tryHandleReplySearch(
   cleanedQuery: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, limit } = context;
+  const { effectiveKinds, dateFilter, nip50Extensions, nip50RelaySet, broadRelaySet, abortSignal, limit, profileProvider } = context;
 
   const matches = Array.from(cleanedQuery.matchAll(/\breply:(\S+)/gi));
   if (matches.length === 0) return null;
@@ -37,7 +37,7 @@ export async function tryHandleReplySearch(
   if (eventIds.length === 0) return [];
 
   const residual = cleanedQuery.replace(/\breply:\S+/gi, '').replace(/\s+/g, ' ').trim();
-  const { authors, search } = await parseResidual(residual, nip50Extensions);
+  const { authors, search } = await parseResidual(residual, nip50Extensions, profileProvider);
 
   const filter: TagEFilter = applyDateFilter({
     kinds: effectiveKinds, '#e': eventIds, limit: Math.max(limit, 500),

--- a/src/lib/search/strategies/strategyUtils.ts
+++ b/src/lib/search/strategies/strategyUtils.ts
@@ -38,14 +38,15 @@ export async function fetchDedupeAndSort(
  */
 export async function parseResidual(
   residual: string,
-  nip50Extensions: Nip50Extensions | undefined
+  nip50Extensions: Nip50Extensions | undefined,
+  profileProvider?: string
 ): Promise<{ authors?: string[]; search?: string }> {
   const byMatches = Array.from(residual.matchAll(/\bby:(\S+)/gi));
   let authors: string[] | undefined;
 
   if (byMatches.length > 0) {
     const tokens = Array.from(new Set(byMatches.map((m) => m[1]).filter(Boolean)));
-    const resolved = await resolveAuthorTokens(tokens);
+    const resolved = await resolveAuthorTokens(tokens, profileProvider);
     if (resolved.length > 0) authors = resolved;
   }
 

--- a/src/lib/search/termSearch.ts
+++ b/src/lib/search/termSearch.ts
@@ -21,7 +21,8 @@ export async function searchByAnyTerms(
   abortSignal?: AbortSignal,
   nip50Extensions?: Nip50Extensions,
   baseFilter?: Partial<NDKFilter>,
-  fallbackRelaySetFactory?: () => Promise<NDKRelaySet>
+  fallbackRelaySetFactory?: () => Promise<NDKRelaySet>,
+  profileProvider?: string
 ): Promise<NDKEvent[]> {
   const seen = new Set<string>();
   const merged: NDKEvent[] = [];
@@ -73,7 +74,7 @@ export async function searchByAnyTerms(
       }
 
       if (byMatches.length > 0) {
-        const resolvedPubkeys = await resolveAuthorTokens(byMatches);
+        const resolvedPubkeys = await resolveAuthorTokens(byMatches, profileProvider);
 
         if (resolvedPubkeys.length === 0) {
           console.warn(`No authors could be resolved for term: ${normalizedTerm}`);

--- a/src/lib/search/tokenExtractors.ts
+++ b/src/lib/search/tokenExtractors.ts
@@ -60,7 +60,7 @@ export function stripRelayFilters(rawQuery: string): string {
 export function extractKindFilter(rawQuery: string): { cleaned: string; kinds?: number[] } {
   let cleaned = rawQuery;
   const kinds: number[] = [];
-  const kindRegex = /(?:^|\s)kind:([0-9,\s]+)(?=\s|$)/gi;
+  const kindRegex = /(?:^|\s)kind:([0-9]+(?:\s*,\s*[0-9]+)*)(?=\s|$)/gi;
   cleaned = cleaned.replace(kindRegex, (_, list: string) => {
     (list || '')
       .split(',')

--- a/src/lib/search/tokenExtractors.ts
+++ b/src/lib/search/tokenExtractors.ts
@@ -114,11 +114,17 @@ export function extractByTokens(seed: string): string[] {
   return matches.map((m) => m[1] || '').filter(Boolean);
 }
 
-export function extractProfileProvider(rawQuery: string): { cleaned: string; profileProvider?: string } {
+export type ProfileProviderKeyword = 'vertex' | 'relatr' | 'relay';
+
+const VALID_PROFILE_PROVIDERS: readonly ProfileProviderKeyword[] = ['vertex', 'relatr', 'relay'] as const;
+
+export function extractProfileProvider(rawQuery: string): { cleaned: string; profileProvider?: ProfileProviderKeyword } {
   const regex = /(?:^|\s)pp:(vertex|relatr|relay)(?:\s|$)/gi;
   const match = regex.exec(rawQuery);
   if (!match) return { cleaned: rawQuery };
-  const provider = (match[1] || '').toLowerCase();
+  const raw = (match[1] || '').toLowerCase();
+  const provider = VALID_PROFILE_PROVIDERS.find((p) => p === raw);
+  if (!provider) return { cleaned: rawQuery };
   const cleaned = rawQuery.replace(regex, ' ').trim();
   return { cleaned, profileProvider: provider };
 }

--- a/src/lib/search/tokenExtractors.ts
+++ b/src/lib/search/tokenExtractors.ts
@@ -1,0 +1,118 @@
+import { Nip50Extensions } from './searchUtils';
+
+/**
+ * Extract NIP-50 extensions from the raw query string.
+ * Removes extension tokens from the query and returns them separately.
+ */
+export function extractNip50Extensions(rawQuery: string): { cleaned: string; extensions: Nip50Extensions } {
+  let cleaned = rawQuery;
+  const extensions: Nip50Extensions = {};
+
+  const includeSpamRegex = /(?:^|\s)include:spam(?:\s|$)/gi;
+  if (includeSpamRegex.test(cleaned)) {
+    extensions.includeSpam = true;
+    cleaned = cleaned.replace(includeSpamRegex, ' ');
+  }
+
+  const domainRegex = /(?:^|\s)domain:([^\s]+)(?:\s|$)/gi;
+  cleaned = cleaned.replace(domainRegex, (_, domain: string) => {
+    const value = (domain || '').trim();
+    if (value) extensions.domain = value;
+    return ' ';
+  });
+
+  const languageRegex = /(?:^|\s)language:([a-z]{2})(?:\s|$)/gi;
+  cleaned = cleaned.replace(languageRegex, (_, lang: string) => {
+    const value = (lang || '').trim().toLowerCase();
+    if (value && value.length === 2) extensions.language = value;
+    return ' ';
+  });
+
+  const sentimentRegex = /(?:^|\s)sentiment:(negative|neutral|positive)(?:\s|$)/gi;
+  cleaned = cleaned.replace(sentimentRegex, (_, sentiment: string) => {
+    const value = (sentiment || '').trim().toLowerCase();
+    if (['negative', 'neutral', 'positive'].includes(value)) {
+      extensions.sentiment = value as 'negative' | 'neutral' | 'positive';
+    }
+    return ' ';
+  });
+
+  const nsfwRegex = /(?:^|\s)nsfw:(true|false)(?:\s|$)/gi;
+  cleaned = cleaned.replace(nsfwRegex, (_, nsfw: string) => {
+    const value = (nsfw || '').trim().toLowerCase();
+    if (value === 'true') extensions.nsfw = true;
+    else if (value === 'false') extensions.nsfw = false;
+    return ' ';
+  });
+
+  return { cleaned: cleaned.trim(), extensions };
+}
+
+/** Strip legacy relay filters from query (relay:..., relays:mine) */
+export function stripRelayFilters(rawQuery: string): string {
+  return rawQuery
+    .replace(/(?:^|\s)relay:[^\s]+(?:\s|$)/gi, ' ')
+    .replace(/(?:^|\s)relays:mine(?:\s|$)/gi, ' ')
+    .trim();
+}
+
+/** Extract kind filter(s) from query string: supports comma-separated numbers */
+export function extractKindFilter(rawQuery: string): { cleaned: string; kinds?: number[] } {
+  let cleaned = rawQuery;
+  const kinds: number[] = [];
+  const kindRegex = /(?:^|\s)kind:([0-9,\s]+)(?=\s|$)/gi;
+  cleaned = cleaned.replace(kindRegex, (_, list: string) => {
+    (list || '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .forEach((token) => {
+        const num = parseInt(token, 10);
+        if (!Number.isNaN(num)) kinds.push(num);
+      });
+    return ' ';
+  });
+  const uniqueKinds = Array.from(new Set(kinds));
+  return { cleaned: cleaned.trim(), kinds: uniqueKinds.length ? uniqueKinds : undefined };
+}
+
+/** Extract date filter(s) from query string: since:YYYY-MM-DD and until:YYYY-MM-DD */
+export function extractDateFilter(rawQuery: string): { cleaned: string; since?: number; until?: number } {
+  let cleaned = rawQuery;
+  let since: number | undefined;
+  let until: number | undefined;
+
+  const dateToTimestamp = (dateStr: string): number => {
+    const date = new Date(dateStr + 'T00:00:00Z');
+    return Math.floor(date.getTime() / 1000);
+  };
+
+  const sinceRegex = /(?:^|\s)since:([0-9]{4}-[0-9]{2}-[0-9]{2})(?=\s|$)/gi;
+  cleaned = cleaned.replace(sinceRegex, (_, dateStr: string) => {
+    since = dateToTimestamp(dateStr);
+    return ' ';
+  });
+
+  const untilRegex = /(?:^|\s)until:([0-9]{4}-[0-9]{2}-[0-9]{2})(?=\s|$)/gi;
+  cleaned = cleaned.replace(untilRegex, (_, dateStr: string) => {
+    const startOfDay = dateToTimestamp(dateStr);
+    until = startOfDay + 86399;
+    return ' ';
+  });
+
+  return { cleaned: cleaned.trim(), since, until };
+}
+
+/**
+ * Extract pp:<provider> keyword from query string.
+ * Forces a specific profile lookup provider for by:/mentions: resolution.
+ * Valid values: vertex, relatr, relay
+ */
+export function extractProfileProvider(rawQuery: string): { cleaned: string; profileProvider?: string } {
+  const regex = /(?:^|\s)pp:(vertex|relatr|relay)(?:\s|$)/gi;
+  const match = regex.exec(rawQuery);
+  if (!match) return { cleaned: rawQuery };
+  const provider = (match[1] || '').toLowerCase();
+  const cleaned = rawQuery.replace(regex, ' ').trim();
+  return { cleaned, profileProvider: provider };
+}

--- a/src/lib/search/tokenExtractors.ts
+++ b/src/lib/search/tokenExtractors.ts
@@ -108,6 +108,12 @@ export function extractDateFilter(rawQuery: string): { cleaned: string; since?: 
  * Forces a specific profile lookup provider for by:/mentions: resolution.
  * Valid values: vertex, relatr, relay
  */
+/** Extract all by: tokens from a string */
+export function extractByTokens(seed: string): string[] {
+  const matches = Array.from(seed.matchAll(/\bby:(\S+)/gi));
+  return matches.map((m) => m[1] || '').filter(Boolean);
+}
+
 export function extractProfileProvider(rawQuery: string): { cleaned: string; profileProvider?: string } {
   const regex = /(?:^|\s)pp:(vertex|relatr|relay)(?:\s|$)/gi;
   const match = regex.exec(rawQuery);

--- a/src/lib/search/topLevelOr.ts
+++ b/src/lib/search/topLevelOr.ts
@@ -18,7 +18,8 @@ export async function handleTopLevelOr(
   nip50RelaySet: NDKRelaySet,
   broadRelaySet: NDKRelaySet,
   abortSignal: AbortSignal | undefined,
-  limit: number
+  limit: number,
+  profileProvider?: string
 ): Promise<NDKEvent[] | null> {
   const normalizedParts = topLevelOrParts
     .map((part) => part.trim())
@@ -35,21 +36,21 @@ export async function handleTopLevelOr(
 
   // Try optimizing pure by: OR queries (no search text, use broad relays)
   const byOnlyResults = await maybeOptimizeByOnlyOrSeeds(
-    normalizedParts, effectiveKinds, dateFilter, nip50Extensions, broadRelaySet, abortSignal, limit
+    normalizedParts, effectiveKinds, dateFilter, nip50Extensions, broadRelaySet, abortSignal, limit, profileProvider
   );
   if (byOnlyResults !== null) return byOnlyResults;
 
   // Profile search: all parts are p:<term>
   const isPClause = (s: string) => /^p:\S+/i.test(s);
   if (normalizedParts.length > 0 && normalizedParts.every(isPClause)) {
-    return handleProfileSeeds(normalizedParts, limit);
+    return handleProfileSeeds(normalizedParts, limit, profileProvider);
   }
 
   // General OR search via searchByAnyTerms
   const orResults = await searchByAnyTerms(
     normalizedParts, Math.max(limit, 500), nip50RelaySet, abortSignal,
     nip50Extensions, applyDateFilter({ kinds: effectiveKinds }, dateFilter),
-    () => Promise.resolve(broadRelaySet)
+    () => Promise.resolve(broadRelaySet), profileProvider
   );
 
   const filtered = orResults.filter((evt) => effectiveKinds.length === 0 || effectiveKinds.includes(evt.kind));

--- a/src/lib/search/types.ts
+++ b/src/lib/search/types.ts
@@ -25,6 +25,8 @@ export interface SearchContext {
   abortSignal?: AbortSignal;
   limit: number;
   extensionFilters?: Array<(content: string) => boolean>;
+  /** Force a specific profile lookup provider for by:/mentions: resolution (pp: keyword) */
+  profileProvider?: string;
 }
 
 // Extend filter type to include tag queries for "t" (hashtags) and "a" (replaceable events)


### PR DESCRIPTION
Adds the `pp:<provider>` query keyword that forces a specific profile lookup provider for `by:` and `mentions:` resolution, addressing the issue where `by:dergigi` resolves to the wrong npub via relatr when logged out. Users can now write `by:dergigi pp:vertex` to bypass relatr entirely, or `by:someone pp:relatr` to force it. Valid values are `vertex`, `relatr`, and `relay`.

- Extracts `pp:` in query parsing and threads `profileProvider` through `SearchContext`, all search strategies, OR handlers, and the full resolution chain down to `tryQueryProviders`
- When `pp:` is set, only the specified provider is tried (no fallback cascade)
- QueryTranslation UI shows `[pp:vertex]` prefix when the keyword is active

Closes #244


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add pp:<provider> to force which profile source is used in searches; previews are prefixed with [pp:<provider>] when present.
  * Profile-provider option threaded through all search flows so by:/mentions/p: resolution honors the forced provider.
* **Improvements**
  * More consistent author/profile resolution and caching across query types.
  * Improved parsing for kinds, dates, NIP‑50 extensions, relay filters, and by/p token extraction for more accurate search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->