### PR TITLE
test: make author smoke coverage deterministic

### DIFF
--- a/e2e/search-smoke.spec.ts
+++ b/e2e/search-smoke.spec.ts
@@ -18,8 +18,7 @@ type SmokeQuery = {
   expectedDateRange?: DateExpectation;
 };
 
-const fiatjafResolvedQuery = 'by:npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6';
-const socratesResolvedQuery = 'by:npub1s0cra5735s8ccw7pfvqtp4see7t7lkfr0gwrfhkhsfakuxkf5ahs83023h';
+const dergigiResolvedQuery = 'by:npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc';
 const relativeSincePattern = /\bsince:\d{4}-\d{2}-\d{2}\b/;
 
 function patternFromAlternatives(...candidates: readonly string[]): RegExp {
@@ -30,25 +29,24 @@ function patternFromAlternatives(...candidates: readonly string[]): RegExp {
   );
 }
 
-const fiatjafExplanationPattern = patternFromAlternatives('by:fiatjaf', fiatjafResolvedQuery);
-const socratesExplanationPattern = patternFromAlternatives('by:socrates', socratesResolvedQuery);
+const dergigiExplanationPattern = patternFromAlternatives('by:dergigi', dergigiResolvedQuery);
 
 const smokeQueries: readonly SmokeQuery[] = [
   { label: 'basic text search', query: 'vibe coding', resultType: 'event' },
   {
-    label: 'author search',
-    query: 'by:fiatjaf',
+    label: 'author alias search',
+    query: 'by:dergigi',
     resultType: 'event',
-    expectedExplanationPattern: fiatjafExplanationPattern,
+    expectedExplanationPattern: dergigiExplanationPattern,
   },
   { label: 'profile search', query: 'p:fiatjaf', resultType: 'profile' },
   { label: 'kind OR search', query: 'kind:0 or kind:1', resultType: 'event' },
   { label: 'gif search', query: 'has:gif', resultType: 'event' },
   {
-    label: 'second author search',
-    query: 'by:socrates',
+    label: 'direct npub author search',
+    query: 'by:npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc',
     resultType: 'event',
-    expectedExplanationPattern: socratesExplanationPattern,
+    expectedExplanationSubstrings: [dergigiResolvedQuery],
   },
   { label: 'second profile search', query: 'p:hodl', resultType: 'profile' },
   { label: 'media search', query: 'has:image', resultType: 'event' },

--- a/e2e/search-smoke.spec.ts
+++ b/e2e/search-smoke.spec.ts
@@ -15,21 +15,13 @@ type SmokeQuery = {
   expectedText?: string;
   expectedExplanationSubstrings?: readonly string[];
   expectedExplanationPattern?: RegExp;
+  expectedEffectiveFilterSubstrings?: readonly string[];
   expectedDateRange?: DateExpectation;
 };
 
 const dergigiResolvedQuery = 'by:npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc';
+const dergigiAuthorHex = '6e468422dfb74a5738702a8823b9b28168abab8655faacb6853cd0ee15deee93';
 const relativeSincePattern = /\bsince:\d{4}-\d{2}-\d{2}\b/;
-
-function patternFromAlternatives(...candidates: readonly string[]): RegExp {
-  return new RegExp(
-    candidates
-      .map((candidate) => candidate.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-      .join('|')
-  );
-}
-
-const dergigiExplanationPattern = patternFromAlternatives('by:dergigi', dergigiResolvedQuery);
 
 const smokeQueries: readonly SmokeQuery[] = [
   { label: 'basic text search', query: 'vibe coding', resultType: 'event' },
@@ -37,7 +29,7 @@ const smokeQueries: readonly SmokeQuery[] = [
     label: 'author alias search',
     query: 'by:dergigi',
     resultType: 'event',
-    expectedExplanationPattern: dergigiExplanationPattern,
+    expectedEffectiveFilterSubstrings: [dergigiAuthorHex],
   },
   { label: 'profile search', query: 'p:fiatjaf', resultType: 'profile' },
   { label: 'kind OR search', query: 'kind:0 or kind:1', resultType: 'event' },
@@ -132,7 +124,7 @@ test.describe('real relay search smoke', () => {
     }
   });
 
-  for (const { label, query, resultType, expectedText, expectedExplanationSubstrings, expectedExplanationPattern, expectedDateRange } of smokeQueries) {
+  for (const { label, query, resultType, expectedText, expectedExplanationSubstrings, expectedExplanationPattern, expectedEffectiveFilterSubstrings, expectedDateRange } of smokeQueries) {
     test(`${label}: ${query}`, async ({ page }) => {
 
       const pageErrors: string[] = [];
@@ -152,10 +144,10 @@ test.describe('real relay search smoke', () => {
         .poll(() => new URL(page.url()).searchParams.get('q'))
         .toBe(query);
 
-      if (expectedExplanationSubstrings || expectedExplanationPattern) {
-        const explanation = page.locator('#search-explanation');
-        const getExplanationText = async () => ((await explanation.textContent()) || '').replace(/\s+/g, ' ').trim();
+      const explanation = page.locator('#search-explanation');
+      const getExplanationText = async () => ((await explanation.textContent()) || '').replace(/\s+/g, ' ').trim();
 
+      if (expectedExplanationSubstrings || expectedExplanationPattern || expectedEffectiveFilterSubstrings) {
         await expect(explanation).toBeVisible({ timeout: 15_000 });
 
         if (expectedExplanationSubstrings) {
@@ -187,6 +179,21 @@ test.describe('real relay search smoke', () => {
         .toBeGreaterThan(0);
       await expect(resultCards.first()).toBeVisible();
       await expect(spinner).toHaveCount(0, { timeout: 45_000 });
+
+      if (expectedEffectiveFilterSubstrings) {
+        const filtersButton = page.getByRole('button', { name: /effective filters/i });
+        await expect(filtersButton).toBeVisible();
+        await filtersButton.click();
+
+        for (const expectedSubstring of expectedEffectiveFilterSubstrings) {
+          await expect
+            .poll(getExplanationText, {
+              timeout: 20_000,
+              message: `Expected effective filters to contain: ${expectedSubstring}`,
+            })
+            .toContain(expectedSubstring);
+        }
+      }
 
       if (expectedDateRange) {
         await expectResultDatesWithinRange(resultCards, expectedDateRange);

--- a/src/lib/examples.ts
+++ b/src/lib/examples.ts
@@ -17,6 +17,7 @@ export const searchExamples = [
   
   // by:Author
   'by:fiatjaf',
+  'by:dergigi',
   'by:@dergigi.com',
   'by:gigi',
   'by:pablof7z',
@@ -154,6 +155,7 @@ export const searchExamples = [
   'NIP-EE (by:jeffg OR by:futurepaul OR by:franzap)',
 
   // Direct npub
+  'by:npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc',
   'GN by:npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc',
   'proof-of-work by:npub1satsv3728d65nenvkmzthrge0aduj8088dvwkxk70rydm407cl4s87sfhu',
   'essay by:npub1sfhflz2msx45rfzjyf5tyj0x35pv4qtq3hh4v2jf8nhrtl79cavsl2ymqt',


### PR DESCRIPTION
This follow-up keeps `by:dergigi` as a real live-lookup smoke and makes the assertion target the effective filters from the actual search path. It also keeps one direct `by:npub...` smoke and updates `src/lib/examples.ts` so both queries stay covered by the examples check.

- `by:dergigi` now proves live resolution by asserting the resolved author hex in the effective filters
- `by:npub...` still gives stable direct author coverage for the explanation path


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new search examples demonstrating author alias syntax (e.g., by:dergigi) and direct npub address searches for easier author-focused discovery.

* **Tests**
  * Updated end-to-end search tests to validate these new example queries and their displayed explanations and effective filters to ensure search results behave as expected.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dergigi/ants/pull/277)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->