### PR TITLE
chore(relays): refresh default relay sets

### DIFF
--- a/src/lib/relays/config.ts
+++ b/src/lib/relays/config.ts
@@ -6,27 +6,28 @@ export const RELAYS = {
   // Default relays for general NDK connection
   DEFAULT: [
     'wss://relay.primal.net',
-    'wss://relay.snort.social',
-    'wss://relay.ditto.pub'
+    'wss://relay.ditto.pub',
+    'wss://nos.lol'
   ],
 
   // Search-capable relays (NIP-50 support)
   SEARCH: [
     'wss://search.nos.today',
-    'wss://relay.nostr.band',
     'wss://relay.ditto.pub',
-    'wss://relay.davidebtc.me',
     'wss://relay.gathr.gives',
-    'wss://nostr.polyserv.xyz',
-    'wss://nostr.azzamo.net'
+    'wss://antiprimal.net',
+    'wss://index.hzrd149.com',
+    'wss://nostr.me/relay',
+    'wss://relay.vertexlab.io'
   ],
 
   // Profile search relays (NIP-50 capable)
   PROFILE_SEARCH: [
     'wss://purplepag.es',
     'wss://search.nos.today',
-    'wss://relay.nostr.band',
-    'wss://relay.ditto.pub'
+    'wss://relay.ditto.pub',
+    'wss://relay.vertexlab.io',
+    'wss://antiprimal.net'
   ],
 
   // Premium relays to use only for logged-in users

--- a/src/lib/relays/nip50.ts
+++ b/src/lib/relays/nip50.ts
@@ -40,15 +40,25 @@ export async function filterNip50Relays(relayUrls: string[]): Promise<string[]> 
     }
   });
 
-  // If we have very few NIP-50 relays, include some known good relays as fallback
+  // If we have very few NIP-50 relays, fall back to unchecked candidates from
+  // the curated search relay set, but only after verifying NIP-50 support
   if (supportedRelays.length < 3) {
-    const fallbackRelays = [
-      'wss://relay.primal.net',
-      'wss://relay.snort.social',
-      'wss://relay.ditto.pub'
-    ].filter(url => !supportedRelays.includes(url) && !rejectedRelays.includes(url));
+    const fallbackCandidates = RELAYS.SEARCH.filter(
+      (url) => !supportedRelays.includes(url) && !rejectedRelays.includes(url)
+    );
 
-    supportedRelays.push(...fallbackRelays);
+    const fallbackResults = await Promise.allSettled(
+      fallbackCandidates.map(async (url) => {
+        const nip50Info = await checkNip50Support(url);
+        return { url, supportsNip50: nip50Info.supportsNip50 };
+      })
+    );
+
+    fallbackResults.forEach((result) => {
+      if (result.status === 'fulfilled' && result.value.supportsNip50) {
+        supportedRelays.push(result.value.url);
+      }
+    });
   }
 
   return supportedRelays;


### PR DESCRIPTION
Reapplies the relay default refresh from #280 on top of the new `src/lib/relays/` module layout from #282 (the old branch carried its own relays split and is now fully conflicted). Search and profile lookups lean on relays that currently respond cleanly, and the NIP-50 fallback path stays aligned with the curated search relay set instead of falling back to non-search relays.

- replace stale or timing-out defaults such as `relay.snort.social`, `relay.nostr.band`, `relay.davidebtc.me`, `nostr.polyserv.xyz`, and `nostr.azzamo.net`
- add healthy NIP-50 relays including `antiprimal.net`, `index.hzrd149.com`, `nostr.me/relay`, and `relay.vertexlab.io`, plus `nos.lol` for the general default set
- re-check fallback relay candidates with `checkNip50Support()` before adding them to NIP-50 searches

All added relays were re-verified via NIP-11 probes today and respond with NIP-50 support. Supersedes #280.

Build preview:
- [/?q=vibe+coding](https://ants-git-chore-refresh-relay-defaults-dergigis-projects.vercel.app/?q=vibe+coding)
