### PR TITLE
fix(profile-search): penalize failed NIP-05 verification in ranking

### DIFF
--- a/src/hooks/useSearchExecution.ts
+++ b/src/hooks/useSearchExecution.ts
@@ -269,7 +269,13 @@ export function useSearchExecution(options: SearchExecutionOptions) {
         relaySet = await getNip50SearchRelaySet();
       }
 
-      const searchResults = await searchEvents(scopedQuery, 200, undefined, relaySet, abortController.signal);
+      const searchResults = await searchEvents(scopedQuery, 200, {
+        // Re-sort displayed profiles when NIP-05 verifications land after the initial render
+        onProfileResultsUpdate: (updated) => {
+          if (abortController.signal.aborted || currentSearchId.current !== searchId) return;
+          setResults(updated);
+        }
+      }, relaySet, abortController.signal);
 
       // Check if search was aborted after getting results
       if (abortController.signal.aborted || currentSearchId.current !== searchId) {

--- a/src/lib/profile/search.ts
+++ b/src/lib/profile/search.ts
@@ -19,6 +19,8 @@ import { PROFILE_SEARCH_MAX_RESULTS } from '../constants';
 type ProfileSearchCacheEntry = { events: NDKEvent[]; timestamp: number };
 
 const PROFILE_SEARCH_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const NIP05_VERIFY_WAIT_MS = 2500; // max time to wait for NIP-05 verifications before ranking
+const NIP05_FAILED_PENALTY = 150; // outweighs the max NIP-05 string-match bonus in computeMatchScore
 const profileSearchCache = new Map<string, ProfileSearchCacheEntry>();
 
 function makeProfileSearchCacheKey(query: string, loggedIn: boolean): string {
@@ -170,17 +172,26 @@ export async function searchProfilesFullText(term: string, limit: number = PROFI
     };
   });
 
-  // Step 3: don't await verifications; they run in background and update cache when done
+  // Step 3: give scheduled verifications a bounded window to finish so that
+  // ranking can use real results instead of an empty cache on first search
+  if (verifications.length > 0) {
+    const timeout = new Promise<void>((resolve) => setTimeout(resolve, NIP05_VERIFY_WAIT_MS));
+    await Promise.race([Promise.allSettled(verifications).then(() => undefined), timeout]);
+  }
 
   // Step 4: assign final score and sort
   for (const row of enriched) {
-    const verified = row.verifyHint === true
-      ? true
-      : (row.pubkey && row.nip05 ? (getCachedNip05Result(row.pubkey, row.nip05) ?? false) : false);
+    // Actual verification result takes precedence; the self-claimed hint from
+    // profile content is only trusted when no real result is available
+    const actualResult = row.pubkey && row.nip05 ? getCachedNip05Result(row.pubkey, row.nip05) : null;
+    const verified = actualResult ?? (row.verifyHint === true);
     let score = row.baseScore;
     if (verified) score += 100;
     // Additional bonus for verified root NIP-05s (double checkmark)
     if (verified && row.nip05 && isRootNip05(row.nip05)) score += 50;
+    // Claimed NIP-05 that failed verification is an impersonation signal:
+    // cancel the string-match bonus the bogus identifier earned
+    if (actualResult === false) score -= NIP05_FAILED_PENALTY;
     const updatedNutzap = row.pubkey ? getCachedLightningFlag(row.pubkey, LIGHTNING_FLAGS.NUTZAP) : undefined;
     const updatedZap = row.pubkey ? getCachedLightningFlag(row.pubkey, LIGHTNING_FLAGS.ZAP) : undefined;
     const hasNutzap = updatedNutzap ?? row.hasNutzap;

--- a/src/lib/profile/search.ts
+++ b/src/lib/profile/search.ts
@@ -19,7 +19,7 @@ import { PROFILE_SEARCH_MAX_RESULTS } from '../constants';
 type ProfileSearchCacheEntry = { events: NDKEvent[]; timestamp: number };
 
 const PROFILE_SEARCH_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
-const NIP05_VERIFY_WAIT_MS = 2500; // max time to wait for NIP-05 verifications before ranking
+const NIP05_RERANK_TIMEOUT_MS = 8000; // max time to wait for NIP-05 verifications before the background re-rank
 const NIP05_FAILED_PENALTY = 150; // outweighs the max NIP-05 string-match bonus in computeMatchScore
 const profileSearchCache = new Map<string, ProfileSearchCacheEntry>();
 
@@ -41,8 +41,14 @@ function setCachedProfileSearch(key: string, events: NDKEvent[]): void {
   profileSearchCache.set(key, { events: events.slice(), timestamp: Date.now() });
 }
 
-// Full-text profile search with ranking
-export async function searchProfilesFullText(term: string, limit: number = PROFILE_SEARCH_MAX_RESULTS): Promise<NDKEvent[]> {
+// Full-text profile search with ranking. Returns immediately with the best
+// ranking available; when pending NIP-05 verifications land, re-ranks and
+// notifies the caller via onUpdate so the UI can re-sort.
+export async function searchProfilesFullText(
+  term: string,
+  limit: number = PROFILE_SEARCH_MAX_RESULTS,
+  onUpdate?: (events: NDKEvent[]) => void
+): Promise<NDKEvent[]> {
   const query = term.trim();
   if (!query) return [];
 
@@ -172,69 +178,79 @@ export async function searchProfilesFullText(term: string, limit: number = PROFI
     };
   });
 
-  // Step 3: give scheduled verifications a bounded window to finish so that
-  // ranking can use real results instead of an empty cache on first search
-  if (verifications.length > 0) {
-    const timeout = new Promise<void>((resolve) => setTimeout(resolve, NIP05_VERIFY_WAIT_MS));
-    await Promise.race([Promise.allSettled(verifications).then(() => undefined), timeout]);
-  }
-
-  // Step 4: assign final score and sort
-  for (const row of enriched) {
-    // Actual verification result takes precedence; the self-claimed hint from
-    // profile content is only trusted when no real result is available
-    const actualResult = row.pubkey && row.nip05 ? getCachedNip05Result(row.pubkey, row.nip05) : null;
-    const verified = actualResult ?? (row.verifyHint === true);
-    let score = row.baseScore;
-    if (verified) score += 100;
-    // Additional bonus for verified root NIP-05s (double checkmark)
-    if (verified && row.nip05 && isRootNip05(row.nip05)) score += 50;
-    // Claimed NIP-05 that failed verification is an impersonation signal:
-    // cancel the string-match bonus the bogus identifier earned
-    if (actualResult === false) score -= NIP05_FAILED_PENALTY;
-    const updatedNutzap = row.pubkey ? getCachedLightningFlag(row.pubkey, LIGHTNING_FLAGS.NUTZAP) : undefined;
-    const updatedZap = row.pubkey ? getCachedLightningFlag(row.pubkey, LIGHTNING_FLAGS.ZAP) : undefined;
-    const hasNutzap = updatedNutzap ?? row.hasNutzap;
-    const hasZap = updatedZap ?? row.hasZap;
-    row.hasNutzap = hasNutzap;
-    row.hasZap = hasZap;
-    if (hasNutzap) score += 150;
-    else if (hasZap) score += 40;
-    if (row.isFriend) score += 50;
-    row.finalScore = score;
-    row.verified = verified;
-  }
-
-  enriched.sort((a, b) => {
-    const as = a.finalScore || 0;
-    const bs = b.finalScore || 0;
-    if (as !== bs) return bs - as;
-    // Tie-breakers: friend first, then name lexicographically
-    if (a.isFriend !== b.isFriend) return a.isFriend ? -1 : 1;
-    return (a.name || '').localeCompare(b.name || '');
-  });
-
-  // Step 5: prepend Vertex results, then append ranked fallback, dedup by pubkey
-  const seen = new Set<string>();
-  const ordered: NDKEvent[] = [];
-
-  const pushIfNew = (evt: NDKEvent) => {
-    const pk = evt.pubkey || evt.author?.pubkey || '';
-    if (!pk || seen.has(pk)) return;
-    seen.add(pk);
-    if (!evt.kind) evt.kind = 0;
-    if (!evt.author && pk) {
-      const user = new NDKUser({ pubkey: pk });
-      user.ndk = evt.ndk;
-      evt.author = user;
+  // Step 3: score, sort and dedupe with whatever verification results are
+  // available in the cache right now
+  const rankAndOrder = (): NDKEvent[] => {
+    for (const row of enriched) {
+      // Actual verification result takes precedence; the self-claimed hint from
+      // profile content is only trusted when no real result is available
+      const actualResult = row.pubkey && row.nip05 ? getCachedNip05Result(row.pubkey, row.nip05) : null;
+      const verified = actualResult ?? (row.verifyHint === true);
+      let score = row.baseScore;
+      if (verified) score += 100;
+      // Additional bonus for verified root NIP-05s (double checkmark)
+      if (verified && row.nip05 && isRootNip05(row.nip05)) score += 50;
+      // Claimed NIP-05 that failed verification is an impersonation signal:
+      // cancel the string-match bonus the bogus identifier earned
+      if (actualResult === false) score -= NIP05_FAILED_PENALTY;
+      const updatedNutzap = row.pubkey ? getCachedLightningFlag(row.pubkey, LIGHTNING_FLAGS.NUTZAP) : undefined;
+      const updatedZap = row.pubkey ? getCachedLightningFlag(row.pubkey, LIGHTNING_FLAGS.ZAP) : undefined;
+      const hasNutzap = updatedNutzap ?? row.hasNutzap;
+      const hasZap = updatedZap ?? row.hasZap;
+      row.hasNutzap = hasNutzap;
+      row.hasZap = hasZap;
+      if (hasNutzap) score += 150;
+      else if (hasZap) score += 40;
+      if (row.isFriend) score += 50;
+      row.finalScore = score;
+      row.verified = verified;
     }
-    ordered.push(evt);
+
+    const sorted = enriched.slice().sort((a, b) => {
+      const as = a.finalScore || 0;
+      const bs = b.finalScore || 0;
+      if (as !== bs) return bs - as;
+      // Tie-breakers: friend first, then name lexicographically
+      if (a.isFriend !== b.isFriend) return a.isFriend ? -1 : 1;
+      return (a.name || '').localeCompare(b.name || '');
+    });
+
+    const seen = new Set<string>();
+    const ordered: NDKEvent[] = [];
+
+    for (const row of sorted) {
+      const evt = row.event;
+      const pk = evt.pubkey || evt.author?.pubkey || '';
+      if (!pk || seen.has(pk)) continue;
+      seen.add(pk);
+      if (!evt.kind) evt.kind = 0;
+      if (!evt.author && pk) {
+        const user = new NDKUser({ pubkey: pk });
+        user.ndk = evt.ndk;
+        evt.author = user;
+      }
+      ordered.push(evt);
+    }
+
+    return ordered;
   };
 
-  for (const row of enriched) {
-    pushIfNew(row.event);
+  const initial = rankAndOrder();
+  setCachedProfileSearch(cacheKey, initial);
+
+  // Step 4: once pending verifications settle (bounded), re-rank in the
+  // background and notify the caller so the UI can re-sort
+  if (verifications.length > 0) {
+    const timeout = new Promise<void>((resolve) => setTimeout(resolve, NIP05_RERANK_TIMEOUT_MS));
+    void Promise.race([Promise.allSettled(verifications).then(() => undefined), timeout]).then(() => {
+      const updated = rankAndOrder();
+      setCachedProfileSearch(cacheKey, updated);
+      const orderChanged =
+        updated.length !== initial.length ||
+        updated.some((evt, idx) => evt.pubkey !== initial[idx]?.pubkey);
+      if (onUpdate && orderChanged) onUpdate(updated.slice(0, limit));
+    });
   }
 
-  setCachedProfileSearch(cacheKey, ordered);
-  return ordered.slice(0, limit);
+  return initial.slice(0, limit);
 }

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -46,6 +46,9 @@ export async function searchEvents(
   // Check if this is a streaming search
   const isStreaming = options && 'streaming' in options && options.streaming;
   const streamingOptions = isStreaming ? options as StreamingSearchOptions : undefined;
+  const onProfileResultsUpdate = options && 'onProfileResultsUpdate' in options
+    ? (options as StreamingSearchOptions).onProfileResultsUpdate
+    : undefined;
 
   // Extract NIP-50 extensions first
   const nip50Extraction = extractNip50Extensions(query);
@@ -87,7 +90,8 @@ export async function searchEvents(
     streamingOptions,
     abortSignal,
     limit,
-    extensionFilters
+    extensionFilters,
+    onProfileResultsUpdate
   };
 
   // Distribute parenthesized OR seeds across the entire query BEFORE any specialized handling

--- a/src/lib/search/strategies/profileSearchStrategy.ts
+++ b/src/lib/search/strategies/profileSearchStrategy.ts
@@ -13,8 +13,6 @@ export async function tryHandleProfileSearch(
   query: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  // Context parameter kept for strategy interface consistency
-  void context;
   const fullProfileMatch = query.match(/^p:(.+)$/i);
   if (fullProfileMatch) {
     const term = (fullProfileMatch[1] || '').trim();
@@ -56,17 +54,25 @@ export async function tryHandleProfileSearch(
     const domainLike = /^[^\s@]+\.[^\s@]+$/.test(term);
     if (domainLike) {
       try {
-        const profiles = await searchProfilesFullText(term);
+        const domainLower = term.toLowerCase();
+        const filterByDomain = (profiles: NDKEvent[]): NDKEvent[] => {
+          const filtered = profiles.filter((evt) => {
+            const nip05 = (evt.author as { profile?: { nip05?: string } } | undefined)?.profile?.nip05;
+            if (!nip05) return false;
+            return getNip05Domain(nip05) === domainLower;
+          });
+          return filtered.length > 0 ? filtered : profiles;
+        };
+
+        const onUpdate = context.onProfileResultsUpdate;
+        const profiles = await searchProfilesFullText(
+          term,
+          undefined,
+          onUpdate ? (updated) => onUpdate(filterByDomain(updated)) : undefined
+        );
         if (profiles.length === 0) return [];
 
-        const domainLower = term.toLowerCase();
-        const filtered = profiles.filter((evt) => {
-          const nip05 = (evt.author as { profile?: { nip05?: string } } | undefined)?.profile?.nip05;
-          if (!nip05) return false;
-          return getNip05Domain(nip05) === domainLower;
-        });
-
-        return (filtered.length > 0 ? filtered : profiles);
+        return filterByDomain(profiles);
       } catch (error) {
         console.warn('Domain-based profile search failed:', error);
         return [];
@@ -75,7 +81,7 @@ export async function tryHandleProfileSearch(
 
     // Otherwise, do a general full-text profile search
     try {
-      const profiles = await searchProfilesFullText(term);
+      const profiles = await searchProfilesFullText(term, undefined, context.onProfileResultsUpdate);
       return profiles;
     } catch (error) {
       console.warn('Full-text profile search failed:', error);

--- a/src/lib/search/types.ts
+++ b/src/lib/search/types.ts
@@ -8,6 +8,8 @@ export interface StreamingSearchOptions {
   maxResults?: number;
   timeoutMs?: number;
   onResults?: (results: NDKEvent[], isComplete: boolean) => void;
+  // Called when profile search results are re-ranked after NIP-05 verifications land
+  onProfileResultsUpdate?: (results: NDKEvent[]) => void;
 }
 
 // Context passed to search strategies
@@ -22,6 +24,7 @@ export interface SearchContext {
   abortSignal?: AbortSignal;
   limit: number;
   extensionFilters?: Array<(content: string) => boolean>;
+  onProfileResultsUpdate?: (results: NDKEvent[]) => void;
 }
 
 // Extend filter type to include tag queries for "t" (hashtags) and "a" (replaceable events)


### PR DESCRIPTION
Follow-up to #284. Profile search ranking treated NIP-05 as a pure string match: verifications were fired off in the background but their results never influenced ranking, and a claimed-but-invalid NIP-05 kept the full string-match bonus it earned. Impersonators claiming `_@dergigi.com` could therefore outrank the real profile. Ranking in `searchProfilesFullText` now penalizes failed claims and re-ranks as verification results land: results render immediately with the best available ranking, then re-sort in place once pending verifications settle.

- Prefer the actual verification result over the self-claimed `verified` hint in profile content
- Subtract a penalty (`-150`, outweighing the max NIP-05 string bonus) when a claimed NIP-05 fails verification
- Render immediately and re-rank in the background, propagated to the UI via a new `onProfileResultsUpdate` callback in the search context

Build preview:
- [/?q=p:dergigi](https://ants-git-fix-profile-scoring-dergigis-projects.vercel.app/?q=p:dergigi)
