### PR TITLE
Fix author-scoped searches returning unrelated notes

### DIFF
--- a/src/lib/search/strategies/authorSearchStrategy.ts
+++ b/src/lib/search/strategies/authorSearchStrategy.ts
@@ -11,6 +11,46 @@ import { getBroadRelaySet, getOutboxSearchCapableRelays } from '../relayManageme
 import { sortEventsNewestFirst } from '../../utils/searchUtils';
 import { SearchContext } from '../types';
 
+function matchesAuthorSeedContent(content: string, seed: string): boolean {
+  const normalizedContent = (content || '').toLowerCase();
+  const normalizedSeed = seed.trim().toLowerCase();
+
+  if (!normalizedSeed) return true;
+  if (!normalizedContent) return false;
+
+  const quotedPhrases = Array.from(normalizedSeed.matchAll(/"([^"]+)"/g))
+    .map((match) => (match[1] || '').trim())
+    .filter(Boolean);
+
+  const tokens = normalizedSeed
+    .replace(/"[^"]+"/g, ' ')
+    .replace(/[()]/g, ' ')
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0 && !/^(OR|AND)$/i.test(token));
+
+  if (quotedPhrases.some((phrase) => !normalizedContent.includes(phrase))) {
+    return false;
+  }
+
+  if (tokens.length === 0) {
+    return quotedPhrases.length > 0;
+  }
+
+  return normalizedContent.includes(tokens.join(' '))
+    || tokens.every((token) => normalizedContent.includes(token));
+}
+
+function filterAuthorResultsByTerms(events: NDKEvent[], terms: string): NDKEvent[] {
+  const seeds = expandParenthesizedOr(terms).map((seed) => seed.trim()).filter(Boolean);
+
+  if (seeds.length === 0) {
+    return events;
+  }
+
+  return events.filter((event) => seeds.some((seed) => matchesAuthorSeedContent(event.content || '', seed)));
+}
+
 /**
  * Handle author filter queries (by:<author>)
  * Supports multiple by: tokens (e.g., "bitcoin by:alice by:bob")
@@ -134,26 +174,25 @@ export async function tryHandleAuthorSearch(
       res = await subscribeAndCollect(filters, 10000, broadRelaySet, abortSignal);
     }
   }
-  // Additional fallback for very short terms (e.g., "GM") or stubborn empties:
-  // some relays require >=3 chars for NIP-50 search; fetch author-only and filter client-side
+
   const termStr = terms.trim();
-  const hasShortToken = termStr.length > 0 && termStr.split(/\s+/).some((t) => t.length < 3);
-  if (res.length === 0 && termStr) {
-    const authorOnly = await subscribeAndCollect(applyDateFilter({ kinds: effectiveKinds, authors: pubkeys, limit: Math.max(limit, 600) }, dateFilter) as NDKFilter, 10000, broadRelaySet, abortSignal);
-    const needle = termStr.toLowerCase();
-    res = authorOnly.filter((e) => (e.content || '').toLowerCase().includes(needle));
-  } else if (res.length === 0 && hasShortToken) {
-    const authorOnly = await subscribeAndCollect(applyDateFilter({ kinds: effectiveKinds, authors: pubkeys, limit: Math.max(limit, 600) }, dateFilter) as NDKFilter, 10000, broadRelaySet, abortSignal);
-    const needle = termStr.toLowerCase();
-    res = authorOnly.filter((e) => (e.content || '').toLowerCase().includes(needle));
+
+  let mergedResults: NDKEvent[] = termStr ? filterAuthorResultsByTerms(res, termStr) : res;
+
+  if (termStr && mergedResults.length === 0) {
+    const authorOnly = await subscribeAndCollect(
+      applyDateFilter({ kinds: effectiveKinds, authors: pubkeys, limit: Math.max(limit, 600) }, dateFilter) as NDKFilter,
+      10000,
+      broadRelaySet,
+      abortSignal
+    );
+    mergedResults = filterAuthorResultsByTerms(authorOnly, termStr);
   }
-  let mergedResults: NDKEvent[] = res;
+
   // Dedupe
   const dedupe = new Map<string, NDKEvent>();
   for (const e of mergedResults) { if (!dedupe.has(e.id)) dedupe.set(e.id, e); }
   mergedResults = Array.from(dedupe.values());
-  // Do not enforce additional client-side text match; rely on relay-side search
-  const filtered = mergedResults;
 
-  return sortEventsNewestFirst(filtered).slice(0, limit);
+  return sortEventsNewestFirst(mergedResults).slice(0, limit);
 }

--- a/src/lib/search/strategies/authorSearchStrategy.ts
+++ b/src/lib/search/strategies/authorSearchStrategy.ts
@@ -7,49 +7,9 @@ import { expandParenthesizedOr } from '../queryTransforms';
 import { subscribeAndCollect } from '../subscriptions';
 import { searchByAnyTerms } from '../termSearch';
 import { resolveAuthorTokens } from '../authorResolve';
-import { getBroadRelaySet, getOutboxSearchCapableRelays } from '../relayManagement';
+import { getOutboxSearchCapableRelays } from '../relayManagement';
 import { sortEventsNewestFirst } from '../../utils/searchUtils';
 import { SearchContext } from '../types';
-
-function matchesAuthorSeedContent(content: string, seed: string): boolean {
-  const normalizedContent = (content || '').toLowerCase();
-  const normalizedSeed = seed.trim().toLowerCase();
-
-  if (!normalizedSeed) return true;
-  if (!normalizedContent) return false;
-
-  const quotedPhrases = Array.from(normalizedSeed.matchAll(/"([^"]+)"/g))
-    .map((match) => (match[1] || '').trim())
-    .filter(Boolean);
-
-  const tokens = normalizedSeed
-    .replace(/"[^"]+"/g, ' ')
-    .replace(/[()]/g, ' ')
-    .split(/\s+/)
-    .map((token) => token.trim())
-    .filter((token) => token.length > 0 && !/^(OR|AND)$/i.test(token));
-
-  if (quotedPhrases.some((phrase) => !normalizedContent.includes(phrase))) {
-    return false;
-  }
-
-  if (tokens.length === 0) {
-    return quotedPhrases.length > 0;
-  }
-
-  return normalizedContent.includes(tokens.join(' '))
-    || tokens.every((token) => normalizedContent.includes(token));
-}
-
-function filterAuthorResultsByTerms(events: NDKEvent[], terms: string): NDKEvent[] {
-  const seeds = expandParenthesizedOr(terms).map((seed) => seed.trim()).filter(Boolean);
-
-  if (seeds.length === 0) {
-    return events;
-  }
-
-  return events.filter((event) => seeds.some((seed) => matchesAuthorSeedContent(event.content || '', seed)));
-}
 
 /**
  * Handle author filter queries (by:<author>)
@@ -113,9 +73,13 @@ export async function tryHandleAuthorSearch(
     console.warn('Failed to get author-specific relays, using chosen relay set:', error);
   }
 
-  // Fetch by base terms if any, restricted to resolved authors
+  // Fetch events, restricted to resolved authors
   let res: NDKEvent[] = [];
-  if (terms) {
+  const hasSearchTerms = terms.length > 0;
+
+  if (hasSearchTerms) {
+    // Text + author query: only use NIP-50 relays. Broad relays ignore
+    // the search field and return all events by the author.
     const seedExpansions3 = expandParenthesizedOr(terms);
     if (seedExpansions3.length > 1) {
       const seen = new Set<string>();
@@ -132,67 +96,46 @@ export async function tryHandleAuthorSearch(
     } else {
       res = await subscribeAndCollect(filters, 8000, authorRelaySet, abortSignal);
     }
-  } else {
-    res = await subscribeAndCollect(filters, 8000, authorRelaySet, abortSignal);
-  }
-
-  // If the remaining terms contain parenthesized OR seeds like (a OR b), run a seeded OR search too
-  const seedMatches = Array.from(terms.matchAll(/\(([^)]+\s+OR\s+[^)]+)\)/gi));
-  const seedTerms: string[] = [];
-  for (const m of seedMatches) {
-    const inner = (m[1] || '').trim();
-    if (!inner) continue;
-    inner.split(/\s+OR\s+/i).forEach((t) => {
-      const token = t.trim();
-      if (token) seedTerms.push(token);
-    });
-  }
-  if (seedTerms.length > 0) {
-    try {
-       const seeded = await searchByAnyTerms(
-         seedTerms,
-         limit,
-         authorRelaySet,
-         abortSignal,
-         nip50Extensions,
-         applyDateFilter({ authors: pubkeys, kinds: effectiveKinds }, dateFilter),
-         () => getBroadRelaySet()
-       );
-      res = [...res, ...seeded];
-    } catch {}
-  }
-  // Fallback: if no results, try a broader relay set (default + search)
-  const broadRelays = Array.from(new Set<string>([...RELAYS.DEFAULT, ...RELAYS.SEARCH]));
-  const broadRelaySet = NDKRelaySet.fromRelayUrls(broadRelays, ndk);
-  if (res.length === 0) {
-    try {
-      res = await subscribeAndCollect(filters, 10000, authorRelaySet, abortSignal);
-    } catch (error) {
-      console.warn('Author relay set fallback failed, using broad relay set:', error);
+    
+    // Parenthesized OR seeds within the terms (e.g., "(GM OR GN) by:dergigi")
+    const seedMatches = Array.from(terms.matchAll(/\(([^)]+\s+OR\s+[^)]+)\)/gi));
+    const seedTerms: string[] = [];
+    for (const m of seedMatches) {
+      const inner = (m[1] || '').trim();
+      if (!inner) continue;
+      inner.split(/\s+OR\s+/i).forEach((t) => {
+        const token = t.trim();
+        if (token) seedTerms.push(token);
+      });
     }
+    if (seedTerms.length > 0) {
+      try {
+        const seeded = await searchByAnyTerms(
+          seedTerms,
+          limit,
+          authorRelaySet,
+          abortSignal,
+          nip50Extensions,
+          applyDateFilter({ authors: pubkeys, kinds: effectiveKinds }, dateFilter)
+        );
+        res = [...res, ...seeded];
+      } catch {}
+    }
+  } else {
+    // Author-only query: broad relays are fine since there is no search
+    // field for them to ignore.
+    res = await subscribeAndCollect(filters, 8000, authorRelaySet, abortSignal);
     if (res.length === 0) {
+      const broadRelays = Array.from(new Set<string>([...RELAYS.DEFAULT, ...RELAYS.SEARCH]));
+      const broadRelaySet = NDKRelaySet.fromRelayUrls(broadRelays, ndk);
       res = await subscribeAndCollect(filters, 10000, broadRelaySet, abortSignal);
     }
   }
 
-  const termStr = terms.trim();
-
-  let mergedResults: NDKEvent[] = termStr ? filterAuthorResultsByTerms(res, termStr) : res;
-
-  if (termStr && mergedResults.length === 0) {
-    const authorOnly = await subscribeAndCollect(
-      applyDateFilter({ kinds: effectiveKinds, authors: pubkeys, limit: Math.max(limit, 600) }, dateFilter) as NDKFilter,
-      10000,
-      broadRelaySet,
-      abortSignal
-    );
-    mergedResults = filterAuthorResultsByTerms(authorOnly, termStr);
-  }
-
   // Dedupe
   const dedupe = new Map<string, NDKEvent>();
-  for (const e of mergedResults) { if (!dedupe.has(e.id)) dedupe.set(e.id, e); }
-  mergedResults = Array.from(dedupe.values());
+  for (const e of res) { if (!dedupe.has(e.id)) dedupe.set(e.id, e); }
+  const results = Array.from(dedupe.values());
 
-  return sortEventsNewestFirst(mergedResults).slice(0, limit);
+  return sortEventsNewestFirst(results).slice(0, limit);
 }


### PR DESCRIPTION
This fixes author-scoped searches like `coffee by:dergigi` by keeping author-plus-text queries on NIP-50 relays only. The broken behavior came from the broad-relay fallback in `authorSearchStrategy`: when a relay ignores the `search` field, it returns every post by that author. Author-only queries still fall back broadly, but text queries no longer do.

- keeps `by:` queries with search terms on relays that are expected to honor NIP-50
- preserves the broad fallback for author-only queries, where no `search` field is involved
