### PR TITLE
fix: suppress sqlite-wasm cache pageerror

### DIFF
--- a/src/lib/ndk.ts
+++ b/src/lib/ndk.ts
@@ -93,16 +93,27 @@ export async function ensureCacheInitialized(): Promise<void> {
   // Install global error handlers first to catch any initialization errors
   if (!cacheErrorHandlersInstalled && typeof window !== 'undefined') {
     try {
-      const handleAnyError = (err: unknown) => {
-        const reason = err && (err as { reason?: unknown; error?: unknown }).reason;
-        const payload = (reason as unknown) || err;
-        if (isUndefinedBindWasmError(payload)) {
-          console.warn('Caught WASM cache binding error, disabling cache:', payload);
-          disableCacheAdapter(payload);
-        }
+      const suppressKnownCacheError = (event: { preventDefault?: () => void; stopImmediatePropagation?: () => void } | undefined) => {
+        try { event?.preventDefault?.(); } catch {}
+        try { event?.stopImmediatePropagation?.(); } catch {}
       };
-      window.addEventListener('error', (ev) => handleAnyError(ev.error || ev.message));
-      window.addEventListener('unhandledrejection', (ev) => handleAnyError((ev as PromiseRejectionEvent).reason));
+
+      window.addEventListener('error', (ev) => {
+        const payload = ev.error || ev.message;
+        if (!isUndefinedBindWasmError(payload)) return;
+        console.warn('Caught WASM cache binding error, disabling cache:', payload);
+        disableCacheAdapter(payload);
+        suppressKnownCacheError(ev);
+      });
+
+      window.addEventListener('unhandledrejection', (ev) => {
+        const payload = (ev as PromiseRejectionEvent).reason;
+        if (!isUndefinedBindWasmError(payload)) return;
+        console.warn('Caught WASM cache binding rejection, disabling cache:', payload);
+        disableCacheAdapter(payload);
+        suppressKnownCacheError(ev);
+      });
+
       cacheErrorHandlersInstalled = true;
     } catch {}
   }


### PR DESCRIPTION
This prevents the known sqlite-wasm cache bind failure from surfacing as an uncaught browser error. When the NDK cache layer throws the `unknown type (undefined)` bind error, we now disable the cache and suppress that specific browser `error` and `unhandledrejection` event so search continues cleanly on live relays only. Closes #255.

- keep the existing cache-disable fallback in `src/lib/ndk.ts`, but stop the known sqlite-wasm bind failure from bubbling into a client-side `pageerror`
- validated with `npm run build`, `npm run lint`, and a dev-mode Playwright repro pass for `giphy.gif`, `by:pablof7z`, and `bitcoin OR lightning`
