### PR TITLE
fix: restore NIP-05 well-known endpoint

### DIFF
--- a/src/app/.well-known/nostr.json/route.ts
+++ b/src/app/.well-known/nostr.json/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+
+const NIP05_DATA = {
+  names: {
+    _: 'e530f930efb36ec1da0f5f249ad3db8edf19b667570acab817c82185d562e889',
+  },
+  relays: {
+    e530f930efb36ec1da0f5f249ad3db8edf19b667570acab817c82185d562e889: [
+      'wss://relay.damus.io',
+      'wss://relay.primal.net',
+      'wss://nos.lol',
+      'wss://purplepag.es',
+      'wss://haven.dergigi.com',
+      'wss://wot.dergigi.com',
+    ],
+  },
+};
+
+export async function GET() {
+  return NextResponse.json(NIP05_DATA, {
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+}


### PR DESCRIPTION
This restores the `.well-known/nostr.json` endpoint for `_@ants.sh` from the pre-reset implementation, including the Haven and WoT relay hints, so the NIP-05 well-known response is served again. Fixes #257.

- adds `src/app/.well-known/nostr.json/route.ts`
- returns the `_` name mapping and relay hints for Haven and WoT
- keeps the previous CORS and cache headers
