### PR TITLE
chore: bump version to 0.4.0 and document revert in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-17
+
+### Changed
+- **Reverted codebase to the `v0.2.11` state** (#248). The `v0.3.0`..`v0.3.5` line introduced several regressions that broke core search behaviour — `by:` author resolution (#244), `stripNonVisible()` killing gif/URL/filename/`nip:05` matching (#190, #228), relay-set mutation (#227), and misc. rendering issues (#217, #243). Rather than continue fixing on top of a shaky base, the tree was reset to the last known-good release (`v0.2.11`) so development can resume from a stable foundation.
+- Version bumped to `0.4.0` to make the reboot explicit; the `v0.3.x` tags remain on GitHub for historical reference but are not part of the `master` lineage.
+
+### Removed
+- All post-`v0.2.11` code through `v0.3.5` (see the diff on #248). Notable deletions: `stripNonVisible` content filter, `relatr` profile provider, spell translate/discovery, NIP-45 count support, reply/d-tag/id/link/ref search strategies, article cards, relay discovery/info modules, and the OR-expansion pipeline. These may be re-introduced later on a case-by-case basis.
+
 ## [0.2.11] - 2026-03-16
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ants.dergigi.com",
-  "version": "0.2.8",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ants.dergigi.com",
-      "version": "0.2.8",
+      "version": "0.4.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
         "@fortawesome/free-brands-svg-icons": "^6.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ants.dergigi.com",
-  "version": "0.2.11",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 7473",


### PR DESCRIPTION
## Summary

- Bump `package.json` (and matching entries in `package-lock.json`) from `0.2.11` → `0.4.0`.
- Add a `[0.4.0]` entry to `CHANGELOG.md` documenting the wholesale revert of the `v0.3.x` line (landed in #248).

Choosing `v0.4.0` rather than `v0.2.12` to make the reboot an explicit, visible cut — `v0.3.x` tags still exist on GitHub for historical reference but are no longer in `master`'s lineage.

## After merge

- Tag `v0.4.0` at the merge commit and publish a GitHub release.

## Test plan

- [ ] `npx tsc --noEmit`
- [ ] `npm test`
- [ ] Visual sanity check on `ants.sh` deploy once merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Revert**
  * Reverted the codebase to v0.2.11 state, removing multiple features and components introduced in recent development cycles to establish a stable foundation.

* **Documentation**
  * Updated CHANGELOG with v0.4.0 release documentation and bumped package version to 0.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->