### PR TITLE
test: assert live relay smoke queries return results

### DIFF
--- a/e2e/search-smoke.spec.ts
+++ b/e2e/search-smoke.spec.ts
@@ -1,13 +1,20 @@
 import { expect, test, type Page } from '@playwright/test';
-import { searchExamples } from '../src/lib/examples';
+import { searchExamples, type SearchExample } from '../src/lib/examples';
 
-const smokeQueries = [
+type SmokeQuery = {
+  label: string;
+  query: SearchExample;
+  resultType: 'event' | 'profile';
+  expectedText?: string;
+};
+
+const smokeQueries: readonly SmokeQuery[] = [
   { label: 'basic text search', query: 'vibe coding', resultType: 'event' },
   { label: 'author search', query: 'by:fiatjaf', resultType: 'event' },
   { label: 'profile search', query: 'p:fiatjaf', resultType: 'profile' },
-  { label: 'text plus author search', query: 'good by:socrates', resultType: 'event' },
+  { label: 'text plus author search', query: 'good by:socrates', resultType: 'event', expectedText: 'good' },
   { label: 'site plus author search', query: 'site:github by:fiatjaf', resultType: 'event' },
-] as const;
+];
 
 const exampleSet = new Set(searchExamples);
 const baseCardSelector = '[class*="relative"][class*="bg-[#2d2d2d]"][class*="border-[#3d3d3d]"]';
@@ -26,7 +33,7 @@ test.describe('real relay search smoke', () => {
     }
   });
 
-  for (const { label, query, resultType } of smokeQueries) {
+  for (const { label, query, resultType, expectedText } of smokeQueries) {
     test(`${label}: ${query}`, async ({ page }) => {
 
       const pageErrors: string[] = [];
@@ -54,6 +61,14 @@ test.describe('real relay search smoke', () => {
         .toBeGreaterThan(0);
       await expect(resultCards.first()).toBeVisible();
       await expect(spinner).toHaveCount(0, { timeout: 45_000 });
+      if (expectedText) {
+        await expect
+          .poll(async () => {
+            const texts = await resultCards.allTextContents();
+            return texts.some((text) => text.toLowerCase().includes(expectedText.toLowerCase()));
+          }, { timeout: 45_000 })
+          .toBe(true);
+      }
 
       await expect(input).toHaveValue(query);
 

--- a/e2e/search-smoke.spec.ts
+++ b/e2e/search-smoke.spec.ts
@@ -6,13 +6,25 @@ type SmokeQuery = {
   query: SearchExample;
   resultType: 'event' | 'profile';
   expectedText?: string;
+  expectedResolvedAuthor?: string;
 };
 
 const smokeQueries: readonly SmokeQuery[] = [
   { label: 'basic text search', query: 'vibe coding', resultType: 'event' },
-  { label: 'author search', query: 'by:fiatjaf', resultType: 'event' },
+  {
+    label: 'author search',
+    query: 'by:fiatjaf',
+    resultType: 'event',
+    expectedResolvedAuthor: 'by:npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6'
+  },
   { label: 'profile search', query: 'p:fiatjaf', resultType: 'profile' },
-  { label: 'text plus author search', query: 'good by:socrates', resultType: 'event', expectedText: 'good' },
+  {
+    label: 'text plus author search',
+    query: 'good by:socrates',
+    resultType: 'event',
+    expectedText: 'good',
+    expectedResolvedAuthor: 'by:npub1s0cra5735s8ccw7pfvqtp4see7t7lkfr0gwrfhkhsfakuxkf5ahs83023h'
+  },
   { label: 'site plus author search', query: 'site:github by:fiatjaf', resultType: 'event' },
 ];
 
@@ -33,7 +45,7 @@ test.describe('real relay search smoke', () => {
     }
   });
 
-  for (const { label, query, resultType, expectedText } of smokeQueries) {
+  for (const { label, query, resultType, expectedText, expectedResolvedAuthor } of smokeQueries) {
     test(`${label}: ${query}`, async ({ page }) => {
 
       const pageErrors: string[] = [];
@@ -52,6 +64,17 @@ test.describe('real relay search smoke', () => {
       await expect
         .poll(() => new URL(page.url()).searchParams.get('q'))
         .toBe(query);
+
+      if (expectedResolvedAuthor) {
+        const explanation = page.locator('#search-explanation');
+        await expect(explanation).toBeVisible({ timeout: 15_000 });
+        await expect
+          .poll(async () => {
+            const text = (await explanation.textContent()) || '';
+            return text.replace(/\s+/g, ' ').trim();
+          }, { timeout: 20_000 })
+          .toContain(expectedResolvedAuthor);
+      }
 
       const spinner = page.locator('#search-row .animate-spin');
       const resultCards = getResultCards(page, resultType);

--- a/e2e/search-smoke.spec.ts
+++ b/e2e/search-smoke.spec.ts
@@ -1,28 +1,33 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 import { searchExamples } from '../src/lib/examples';
 
 const smokeQueries = [
-  { label: 'basic text search', query: 'vibe coding' },
-  { label: 'author search', query: 'by:fiatjaf' },
-  { label: 'profile search', query: 'p:fiatjaf' },
-  { label: 'text plus author search', query: 'GM by:dergigi' },
-  { label: 'site plus author search', query: 'site:github by:fiatjaf' },
+  { label: 'basic text search', query: 'vibe coding', resultType: 'event' },
+  { label: 'author search', query: 'by:fiatjaf', resultType: 'event' },
+  { label: 'profile search', query: 'p:fiatjaf', resultType: 'profile' },
+  { label: 'text plus author search', query: 'good by:socrates', resultType: 'event' },
+  { label: 'site plus author search', query: 'site:github by:fiatjaf', resultType: 'event' },
 ] as const;
 
 const exampleSet = new Set(searchExamples);
+const baseCardSelector = '[class*="relative"][class*="bg-[#2d2d2d]"][class*="border-[#3d3d3d]"]';
+const eventCardSelector = `${baseCardSelector}:not([class*="overflow-hidden"])`;
+const profileCardSelector = `${baseCardSelector}[class*="overflow-hidden"]`;
 
-for (const { query } of smokeQueries) {
-  if (!exampleSet.has(query)) {
-    throw new Error(`Missing smoke query in src/lib/examples.ts: ${query}`);
-  }
-}
+const getResultCards = (page: Page, resultType: 'event' | 'profile') =>
+  page.locator(resultType === 'profile' ? profileCardSelector : eventCardSelector);
 
 test.describe('real relay search smoke', () => {
   test.describe.configure({ mode: 'serial' });
 
-  for (const { label, query } of smokeQueries) {
+  test('smoke queries exist in src/lib/examples.ts', () => {
+    for (const { query } of smokeQueries) {
+      expect(exampleSet.has(query), `Missing smoke query: ${query}`).toBe(true);
+    }
+  });
+
+  for (const { label, query, resultType } of smokeQueries) {
     test(`${label}: ${query}`, async ({ page }) => {
-      test.setTimeout(90_000);
 
       const pageErrors: string[] = [];
       page.on('pageerror', (error) => {
@@ -42,7 +47,12 @@ test.describe('real relay search smoke', () => {
         .toBe(query);
 
       const spinner = page.locator('#search-row .animate-spin');
-      await spinner.first().waitFor({ state: 'visible', timeout: 5_000 }).catch(() => null);
+      const resultCards = getResultCards(page, resultType);
+
+      await expect
+        .poll(() => resultCards.count(), { timeout: 45_000 })
+        .toBeGreaterThan(0);
+      await expect(resultCards.first()).toBeVisible();
       await expect(spinner).toHaveCount(0, { timeout: 45_000 });
 
       await expect(input).toHaveValue(query);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './e2e',
-  fullyParallel: false,
   workers: 1,
   retries: process.env.CI ? 1 : 0,
   timeout: 90_000,


### PR DESCRIPTION
This tightens the real-relay smoke suite so it checks that the chosen queries return plausible results and that the current author resolver still maps the tested `by:` handles to the expected npubs. The assertions still avoid pinning exact relay result sets, but they now fail if the expected result shape, key content, or author resolution never appears.

- adds a named guard test that confirms the smoke queries still exist in `src/lib/examples.ts`
- requires event queries to render at least one event-style result card, requires `p:fiatjaf` to render at least one profile card, and requires `good by:socrates` to return at least one result containing `good`
- checks the query translation UI for the exact current author-resolution mappings of `by:fiatjaf` and `by:socrates`
