### PR TITLE
fix: restore tutorial target

### DIFF
--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -253,7 +253,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       }
     },
     onTutorial: () => {
-      const tutorialNevent = 'nevent1qqstgekdlmaeu3n6gf3ss7nnlq4f0hfx3nm3nmy0pf84xs7e98wyt2ssw5p34';
+      const tutorialNevent = 'nevent1qqsqnndhkz4u26m4v4gut2xjsun8hzfxn75spzcr8337a06g66zwzespzamhxue69uhksctkv4hzuer9wfnkjemf9e3k7mgehz685';
       setTopCommandText(buildCli('--help tutorial', 'Loading tutorial event...'));
       setTopExamples(null);
       setHelpCommands(null);


### PR DESCRIPTION
This restores the `/tutorial` target from `v0.2.11` by pointing the slash command back to the hosted Haven tutorial event. Fixes #259.

- updates the tutorial nevent in `SearchView`
- keeps the current simple direct behavior of loading the tutorial event


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the tutorial event identifier to ensure the tutorial feature functions correctly.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dergigi/ants/pull/274)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->