### PR TITLE
test: add real-relay search smoke suite

### DIFF
--- a/.github/workflows/search-smoke.yml
+++ b/.github/workflows/search-smoke.yml
@@ -1,0 +1,35 @@
+name: Search Smoke
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  search-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Jest suite
+        run: npm test -- --runInBand
+
+      - name: Run search smoke suite
+        run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
 
 # next.js
 /.next/

--- a/e2e/search-smoke.spec.ts
+++ b/e2e/search-smoke.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from '@playwright/test';
+import { searchExamples } from '../src/lib/examples';
+
+const smokeQueries = [
+  { label: 'basic text search', query: 'vibe coding' },
+  { label: 'author search', query: 'by:fiatjaf' },
+  { label: 'profile search', query: 'p:fiatjaf' },
+  { label: 'text plus author search', query: 'GM by:dergigi' },
+  { label: 'site plus author search', query: 'site:github by:fiatjaf' },
+] as const;
+
+const exampleSet = new Set(searchExamples);
+
+for (const { query } of smokeQueries) {
+  if (!exampleSet.has(query)) {
+    throw new Error(`Missing smoke query in src/lib/examples.ts: ${query}`);
+  }
+}
+
+test.describe('real relay search smoke', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  for (const { label, query } of smokeQueries) {
+    test(`${label}: ${query}`, async ({ page }) => {
+      test.setTimeout(90_000);
+
+      const pageErrors: string[] = [];
+      page.on('pageerror', (error) => {
+        pageErrors.push(error.message);
+      });
+
+      await page.goto('/');
+
+      const input = page.locator('#search-row input[type="text"]');
+      await expect(input).toBeVisible();
+
+      await input.fill(query);
+      await input.press('Enter');
+
+      await expect
+        .poll(() => new URL(page.url()).searchParams.get('q'))
+        .toBe(query);
+
+      const spinner = page.locator('#search-row .animate-spin');
+      await spinner.first().waitFor({ state: 'visible', timeout: 5_000 }).catch(() => null);
+      await expect(spinner).toHaveCount(0, { timeout: 45_000 });
+
+      await expect(input).toHaveValue(query);
+
+      const followUpQuery = `${query} again`;
+      await input.fill(followUpQuery);
+      await expect(input).toHaveValue(followUpQuery);
+
+      expect(pageErrors).toEqual([]);
+    });
+  }
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,8 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  testPathIgnorePatterns: ['<rootDir>/e2e/'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1'
   }
-}; 
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.3.0",
@@ -2396,6 +2397,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -8606,6 +8623,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint && tsc --noEmit",
-    "test": "jest"
+    "test": "jest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
@@ -34,6 +35,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.3.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   testDir: './e2e',
   fullyParallel: false,
   workers: 1,
+  retries: process.env.CI ? 1 : 0,
   timeout: 90_000,
   expect: {
     timeout: 45_000,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  workers: 1,
+  timeout: 90_000,
+  expect: {
+    timeout: 45_000,
+  },
+  use: {
+    baseURL: 'http://localhost:7473',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:7473',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});


### PR DESCRIPTION
This adds the smallest useful real-relay smoke suite for search so we have an end-to-end check before shipping more search changes. The new Playwright run hits the live app on `localhost:7473`, executes five existing queries from `src/lib/examples.ts`, and waits for each NIP-50 search flow to finish without uncaught browser errors or a broken search box.

- adds `npm run test:e2e` with a serial Playwright config so we do not hammer relays in parallel
- covers five real example queries: basic text, `by:` author, `p:` profile, text plus author, and `site:` plus author
- keeps the assertions intentionally minimal: the suite checks that search completes and the input stays usable, without depending on specific relay content


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Introduced comprehensive end-to-end testing infrastructure with data-driven smoke tests that validate search functionality. Tests verify query execution, URL parameter handling, loading state transitions, input field retention, follow-up search capabilities, and error detection across multiple scenarios to ensure consistent and reliable search behavior while maintaining high product quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->