### PR TITLE
fix(profile): verify NIP-05 claims when resolving author aliases

### DIFF
--- a/src/lib/profile/resolver.ts
+++ b/src/lib/profile/resolver.ts
@@ -1,6 +1,6 @@
 import { NDKEvent } from '@nostr-dev-kit/ndk';
 import { nip19 } from 'nostr-tools';
-import { resolveNip05ToPubkey } from './nip05';
+import { resolveNip05ToPubkey, verifyNip05 } from './nip05';
 import { normalizeNip05String } from '../nip05';
 import { extractProfileFields, profileEventFromPubkey } from './utils';
 import { getCachedUsername, setCachedUsername } from './username-cache';
@@ -48,7 +48,23 @@ function isStrongAuthorResolutionMatch(input: string, event: NDKEvent): boolean 
   return scoreAuthorResolutionCandidate(input, event) >= 500;
 }
 
-function pickBestAuthorResolutionProfile(input: string, profiles: NDKEvent[]): NDKEvent | null {
+const NIP05_VERIFY_TIMEOUT_MS = 3000;
+const NIP05_VERIFY_BATCH_SIZE = 8;
+const NIP05_VERIFY_MAX_CANDIDATES = 32;
+
+async function verifyCandidateNip05(event: NDKEvent): Promise<boolean> {
+  const pubkey = event.author?.pubkey || event.pubkey || '';
+  const { nip05 } = extractProfileFields(event);
+  if (!pubkey || !nip05) return false;
+  try {
+    const timeout = new Promise<false>((resolve) => setTimeout(() => resolve(false), NIP05_VERIFY_TIMEOUT_MS));
+    return await Promise.race([verifyNip05(pubkey, nip05), timeout]);
+  } catch {
+    return false;
+  }
+}
+
+async function pickBestAuthorResolutionProfile(input: string, profiles: NDKEvent[]): Promise<NDKEvent | null> {
   if (profiles.length === 0) return null;
 
   const ranked = profiles
@@ -62,10 +78,24 @@ function pickBestAuthorResolutionProfile(input: string, profiles: NDKEvent[]): N
       if (a.score !== b.score) return b.score - a.score;
       if (a.createdAt !== b.createdAt) return b.createdAt - a.createdAt;
       return a.index - b.index;
-    });
+    })
+    .filter((candidate) => candidate.score > 0);
 
-  const best = ranked[0];
-  return best && best.score > 0 ? best.event : null;
+  if (ranked.length === 0) return null;
+
+  // Impersonators copy names and NIP-05 strings of well-known profiles and can
+  // outscore the real one. Walk the ranked candidates in batches and return the
+  // highest-scored profile whose NIP-05 claim actually verifies against its
+  // domain; fall back to the top scorer when nothing verifies.
+  const candidates = ranked.slice(0, NIP05_VERIFY_MAX_CANDIDATES);
+  for (let offset = 0; offset < candidates.length; offset += NIP05_VERIFY_BATCH_SIZE) {
+    const batch = candidates.slice(offset, offset + NIP05_VERIFY_BATCH_SIZE);
+    const verifications = await Promise.all(batch.map((candidate) => verifyCandidateNip05(candidate.event)));
+    const verified = batch.find((_, idx) => verifications[idx]);
+    if (verified) return verified.event;
+  }
+
+  return ranked[0].event;
 }
 
 // Unified author resolver: npub | nip05 | username -> pubkey (hex) and an optional profile event
@@ -122,7 +152,7 @@ export async function resolveAuthor(authorInput: string): Promise<{ pubkeyHex: s
     let profileEvt: NDKEvent | null = null;
     try {
       const profiles = await searchProfilesFullText(input, 200);
-      profileEvt = pickBestAuthorResolutionProfile(input, profiles);
+      profileEvt = await pickBestAuthorResolutionProfile(input, profiles);
     } catch {}
 
     setCachedUsername(usernameLower, profileEvt);


### PR DESCRIPTION
The search smoke tests broke with #283: the refreshed profile-search relays (`antiprimal.net`, `relay.vertexlab.io`) return impersonator profiles named `derGigi` claiming `_@dergigi.com`, which outscore the real profile in `scoreAuthorResolutionCandidate` (940 vs 700, since the real profile is named "Gigi"). As a result `by:dergigi` resolved to a clone and the smoke test timed out. The resolver now walks ranked candidates in batches and prefers the highest-scored profile whose NIP-05 claim actually verifies against its domain, so clones fail verification and the real profile wins.

- Verify NIP-05 claims (batches of 8, up to 32 candidates) in `pickBestAuthorResolutionProfile`, with a 3s timeout per check
- Fall back to the top scorer when nothing verifies
- Full smoke suite passes locally (14/14)

Build preview:
- [/?q=by:dergigi](https://ants-git-fix-smoke-tests-dergigis-projects.vercel.app/?q=by:dergigi)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved author profile resolution with enhanced NIP-05 identity verification capabilities. Profile candidates are now thoroughly evaluated through batched verification requests with timeout protection to ensure selection of properly authenticated profiles. When verification succeeds, the verified candidate is prioritized; otherwise falls back to the highest-scored profile to ensure reliable and accurate profile matching in all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->