### PR TITLE
Stream search results as relays respond

### DIFF
--- a/src/hooks/useSearchExecution.ts
+++ b/src/hooks/useSearchExecution.ts
@@ -269,12 +269,16 @@ export function useSearchExecution(options: SearchExecutionOptions) {
         relaySet = await getNip50SearchRelaySet();
       }
 
+      // Render results as they arrive; the awaited final result overwrites them
+      const applyPartialResults = (updated: NDKEvent[]) => {
+        if (abortController.signal.aborted || currentSearchId.current !== searchId) return;
+        setResults(updated);
+      };
+
       const searchResults = await searchEvents(scopedQuery, 200, {
+        onPartialResults: applyPartialResults,
         // Re-sort displayed profiles when NIP-05 verifications land after the initial render
-        onProfileResultsUpdate: (updated) => {
-          if (abortController.signal.aborted || currentSearchId.current !== searchId) return;
-          setResults(updated);
-        }
+        onProfileResultsUpdate: applyPartialResults
       }, relaySet, abortController.signal);
 
       // Check if search was aborted after getting results

--- a/src/hooks/useSearchExecution.ts
+++ b/src/hooks/useSearchExecution.ts
@@ -270,16 +270,22 @@ export function useSearchExecution(options: SearchExecutionOptions) {
       }
 
       // Render results as they arrive; the awaited final result overwrites them
+      let searchSettled = false;
       const applyPartialResults = (updated: NDKEvent[]) => {
         if (abortController.signal.aborted || currentSearchId.current !== searchId) return;
         setResults(updated);
       };
 
       const searchResults = await searchEvents(scopedQuery, 200, {
-        onPartialResults: applyPartialResults,
+        // Ignore throttled partials that flush after the final result landed
+        onPartialResults: (updated) => {
+          if (searchSettled) return;
+          applyPartialResults(updated);
+        },
         // Re-sort displayed profiles when NIP-05 verifications land after the initial render
         onProfileResultsUpdate: applyPartialResults
       }, relaySet, abortController.signal);
+      searchSettled = true;
 
       // Check if search was aborted after getting results
       if (abortController.signal.aborted || currentSearchId.current !== searchId) {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -94,7 +94,10 @@ export const UI_CONFIG = {
     PING_TIMEOUT: 5000, // 5 seconds
     
     // Cache duration for relay info (milliseconds)
-    INFO_CACHE_DURATION: 60000, // 1 minute
+    INFO_CACHE_DURATION: 3600000, // 1 hour
+
+    // Cache duration for failed relay info lookups (milliseconds)
+    INFO_NEGATIVE_CACHE_DURATION: 600000, // 10 minutes
     
     // User relay cache duration (milliseconds)
     USER_RELAY_CACHE_DURATION: 3600000, // 1 hour
@@ -147,6 +150,7 @@ export const RELAY_INFO_CHECK_TIMEOUT = UI_CONFIG.RELAYS.INFO_CHECK_TIMEOUT;
 export const RELAY_HTTP_REQUEST_TIMEOUT = UI_CONFIG.RELAYS.HTTP_REQUEST_TIMEOUT;
 export const RELAY_PING_TIMEOUT = UI_CONFIG.RELAYS.PING_TIMEOUT;
 export const RELAY_INFO_CACHE_DURATION = UI_CONFIG.RELAYS.INFO_CACHE_DURATION;
+export const RELAY_INFO_NEGATIVE_CACHE_DURATION = UI_CONFIG.RELAYS.INFO_NEGATIVE_CACHE_DURATION;
 export const RELAY_USER_RELAY_CACHE_DURATION = UI_CONFIG.RELAYS.USER_RELAY_CACHE_DURATION;
 
 // UI refresh constants

--- a/src/lib/relays/infoCache.ts
+++ b/src/lib/relays/infoCache.ts
@@ -2,6 +2,7 @@ import { ndk } from '../ndk';
 import { hasLocalStorage, loadMapFromStorage, saveMapToStorage, clearStorageKey } from '../storageCache';
 import {
   RELAY_INFO_CACHE_DURATION,
+  RELAY_INFO_NEGATIVE_CACHE_DURATION,
   RELAY_INFO_CHECK_TIMEOUT,
   RELAY_HTTP_REQUEST_TIMEOUT
 } from '../constants';
@@ -15,10 +16,16 @@ export type RelayInfo = {
   version?: string;
 };
 
+type CachedRelayInfo = RelayInfo & { timestamp: number; failed?: boolean };
+
 // Cache for relay information (complete NIP-11 data)
-export const relayInfoCache = new Map<string, RelayInfo & { timestamp: number }>();
+export const relayInfoCache = new Map<string, CachedRelayInfo>();
 const CACHE_DURATION_MS = RELAY_INFO_CACHE_DURATION;
+const NEGATIVE_CACHE_DURATION_MS = RELAY_INFO_NEGATIVE_CACHE_DURATION;
 const CACHE_STORAGE_KEY = 'ants_relay_info_cache';
+
+// Dedupe concurrent lookups per relay
+const inFlightLookups = new Map<string, Promise<RelayInfo>>();
 
 // Load cache from localStorage on initialization (browser only)
 function loadCacheFromStorage(): void {
@@ -47,55 +54,78 @@ if (hasLocalStorage()) {
   loadCacheFromStorage();
 }
 
-// Get complete relay information using multiple detection methods
+// Get complete relay information using multiple detection methods.
+// Stale-while-revalidate: a cached entry (even expired) is returned
+// immediately and refreshed in the background; only relays never seen
+// before block on the HTTP check. Failed lookups are negative-cached
+// so dead relays don't delay every search.
 export async function getRelayInfo(relayUrl: string): Promise<RelayInfo> {
-  try {
-    // Check cache first
-    const cached = relayInfoCache.get(relayUrl);
-    if (cached && (Date.now() - cached.timestamp) < CACHE_DURATION_MS) {
-      return cached;
+  const cached = relayInfoCache.get(relayUrl);
+  if (cached) {
+    const ttl = cached.failed ? NEGATIVE_CACHE_DURATION_MS : CACHE_DURATION_MS;
+    if ((Date.now() - cached.timestamp) >= ttl) {
+      void refreshRelayInfo(relayUrl);
     }
-
-    // Add a global timeout for the entire relay info checking process
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      setTimeout(() => reject(new Error('Relay info check timeout')), RELAY_INFO_CHECK_TIMEOUT);
-    });
-
-    const relayInfoPromise = (async () => {
-      // Method 1: Check NDK's cached relay info
-      const relay = ndk.pool?.relays?.get(relayUrl);
-      if (relay) {
-        // Check if relay has info cached from NIP-11
-        const relayInfo = (relay as { info?: { supported_nips?: number[] } }).info;
-        if (relayInfo && relayInfo.supported_nips) {
-          const result = { supportedNips: relayInfo.supported_nips };
-          // Cache this result
-          relayInfoCache.set(relayUrl, { ...result, timestamp: Date.now() });
-          saveCacheToStorage();
-          return result;
-        }
-      }
-
-      // Method 2: Try HTTP NIP-11 detection as fallback
-      const httpResult = await checkRelayInfoViaHttp(relayUrl);
-
-      if (httpResult && (httpResult.supportedNips?.length || httpResult.name || httpResult.description)) {
-        // Cache this result
-        relayInfoCache.set(relayUrl, { ...httpResult, timestamp: Date.now() });
-        saveCacheToStorage();
-        return httpResult;
-      }
-
-      // no relay info found
-      return {};
-    })();
-
-    // Race between the relay info promise and the timeout
-    return await Promise.race([relayInfoPromise, timeoutPromise]);
-  } catch (error) {
-    console.warn(`Failed to get relay info for ${relayUrl}:`, error);
-    return {};
+    return cached;
   }
+  return refreshRelayInfo(relayUrl);
+}
+
+function refreshRelayInfo(relayUrl: string): Promise<RelayInfo> {
+  const existing = inFlightLookups.get(relayUrl);
+  if (existing) return existing;
+
+  const lookup = (async (): Promise<RelayInfo> => {
+    try {
+      // Add a global timeout for the entire relay info checking process
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error('Relay info check timeout')), RELAY_INFO_CHECK_TIMEOUT);
+      });
+
+      const relayInfoPromise = (async () => {
+        // Method 1: Check NDK's cached relay info
+        const relay = ndk.pool?.relays?.get(relayUrl);
+        if (relay) {
+          // Check if relay has info cached from NIP-11
+          const relayInfo = (relay as { info?: { supported_nips?: number[] } }).info;
+          if (relayInfo && relayInfo.supported_nips) {
+            const result = { supportedNips: relayInfo.supported_nips };
+            cacheRelayInfo(relayUrl, result, false);
+            return result;
+          }
+        }
+
+        // Method 2: Try HTTP NIP-11 detection as fallback
+        const httpResult = await checkRelayInfoViaHttp(relayUrl);
+
+        if (httpResult && (httpResult.supportedNips?.length || httpResult.name || httpResult.description)) {
+          cacheRelayInfo(relayUrl, httpResult, false);
+          return httpResult;
+        }
+
+        // No relay info found: negative-cache so we don't re-check on every search
+        cacheRelayInfo(relayUrl, {}, true);
+        return {};
+      })();
+
+      // Race between the relay info promise and the timeout
+      return await Promise.race([relayInfoPromise, timeoutPromise]);
+    } catch (error) {
+      console.warn(`Failed to get relay info for ${relayUrl}:`, error);
+      cacheRelayInfo(relayUrl, {}, true);
+      return {};
+    } finally {
+      inFlightLookups.delete(relayUrl);
+    }
+  })();
+
+  inFlightLookups.set(relayUrl, lookup);
+  return lookup;
+}
+
+function cacheRelayInfo(relayUrl: string, info: RelayInfo, failed: boolean): void {
+  relayInfoCache.set(relayUrl, { ...info, timestamp: Date.now(), ...(failed && { failed }) });
+  saveCacheToStorage();
 }
 
 // Check relay information via HTTP (NIP-11 compatible)

--- a/src/lib/relays/infoCache.ts
+++ b/src/lib/relays/infoCache.ts
@@ -98,7 +98,17 @@ function refreshRelayInfo(relayUrl: string): Promise<RelayInfo> {
         // Method 2: Try HTTP NIP-11 detection as fallback
         const httpResult = await checkRelayInfoViaHttp(relayUrl);
 
-        if (httpResult && (httpResult.supportedNips?.length || httpResult.name || httpResult.description)) {
+        const hasAnyInfo = Boolean(
+          httpResult && (
+            httpResult.supportedNips?.length ||
+            httpResult.name ||
+            httpResult.description ||
+            httpResult.contact ||
+            httpResult.software ||
+            httpResult.version
+          )
+        );
+        if (hasAnyInfo) {
           cacheRelayInfo(relayUrl, httpResult, false);
           return httpResult;
         }

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -11,16 +11,16 @@ import {
   parseSearchQuery
 } from './search/queryParsing';
 import { getBroadRelaySet } from './search/relayManagement';
-import { subscribeAndStream, subscribeAndCollect } from './search/subscriptions';
+import { subscribeAndCollect, createPartialEmitter } from './search/subscriptions';
 import { runSearchStrategies } from './search/searchOrchestrator';
 import { tryHandleAuthorSearch } from './search/strategies/authorSearchStrategy';
 import { handleParenthesizedOr, handleTopLevelOr } from './search/orQueryHandler';
-import { StreamingSearchOptions, SearchContext } from './search/types';
+import { SearchOptions, SearchContext } from './search/types';
 
 export async function searchEvents(
   query: string,
   limit: number = 200,
-  options?: { exact?: boolean } | StreamingSearchOptions,
+  options?: SearchOptions,
   relaySetOverride?: NDKRelaySet,
   abortSignal?: AbortSignal
 ): Promise<NDKEvent[]> {
@@ -43,12 +43,9 @@ export async function searchEvents(
     throw new Error('Search aborted');
   }
 
-  // Check if this is a streaming search
-  const isStreaming = options && 'streaming' in options && options.streaming;
-  const streamingOptions = isStreaming ? options as StreamingSearchOptions : undefined;
-  const onProfileResultsUpdate = options && 'onProfileResultsUpdate' in options
-    ? (options as StreamingSearchOptions).onProfileResultsUpdate
-    : undefined;
+  // Shared emitter: merges partials across all subscriptions of this search
+  const onPartialResults = createPartialEmitter(options?.onPartialResults);
+  const onProfileResultsUpdate = options?.onProfileResultsUpdate;
 
   // Extract NIP-50 extensions first
   const nip50Extraction = extractNip50Extensions(query);
@@ -86,11 +83,10 @@ export async function searchEvents(
     nip50Extensions,
     chosenRelaySet,
     relaySetOverride,
-    isStreaming: isStreaming || false,
-    streamingOptions,
     abortSignal,
     limit,
     extensionFilters,
+    onPartialResults,
     onProfileResultsUpdate
   };
 
@@ -127,15 +123,12 @@ export async function searchEvents(
       search: searchQuery
     }, dateFilter) as NDKFilter;
 
-    results = isStreaming
-      ? await subscribeAndStream(searchFilter, {
-          timeoutMs: streamingOptions?.timeoutMs || 30000,
-          maxResults: streamingOptions?.maxResults || 1000,
-          onResults: streamingOptions?.onResults,
-          relaySet: chosenRelaySet,
-          abortSignal
-        })
-      : await subscribeAndCollect(searchFilter, 8000, chosenRelaySet, abortSignal);
+    results = await subscribeAndCollect(searchFilter, {
+      timeoutMs: 8000,
+      relaySet: chosenRelaySet,
+      abortSignal,
+      onPartial: onPartialResults
+    });
     // Dedupe by id
     const filtered = results.filter((e, idx, arr) => {
       const firstIdx = arr.findIndex((x) => x.id === e.id);
@@ -151,25 +144,4 @@ export async function searchEvents(
     console.error('Error fetching events:', error);
     return [];
   }
-}
-
-// Convenience function for streaming search
-export async function searchEventsStreaming(
-  query: string,
-  onResults: (results: NDKEvent[], isComplete: boolean) => void,
-  options: {
-    maxResults?: number;
-    timeoutMs?: number;
-    exact?: boolean;
-    relaySetOverride?: NDKRelaySet;
-    abortSignal?: AbortSignal;
-  } = {}
-): Promise<NDKEvent[]> {
-  return searchEvents(query, 1000, {
-    streaming: true,
-    onResults,
-    maxResults: options.maxResults || 1000,
-    timeoutMs: options.timeoutMs || 30000,
-    exact: options.exact
-  }, options.relaySetOverride, options.abortSignal);
 }

--- a/src/lib/search/idLookup.ts
+++ b/src/lib/search/idLookup.ts
@@ -69,7 +69,7 @@ export async function fetchEventByIdentifier(
   }
 
   for (const rs of relaySetsToTry) {
-    const events = await subscribeAndCollect(baseFilter as NDKFilter, 8000, rs, abortSignal);
+    const events = await subscribeAndCollect(baseFilter as NDKFilter, { timeoutMs: 8000, relaySet: rs, abortSignal });
     if (events.length > 0) return events;
   }
   return [];

--- a/src/lib/search/orOptimizations.ts
+++ b/src/lib/search/orOptimizations.ts
@@ -65,7 +65,8 @@ export async function maybeOptimizeByOnlyOrSeeds(
   nip50Extensions: Nip50Extensions | undefined,
   chosenRelaySet: NDKRelaySet,
   abortSignal: AbortSignal | undefined,
-  limit: number
+  limit: number,
+  onPartial?: (events: NDKEvent[]) => void
 ): Promise<NDKEvent[] | null> {
   // Trim and filter empty seeds
   const trimmedSeeds = seeds.map(s => s.trim()).filter(Boolean);
@@ -105,6 +106,6 @@ export async function maybeOptimizeByOnlyOrSeeds(
   }, dateFilter) as NDKFilter;
 
   // Execute single subscription
-  const results = await subscribeAndCollect(filter, 10000, chosenRelaySet, abortSignal);
+  const results = await subscribeAndCollect(filter, { timeoutMs: 10000, relaySet: chosenRelaySet, abortSignal, onPartial });
   return sortEventsNewestFirst(results).slice(0, limit);
 }

--- a/src/lib/search/orQueryHandler.ts
+++ b/src/lib/search/orQueryHandler.ts
@@ -45,7 +45,7 @@ export async function handleParenthesizedOr(
   cleanedQuery: string,
   ctx: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { effectiveKinds, nip50Extensions, chosenRelaySet, abortSignal, limit } = ctx;
+  const { effectiveKinds, nip50Extensions, chosenRelaySet, abortSignal, limit, onPartialResults } = ctx;
   const dateFilter = ctx.dateFilter || {};
 
   const expandedSeeds = expandParenthesizedOr(cleanedQuery).map((seed) => seed.trim()).filter(Boolean);
@@ -68,7 +68,8 @@ export async function handleParenthesizedOr(
     nip50Extensions,
     chosenRelaySet,
     abortSignal,
-    limit
+    limit,
+    onPartialResults
   );
   if (byOnlyResults !== null) {
     return byOnlyResults;
@@ -113,7 +114,7 @@ export async function handleParenthesizedOr(
           : residual;
       }
 
-      const results = await subscribeAndCollect(filter, 10000, chosenRelaySet, abortSignal);
+      const results = await subscribeAndCollect(filter, { timeoutMs: 10000, relaySet: chosenRelaySet, abortSignal, onPartial: onPartialResults });
       return sortEventsNewestFirst(results).slice(0, limit);
     }
   }
@@ -162,7 +163,7 @@ export async function handleParenthesizedOr(
           : residual;
       }
 
-      const results = await subscribeAndCollect(filter, 10000, chosenRelaySet, abortSignal);
+      const results = await subscribeAndCollect(filter, { timeoutMs: 10000, relaySet: chosenRelaySet, abortSignal, onPartial: onPartialResults });
       return sortEventsNewestFirst(results).slice(0, limit);
     }
   }
@@ -184,7 +185,8 @@ export async function handleParenthesizedOr(
     abortSignal,
     nip50Extensions,
     applyDateFilter({ kinds: effectiveKinds }, dateFilter),
-    () => getBroadRelaySet()
+    () => getBroadRelaySet(),
+    onPartialResults
   );
 
   return sortEventsNewestFirst(seedResults).slice(0, limit);
@@ -199,7 +201,7 @@ export async function handleTopLevelOr(
   topLevelOrParts: string[],
   ctx: SearchContext
 ): Promise<NDKEvent[]> {
-  const { effectiveKinds, nip50Extensions, chosenRelaySet, relaySetOverride, abortSignal, limit } = ctx;
+  const { effectiveKinds, nip50Extensions, chosenRelaySet, relaySetOverride, abortSignal, limit, onPartialResults } = ctx;
   const dateFilter = ctx.dateFilter || {};
 
   const normalizedParts = topLevelOrParts
@@ -225,7 +227,8 @@ export async function handleTopLevelOr(
     nip50Extensions,
     chosenRelaySet,
     abortSignal,
-    limit
+    limit,
+    onPartialResults
   );
   if (byOnlyResults !== null) {
     return byOnlyResults;
@@ -246,13 +249,14 @@ export async function handleTopLevelOr(
     abortSignal,
     nip50Extensions,
     applyDateFilter({ kinds: effectiveKinds }, dateFilter),
-    () => getBroadRelaySet()
+    () => getBroadRelaySet(),
+    onPartialResults
   );
 
   // If we got no results and we're using NIP-50 relays, try with broader relay set
   if (orResults.length === 0 && !relaySetOverride) {
     const broadRelaySet = await getBroadRelaySet();
-    orResults = await searchByAnyTerms(normalizedParts, Math.max(limit, 500), broadRelaySet, abortSignal, nip50Extensions, applyDateFilter({ kinds: effectiveKinds }, dateFilter));
+    orResults = await searchByAnyTerms(normalizedParts, Math.max(limit, 500), broadRelaySet, abortSignal, nip50Extensions, applyDateFilter({ kinds: effectiveKinds }, dateFilter), undefined, onPartialResults);
   }
 
   const filteredResults = orResults.filter((evt) => effectiveKinds.length === 0 || effectiveKinds.includes(evt.kind));

--- a/src/lib/search/searchOrchestrator.ts
+++ b/src/lib/search/searchOrchestrator.ts
@@ -20,19 +20,10 @@ export async function runSearchStrategies(
   cleanedQuery: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { isStreaming, streamingOptions, chosenRelaySet, abortSignal, effectiveKinds, nip50Extensions, limit } = context;
+  const { abortSignal } = context;
 
   // URL search: strip protocol and search for domain/path content
-  const urlResults = await tryHandleUrlSearch(
-    cleanedQuery,
-    effectiveKinds,
-    nip50Extensions,
-    limit,
-    isStreaming || false,
-    streamingOptions,
-    chosenRelaySet,
-    abortSignal
-  );
+  const urlResults = await tryHandleUrlSearch(cleanedQuery, context);
   if (urlResults) return urlResults;
 
   // nevent/note/naddr bech32: fetch by NIP-19 identifier

--- a/src/lib/search/searchUtils.ts
+++ b/src/lib/search/searchUtils.ts
@@ -49,4 +49,4 @@ export function buildSearchQueryWithExtensions(baseQuery: string, extensions: Ni
 }
 
 // Re-export the subscription functions from the subscriptions module
-export { subscribeAndStream, subscribeAndCollect } from './subscriptions';
+export { subscribeAndCollect, createPartialEmitter } from './subscriptions';

--- a/src/lib/search/strategies/aTagSearchStrategy.ts
+++ b/src/lib/search/strategies/aTagSearchStrategy.ts
@@ -1,6 +1,6 @@
 import { NDKEvent } from '@nostr-dev-kit/ndk';
 import { applyDateFilter } from '../queryParsing';
-import { subscribeAndStream, subscribeAndCollect } from '../subscriptions';
+import { subscribeAndCollect } from '../subscriptions';
 import { getBroadRelaySet } from '../relayManagement';
 import { sortEventsNewestFirst } from '../../utils/searchUtils';
 import { SearchContext, TagTFilter } from '../types';
@@ -13,7 +13,7 @@ export async function tryHandleATagSearch(
   query: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { effectiveKinds, dateFilter, limit, isStreaming, streamingOptions, abortSignal, extensionFilters } = context;
+  const { effectiveKinds, dateFilter, limit, abortSignal, extensionFilters, onPartialResults } = context;
   
   const aTagMatch = query.match(/^a:(.+)$/i);
   if (aTagMatch) {
@@ -24,15 +24,12 @@ export async function tryHandleATagSearch(
       // Use broader relay set for a tag searches
       const aTagRelaySet = await getBroadRelaySet();
 
-      const results = isStreaming
-        ? await subscribeAndStream(aTagFilter, {
-            timeoutMs: streamingOptions?.timeoutMs || 30000,
-            maxResults: streamingOptions?.maxResults || 1000,
-            onResults: streamingOptions?.onResults,
-            relaySet: aTagRelaySet,
-            abortSignal
-          })
-        : await subscribeAndCollect(aTagFilter, 10000, aTagRelaySet, abortSignal);
+      const results = await subscribeAndCollect(aTagFilter, {
+        timeoutMs: 10000,
+        relaySet: aTagRelaySet,
+        abortSignal,
+        onPartial: onPartialResults
+      });
 
       let final = results;
       if (extensionFilters && extensionFilters.length > 0) {

--- a/src/lib/search/strategies/authorSearchStrategy.ts
+++ b/src/lib/search/strategies/authorSearchStrategy.ts
@@ -65,16 +65,18 @@ export async function tryHandleAuthorSearch(
   if (terms) {
     const seedExpansions3 = expandParenthesizedOr(terms);
     if (seedExpansions3.length > 1) {
-      const seen = new Set<string>();
-      for (const seed of seedExpansions3) {
+      const perSeed = await Promise.all(seedExpansions3.map(async (seed) => {
         try {
           const searchQuery = nip50Extensions 
             ? buildSearchQueryWithExtensions(seed, nip50Extensions)
             : seed;
           const f: NDKFilter = applyDateFilter({ kinds: effectiveKinds, authors: [pubkey], search: searchQuery, limit: Math.max(limit, 200) }, dateFilter) as NDKFilter;
-          const r = await subscribeAndCollect(f, { timeoutMs: 8000, relaySet: chosenRelaySet, abortSignal, onPartial: onPartialResults });
-          for (const e of r) { if (!seen.has(e.id)) { seen.add(e.id); res.push(e); } }
-        } catch {}
+          return await subscribeAndCollect(f, { timeoutMs: 8000, relaySet: chosenRelaySet, abortSignal, onPartial: onPartialResults });
+        } catch { return []; }
+      }));
+      const seen = new Set<string>();
+      for (const r of perSeed) {
+        for (const e of r) { if (!seen.has(e.id)) { seen.add(e.id); res.push(e); } }
       }
     } else {
       res = await subscribeAndCollect(filters, { timeoutMs: 8000, relaySet: chosenRelaySet, abortSignal, onPartial: onPartialResults });

--- a/src/lib/search/strategies/authorSearchStrategy.ts
+++ b/src/lib/search/strategies/authorSearchStrategy.ts
@@ -19,7 +19,7 @@ export async function tryHandleAuthorSearch(
   cleanedQuery: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { effectiveKinds, dateFilter, nip50Extensions, chosenRelaySet, abortSignal, limit } = context;
+  const { effectiveKinds, dateFilter, nip50Extensions, chosenRelaySet, abortSignal, limit, onPartialResults } = context;
   
   const authorMatch = cleanedQuery.match(/(?:^|\s)by:(\S+)(?:\s|$)/i);
   if (!authorMatch) {
@@ -72,15 +72,15 @@ export async function tryHandleAuthorSearch(
             ? buildSearchQueryWithExtensions(seed, nip50Extensions)
             : seed;
           const f: NDKFilter = applyDateFilter({ kinds: effectiveKinds, authors: [pubkey], search: searchQuery, limit: Math.max(limit, 200) }, dateFilter) as NDKFilter;
-          const r = await subscribeAndCollect(f, 8000, chosenRelaySet, abortSignal);
+          const r = await subscribeAndCollect(f, { timeoutMs: 8000, relaySet: chosenRelaySet, abortSignal, onPartial: onPartialResults });
           for (const e of r) { if (!seen.has(e.id)) { seen.add(e.id); res.push(e); } }
         } catch {}
       }
     } else {
-      res = await subscribeAndCollect(filters, 8000, chosenRelaySet, abortSignal);
+      res = await subscribeAndCollect(filters, { timeoutMs: 8000, relaySet: chosenRelaySet, abortSignal, onPartial: onPartialResults });
     }
   } else {
-    res = await subscribeAndCollect(filters, 8000, chosenRelaySet, abortSignal);
+    res = await subscribeAndCollect(filters, { timeoutMs: 8000, relaySet: chosenRelaySet, abortSignal, onPartial: onPartialResults });
   }
 
   // If the remaining terms contain parenthesized OR seeds like (a OR b), run a seeded OR search too
@@ -103,7 +103,8 @@ export async function tryHandleAuthorSearch(
         abortSignal,
         nip50Extensions,
         applyDateFilter({ authors: [pubkey], kinds: effectiveKinds }, dateFilter),
-        () => getBroadRelaySet()
+        () => getBroadRelaySet(),
+        onPartialResults
       );
       res = [...res, ...seeded];
     } catch {}
@@ -112,18 +113,20 @@ export async function tryHandleAuthorSearch(
   const broadRelays = Array.from(new Set<string>([...RELAYS.DEFAULT, ...RELAYS.SEARCH]));
   const broadRelaySet = NDKRelaySet.fromRelayUrls(broadRelays, ndk);
   if (res.length === 0) {
-    res = await subscribeAndCollect(filters, 10000, broadRelaySet, abortSignal);
+    res = await subscribeAndCollect(filters, { timeoutMs: 10000, relaySet: broadRelaySet, abortSignal, onPartial: onPartialResults });
   }
   // Additional fallback for very short terms (e.g., "GM") or stubborn empties:
   // some relays require >=3 chars for NIP-50 search; fetch author-only and filter client-side
   const termStr = terms.trim();
   const hasShortToken = termStr.length > 0 && termStr.split(/\s+/).some((t) => t.length < 3);
+  // No onPartial here: these fetch all author events and filter client-side,
+  // so partials would surface unrelated notes
   if (res.length === 0 && termStr) {
-    const authorOnly = await subscribeAndCollect(applyDateFilter({ kinds: effectiveKinds, authors: [pubkey], limit: Math.max(limit, 600) }, dateFilter) as NDKFilter, 10000, broadRelaySet, abortSignal);
+    const authorOnly = await subscribeAndCollect(applyDateFilter({ kinds: effectiveKinds, authors: [pubkey], limit: Math.max(limit, 600) }, dateFilter) as NDKFilter, { timeoutMs: 10000, relaySet: broadRelaySet, abortSignal });
     const needle = termStr.toLowerCase();
     res = authorOnly.filter((e) => (e.content || '').toLowerCase().includes(needle));
   } else if (res.length === 0 && hasShortToken) {
-    const authorOnly = await subscribeAndCollect(applyDateFilter({ kinds: effectiveKinds, authors: [pubkey], limit: Math.max(limit, 600) }, dateFilter) as NDKFilter, 10000, broadRelaySet, abortSignal);
+    const authorOnly = await subscribeAndCollect(applyDateFilter({ kinds: effectiveKinds, authors: [pubkey], limit: Math.max(limit, 600) }, dateFilter) as NDKFilter, { timeoutMs: 10000, relaySet: broadRelaySet, abortSignal });
     const needle = termStr.toLowerCase();
     res = authorOnly.filter((e) => (e.content || '').toLowerCase().includes(needle));
   }

--- a/src/lib/search/strategies/hashtagSearchStrategy.ts
+++ b/src/lib/search/strategies/hashtagSearchStrategy.ts
@@ -1,6 +1,6 @@
 import { NDKEvent } from '@nostr-dev-kit/ndk';
 import { applyDateFilter } from '../queryParsing';
-import { subscribeAndStream, subscribeAndCollect } from '../subscriptions';
+import { subscribeAndCollect } from '../subscriptions';
 import { getBroadRelaySet } from '../relayManagement';
 import { sortEventsNewestFirst } from '../../utils/searchUtils';
 import { SearchContext, TagTFilter } from '../types';
@@ -13,7 +13,7 @@ export async function tryHandleHashtagSearch(
   query: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { effectiveKinds, dateFilter, limit, isStreaming, streamingOptions, abortSignal, extensionFilters } = context;
+  const { effectiveKinds, dateFilter, limit, abortSignal, extensionFilters, onPartialResults } = context;
   
   const hashtagMatches = query.match(/#[A-Za-z0-9_]+/g) || [];
   const nonHashtagRemainder = query.replace(/#[A-Za-z0-9_]+/g, '').trim();
@@ -25,15 +25,12 @@ export async function tryHandleHashtagSearch(
     // Use broader relay set for hashtag searches - include all available relays
     const tagRelaySet = await getBroadRelaySet();
 
-    const results = isStreaming
-      ? await subscribeAndStream(tagFilter, {
-          timeoutMs: streamingOptions?.timeoutMs || 30000,
-          maxResults: streamingOptions?.maxResults || 1000,
-          onResults: streamingOptions?.onResults,
-          relaySet: tagRelaySet,
-          abortSignal
-        })
-      : await subscribeAndCollect(tagFilter, 10000, tagRelaySet, abortSignal);
+    const results = await subscribeAndCollect(tagFilter, {
+      timeoutMs: 10000,
+      relaySet: tagRelaySet,
+      abortSignal,
+      onPartial: onPartialResults
+    });
 
     let final = results;
     if (extensionFilters && extensionFilters.length > 0) {

--- a/src/lib/search/strategies/identitySearchStrategy.ts
+++ b/src/lib/search/strategies/identitySearchStrategy.ts
@@ -14,7 +14,7 @@ export async function tryHandleIdentitySearch(
   cleanedQuery: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { effectiveKinds, dateFilter, chosenRelaySet, abortSignal, limit } = context;
+  const { effectiveKinds, dateFilter, chosenRelaySet, abortSignal, limit, onPartialResults } = context;
 
   // Check if the query is a direct npub
   if (isNpub(cleanedQuery)) {
@@ -26,7 +26,7 @@ export async function tryHandleIdentitySearch(
         kinds: effectiveKinds,
         authors: [pubkey],
         limit: Math.max(limit, 200)
-      }, dateFilter) as NDKFilter, 8000, chosenRelaySet, abortSignal);
+      }, dateFilter) as NDKFilter, { timeoutMs: 8000, relaySet: chosenRelaySet, abortSignal, onPartial: onPartialResults });
       return sortEventsNewestFirst(res).slice(0, limit);
     } catch (error) {
       console.error('Error processing npub query:', error);

--- a/src/lib/search/strategies/licenseSearchStrategy.ts
+++ b/src/lib/search/strategies/licenseSearchStrategy.ts
@@ -1,6 +1,6 @@
 import { NDKEvent } from '@nostr-dev-kit/ndk';
 import { applyDateFilter } from '../queryParsing';
-import { subscribeAndStream, subscribeAndCollect } from '../subscriptions';
+import { subscribeAndCollect } from '../subscriptions';
 import { getBroadRelaySet } from '../relayManagement';
 import { sortEventsNewestFirst } from '../../utils/searchUtils';
 import { SearchContext, TagTFilter } from '../types';
@@ -13,7 +13,7 @@ export async function tryHandleLicenseSearch(
   query: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { effectiveKinds, dateFilter, limit, isStreaming, streamingOptions, abortSignal, extensionFilters } = context;
+  const { effectiveKinds, dateFilter, limit, abortSignal, extensionFilters, onPartialResults } = context;
   
   const licenseMatches = Array.from(query.match(/\blicense:([^\s)]+)\b/gi) || []).map((m) => m.split(':')[1]?.trim()).filter(Boolean) as string[];
   const nonLicenseRemainder = query.replace(/\blicense:[^\s)]+/gi, '').trim();
@@ -22,15 +22,12 @@ export async function tryHandleLicenseSearch(
     const licenses = Array.from(new Set(licenseMatches.map((v) => v.toUpperCase())));
     const licenseFilter: TagTFilter = applyDateFilter({ kinds: effectiveKinds, '#license': licenses, limit: Math.max(limit, 500) }, dateFilter) as TagTFilter;
     const tagRelaySet = await getBroadRelaySet();
-    const results = isStreaming
-      ? await subscribeAndStream(licenseFilter, {
-          timeoutMs: streamingOptions?.timeoutMs || 30000,
-          maxResults: streamingOptions?.maxResults || 1000,
-          onResults: streamingOptions?.onResults,
-          relaySet: tagRelaySet,
-          abortSignal
-        })
-      : await subscribeAndCollect(licenseFilter, 10000, tagRelaySet, abortSignal);
+    const results = await subscribeAndCollect(licenseFilter, {
+      timeoutMs: 10000,
+      relaySet: tagRelaySet,
+      abortSignal,
+      onPartial: onPartialResults
+    });
     let final = results;
     if (extensionFilters && extensionFilters.length > 0) {
       final = final.filter((e) => extensionFilters.every((f) => f(e.content || '')));

--- a/src/lib/search/strategies/mentionsSearchStrategy.ts
+++ b/src/lib/search/strategies/mentionsSearchStrategy.ts
@@ -48,7 +48,7 @@ export async function tryHandleMentionsSearch(
   cleanedQuery: string,
   context: SearchContext
 ): Promise<NDKEvent[] | null> {
-  const { effectiveKinds, dateFilter, nip50Extensions, chosenRelaySet, abortSignal, limit } = context;
+  const { effectiveKinds, dateFilter, nip50Extensions, chosenRelaySet, abortSignal, limit, onPartialResults } = context;
   const matches = Array.from(cleanedQuery.matchAll(/\bmentions:(\S+)/gi));
   if (matches.length === 0) return null;
 
@@ -92,9 +92,9 @@ export async function tryHandleMentionsSearch(
 
   let results: NDKEvent[];
   try {
-    results = await subscribeAndCollect(filter, 10000, relaySet, abortSignal);
+    results = await subscribeAndCollect(filter, { timeoutMs: 10000, relaySet, abortSignal, onPartial: onPartialResults });
   } catch {
-    results = await subscribeAndCollect(filter, 10000, chosenRelaySet, abortSignal);
+    results = await subscribeAndCollect(filter, { timeoutMs: 10000, relaySet: chosenRelaySet, abortSignal, onPartial: onPartialResults });
   }
 
   const deduped = new Map<string, NDKEvent>();

--- a/src/lib/search/strategies/urlSearchStrategy.ts
+++ b/src/lib/search/strategies/urlSearchStrategy.ts
@@ -1,7 +1,5 @@
 import { NDKEvent } from '@nostr-dev-kit/ndk';
-import { NDKRelaySet } from '@nostr-dev-kit/ndk';
-import { Nip50Extensions } from '../searchUtils';
-import { StreamingSearchOptions } from '../types';
+import { SearchContext } from '../types';
 
 /**
  * Handle URL search queries
@@ -9,33 +7,17 @@ import { StreamingSearchOptions } from '../types';
  */
 export async function tryHandleUrlSearch(
   query: string,
-  effectiveKinds: number[],
-  nip50Extensions: Nip50Extensions | undefined,
-  limit: number,
-  isStreaming: boolean,
-  streamingOptions: StreamingSearchOptions | undefined,
-  chosenRelaySet: NDKRelaySet,
-  abortSignal?: AbortSignal
+  context: SearchContext
 ): Promise<NDKEvent[] | null> {
   try {
     const url = new URL(query);
     if (url.protocol === 'http:' || url.protocol === 'https:') {
       const { searchUrlEvents } = await import('../urlSearch');
-      return await searchUrlEvents(
-        query,
-        effectiveKinds,
-        nip50Extensions || {},
-        limit,
-        isStreaming,
-        streamingOptions,
-        chosenRelaySet,
-        abortSignal
-      );
+      return await searchUrlEvents(query, context);
     }
   } catch {
     // Not a valid URL
   }
-  
+
   return null;
 }
-

--- a/src/lib/search/subscriptions.ts
+++ b/src/lib/search/subscriptions.ts
@@ -11,33 +11,55 @@ export type CollectOptions = {
   timeoutMs?: number;
   relaySet?: NDKRelaySet;
   abortSignal?: AbortSignal;
-  /** Called with the deduped, newest-first sorted events collected so far (throttled). */
+  /**
+   * Called with batches of newly collected events while the subscription is
+   * open. Pass an emitter from createPartialEmitter, which accumulates,
+   * dedupes, sorts, and throttles before notifying the UI.
+   */
   onPartial?: (events: NDKEvent[]) => void;
 };
 
 /**
  * Create a callback that merges partial batches (by event id) across multiple
- * subscriptions and emits the sorted union. Multi-seed paths (OR queries,
- * author fallbacks) share one emitter so partials accumulate instead of
- * clobbering each other.
+ * subscriptions and emits the sorted union, throttled to one emission per
+ * PARTIAL_EMIT_INTERVAL_MS (with a trailing flush so the last batch always
+ * lands). Multi-seed paths (OR queries, author fallbacks) share one emitter
+ * so partials accumulate instead of clobbering each other.
  */
 export function createPartialEmitter(
   onPartialResults?: (events: NDKEvent[]) => void
 ): ((events: NDKEvent[]) => void) | undefined {
   if (!onPartialResults) return undefined;
   const all = new Map<string, NDKEvent>();
+  let lastEmitTime = 0;
+  let trailingTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const flush = () => {
+    lastEmitTime = Date.now();
+    onPartialResults(sortEventsNewestFirst(Array.from(all.values())));
+  };
+
   return (events: NDKEvent[]) => {
     for (const evt of events) {
       if (evt.id && !all.has(evt.id)) all.set(evt.id, evt);
     }
-    onPartialResults(sortEventsNewestFirst(Array.from(all.values())));
+    const elapsed = Date.now() - lastEmitTime;
+    if (elapsed >= PARTIAL_EMIT_INTERVAL_MS) {
+      if (trailingTimer) { clearTimeout(trailingTimer); trailingTimer = null; }
+      flush();
+    } else if (!trailingTimer) {
+      trailingTimer = setTimeout(() => {
+        trailingTimer = null;
+        flush();
+      }, PARTIAL_EMIT_INTERVAL_MS - elapsed);
+    }
   };
 }
 
 /**
  * Collect events from a subscription until EOSE or timeout.
- * When onPartial is provided, partial results are emitted while collecting
- * (throttled) and once more on completion.
+ * When onPartial is provided, newly collected events are forwarded to it
+ * while collecting and once more on completion.
  */
 export async function subscribeAndCollect(filter: NDKFilter, options: CollectOptions = {}): Promise<NDKEvent[]> {
   const { timeoutMs = 8000, relaySet, abortSignal, onPartial } = options;
@@ -57,66 +79,78 @@ export async function subscribeAndCollect(filter: NDKFilter, options: CollectOpt
     }
 
     const collected: Map<string, NDKEvent> = new Map();
-    let lastEmitTime = 0;
     let settled = false;
 
-    const emitPartial = () => {
-      if (!onPartial || settled) return;
-      const now = Date.now();
-      if (now - lastEmitTime < PARTIAL_EMIT_INTERVAL_MS) return;
-      lastEmitTime = now;
-      onPartial(sortEventsNewestFirst(Array.from(collected.values())));
-    };
-
     (async () => {
-      const rs = relaySet || await getSearchRelaySet();
-      const sub = safeSubscribe([filter], { closeOnEose: true, cacheUsage: NDKSubscriptionCacheUsage.ONLY_RELAY, relaySet: rs, __trackFilters: true });
-
-      if (!sub) {
-        console.warn('Failed to create subscription in subscribeAndCollect');
+      let rs: NDKRelaySet;
+      try {
+        rs = relaySet || await getSearchRelaySet();
+      } catch (error) {
+        console.warn('Failed to resolve relay set in subscribeAndCollect:', error);
         resolve([]);
         return;
       }
 
-      const finish = () => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        if (abortSignal) {
-          try { abortSignal.removeEventListener('abort', abortHandler); } catch {}
-        }
-        try { sub.stop(); } catch {}
-        const finalResults = Array.from(collected.values());
-        // Final emission so shared emitters see this subscription's full set
-        if (onPartial && finalResults.length > 0) {
-          onPartial(sortEventsNewestFirst(finalResults));
-        }
-        resolve(finalResults);
-      };
-
-      const timer = setTimeout(finish, timeoutMs);
-      const abortHandler = () => finish();
-
-      if (abortSignal) {
-        abortSignal.addEventListener('abort', abortHandler);
+      // An abort may have fired while awaiting the relay set
+      if (abortSignal?.aborted) {
+        resolve([]);
+        return;
       }
 
-      sub.on('event', (event: NDKEvent, relay: NDKRelay | undefined) => {
-        const relayUrl = relay?.url || 'unknown';
-        if (relayUrl !== 'unknown') {
-          try { markRelayActivity(relayUrl); } catch {}
-        }
-        const normalizedUrl = normalizeRelayUrl(relayUrl);
-        trackEventRelay(event, normalizedUrl);
-        if (!collected.has(event.id)) {
-          collected.set(event.id, event);
-          emitPartial();
-        }
-      });
+      try {
+        const sub = safeSubscribe([filter], { closeOnEose: true, cacheUsage: NDKSubscriptionCacheUsage.ONLY_RELAY, relaySet: rs, __trackFilters: true });
 
-      sub.on('eose', finish);
+        if (!sub) {
+          console.warn('Failed to create subscription in subscribeAndCollect');
+          resolve([]);
+          return;
+        }
 
-      sub.start();
+        const finish = () => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          if (abortSignal) {
+            try { abortSignal.removeEventListener('abort', abortHandler); } catch {}
+          }
+          try { sub.stop(); } catch {}
+          const finalResults = Array.from(collected.values());
+          // Final emission so shared emitters see this subscription's full set
+          if (onPartial && finalResults.length > 0) {
+            onPartial(finalResults);
+          }
+          resolve(finalResults);
+        };
+
+        const timer = setTimeout(finish, timeoutMs);
+        const abortHandler = () => finish();
+
+        if (abortSignal) {
+          abortSignal.addEventListener('abort', abortHandler);
+        }
+
+        sub.on('event', (event: NDKEvent, relay: NDKRelay | undefined) => {
+          const relayUrl = relay?.url || 'unknown';
+          if (relayUrl !== 'unknown') {
+            try { markRelayActivity(relayUrl); } catch {}
+          }
+          const normalizedUrl = normalizeRelayUrl(relayUrl);
+          trackEventRelay(event, normalizedUrl);
+          if (!collected.has(event.id)) {
+            collected.set(event.id, event);
+            // Throttling happens in the shared emitter (createPartialEmitter)
+            if (onPartial && !settled) onPartial([event]);
+          }
+        });
+
+        sub.on('eose', finish);
+
+        sub.start();
+      } catch (error) {
+        console.warn('subscribeAndCollect setup failed:', error);
+        settled = true;
+        resolve(Array.from(collected.values()));
+      }
     })();
   });
 }

--- a/src/lib/search/subscriptions.ts
+++ b/src/lib/search/subscriptions.ts
@@ -5,152 +5,43 @@ import { trackEventRelay } from '../eventRelayTracking';
 import { sortEventsNewestFirst } from '../utils/searchUtils';
 import { getSearchRelaySet } from './relayManagement';
 
+const PARTIAL_EMIT_INTERVAL_MS = 500;
+
+export type CollectOptions = {
+  timeoutMs?: number;
+  relaySet?: NDKRelaySet;
+  abortSignal?: AbortSignal;
+  /** Called with the deduped, newest-first sorted events collected so far (throttled). */
+  onPartial?: (events: NDKEvent[]) => void;
+};
+
 /**
- * Streaming subscription that keeps connections open and streams results
+ * Create a callback that merges partial batches (by event id) across multiple
+ * subscriptions and emits the sorted union. Multi-seed paths (OR queries,
+ * author fallbacks) share one emitter so partials accumulate instead of
+ * clobbering each other.
  */
-export async function subscribeAndStream(
-  filter: NDKFilter, 
-  options: {
-    timeoutMs?: number;
-    maxResults?: number;
-    onResults?: (results: NDKEvent[], isComplete: boolean) => void;
-    relaySet?: NDKRelaySet;
-    abortSignal?: AbortSignal;
-  } = {}
-): Promise<NDKEvent[]> {
-  const { timeoutMs = 30000, maxResults = 1000, onResults, relaySet, abortSignal } = options;
-  const rs = relaySet || await getSearchRelaySet();
-  
-  return new Promise<NDKEvent[]>((resolve) => {
-    // Check if already aborted
-    if (abortSignal?.aborted) {
-      resolve([]);
-      return;
+export function createPartialEmitter(
+  onPartialResults?: (events: NDKEvent[]) => void
+): ((events: NDKEvent[]) => void) | undefined {
+  if (!onPartialResults) return undefined;
+  const all = new Map<string, NDKEvent>();
+  return (events: NDKEvent[]) => {
+    for (const evt of events) {
+      if (evt.id && !all.has(evt.id)) all.set(evt.id, evt);
     }
-
-    // Validate filter
-    if (!isValidFilter(filter)) {
-      console.warn('Invalid filter passed to subscribeAndStream, returning empty results');
-      resolve([]);
-      return;
-    }
-
-    const collected: Map<string, NDKEvent> = new Map();
-    let isComplete = false;
-    let lastEmitTime = 0;
-    const emitInterval = 500; // Emit results every 500ms
-
-    // Remove limit from filter for streaming - we'll handle it ourselves
-    const streamingFilter = { ...filter };
-    delete streamingFilter.limit;
-
-    // Validate the streaming filter after modification
-    if (!isValidFilter(streamingFilter)) {
-      console.warn('Streaming filter became invalid after removing limit, returning empty results');
-      resolve([]);
-      return;
-    }
-
-    const sub = safeSubscribe([streamingFilter], { 
-      closeOnEose: false, // Keep connection open!
-      cacheUsage: NDKSubscriptionCacheUsage.ONLY_RELAY, 
-      relaySet: rs,
-      __trackFilters: true
-    });
-
-    if (!sub) {
-      console.warn('Failed to create subscription in subscribeAndStream');
-      resolve([]);
-      return;
-    }
-
-    const timer = setTimeout(() => {
-      isComplete = true;
-      try { sub.stop(); } catch {}
-      // Final emit before resolving
-      const sortedResults = sortEventsNewestFirst(Array.from(collected.values()));
-      if (onResults) {
-        onResults(sortedResults, true);
-      }
-      resolve(sortedResults);
-    }, timeoutMs);
-
-    // Handle abort signal
-    const abortHandler = () => {
-      isComplete = true;
-      try { sub.stop(); } catch {}
-      clearTimeout(timer);
-      if (abortSignal) {
-        try { abortSignal.removeEventListener('abort', abortHandler); } catch {}
-      }
-      const sortedResults = sortEventsNewestFirst(Array.from(collected.values()));
-      if (onResults) {
-        onResults(sortedResults, true);
-      }
-      resolve(sortedResults);
-    };
-
-    if (abortSignal) {
-      abortSignal.addEventListener('abort', abortHandler);
-    }
-
-    // Periodic emission of results
-    const emitResults = () => {
-      if (onResults && !isComplete) {
-        const now = Date.now();
-        if (now - lastEmitTime >= emitInterval) {
-          const sortedResults = sortEventsNewestFirst(Array.from(collected.values()));
-          onResults(sortedResults, false);
-          lastEmitTime = now;
-        }
-      }
-    };
-
-    sub.on('event', (event: NDKEvent, relay: NDKRelay | undefined) => {
-      const relayUrl = relay?.url || 'unknown';
-      // Mark this relay as active
-      if (relayUrl !== 'unknown') {
-        try { markRelayActivity(relayUrl); } catch {}
-      }
-      
-      if (!collected.has(event.id)) {
-        // Track this event's relay source
-        trackEventRelay(event, relayUrl);
-        collected.set(event.id, event);
-        
-        // Check if we've hit max results
-        if (maxResults && collected.size >= maxResults) {
-          isComplete = true;
-          try { sub.stop(); } catch {}
-          clearTimeout(timer);
-          const sortedResults = sortEventsNewestFirst(Array.from(collected.values()));
-          if (onResults) {
-            onResults(sortedResults, true);
-          }
-          resolve(sortedResults);
-          return;
-        }
-        
-        // Emit results periodically
-        emitResults();
-      } else {
-        // Event already exists, track this additional relay source
-        trackEventRelay(event, relayUrl);
-      }
-    });
-
-    sub.on('eose', () => {
-      // Keep streaming after EOSE
-    });
-    
-    sub.start();
-  });
+    onPartialResults(sortEventsNewestFirst(Array.from(all.values())));
+  };
 }
 
 /**
- * Collect events from a subscription until EOSE or timeout
+ * Collect events from a subscription until EOSE or timeout.
+ * When onPartial is provided, partial results are emitted while collecting
+ * (throttled) and once more on completion.
  */
-export async function subscribeAndCollect(filter: NDKFilter, timeoutMs: number = 8000, relaySet?: NDKRelaySet, abortSignal?: AbortSignal): Promise<NDKEvent[]> {
+export async function subscribeAndCollect(filter: NDKFilter, options: CollectOptions = {}): Promise<NDKEvent[]> {
+  const { timeoutMs = 8000, relaySet, abortSignal, onPartial } = options;
+
   return new Promise<NDKEvent[]>((resolve) => {
     // Check if already aborted
     if (abortSignal?.aborted) {
@@ -166,59 +57,66 @@ export async function subscribeAndCollect(filter: NDKFilter, timeoutMs: number =
     }
 
     const collected: Map<string, NDKEvent> = new Map();
+    let lastEmitTime = 0;
+    let settled = false;
+
+    const emitPartial = () => {
+      if (!onPartial || settled) return;
+      const now = Date.now();
+      if (now - lastEmitTime < PARTIAL_EMIT_INTERVAL_MS) return;
+      lastEmitTime = now;
+      onPartial(sortEventsNewestFirst(Array.from(collected.values())));
+    };
 
     (async () => {
       const rs = relaySet || await getSearchRelaySet();
       const sub = safeSubscribe([filter], { closeOnEose: true, cacheUsage: NDKSubscriptionCacheUsage.ONLY_RELAY, relaySet: rs, __trackFilters: true });
-    
+
       if (!sub) {
         console.warn('Failed to create subscription in subscribeAndCollect');
         resolve([]);
         return;
       }
-    const timer = setTimeout(() => {
-      try { sub.stop(); } catch {}
-      const finalResults = Array.from(collected.values());
-      resolve(finalResults);
-    }, timeoutMs);
 
-    // Handle abort signal
-    const abortHandler = () => {
-      try { sub.stop(); } catch {}
-      clearTimeout(timer);
-      if (abortSignal) {
-        try { abortSignal.removeEventListener('abort', abortHandler); } catch {}
-      }
-      // Resolve with whatever we have so far (partial results) instead of rejecting
-      resolve(Array.from(collected.values()));
-    };
-
-    if (abortSignal) {
-      abortSignal.addEventListener('abort', abortHandler);
-    }
-
-    sub.on('event', (event: NDKEvent, relay: NDKRelay | undefined) => {
-      const relayUrl = relay?.url || 'unknown';
-      if (relayUrl !== 'unknown') {
-        try { markRelayActivity(relayUrl); } catch {}
-      }
-      const normalizedUrl = normalizeRelayUrl(relayUrl);
-      trackEventRelay(event, normalizedUrl);
-      if (!collected.has(event.id)) {
-        collected.set(event.id, event);
-      }
-    });
-
-      sub.on('eose', () => {
+      const finish = () => {
+        if (settled) return;
+        settled = true;
         clearTimeout(timer);
         if (abortSignal) {
-          abortSignal.removeEventListener('abort', abortHandler);
+          try { abortSignal.removeEventListener('abort', abortHandler); } catch {}
         }
-        resolve(Array.from(collected.values()));
+        try { sub.stop(); } catch {}
+        const finalResults = Array.from(collected.values());
+        // Final emission so shared emitters see this subscription's full set
+        if (onPartial && finalResults.length > 0) {
+          onPartial(sortEventsNewestFirst(finalResults));
+        }
+        resolve(finalResults);
+      };
+
+      const timer = setTimeout(finish, timeoutMs);
+      const abortHandler = () => finish();
+
+      if (abortSignal) {
+        abortSignal.addEventListener('abort', abortHandler);
+      }
+
+      sub.on('event', (event: NDKEvent, relay: NDKRelay | undefined) => {
+        const relayUrl = relay?.url || 'unknown';
+        if (relayUrl !== 'unknown') {
+          try { markRelayActivity(relayUrl); } catch {}
+        }
+        const normalizedUrl = normalizeRelayUrl(relayUrl);
+        trackEventRelay(event, normalizedUrl);
+        if (!collected.has(event.id)) {
+          collected.set(event.id, event);
+          emitPartial();
+        }
       });
-      
+
+      sub.on('eose', finish);
+
       sub.start();
     })();
   });
 }
-

--- a/src/lib/search/termSearch.ts
+++ b/src/lib/search/termSearch.ts
@@ -8,7 +8,7 @@ import { subscribeAndCollect } from './subscriptions';
 
 /**
  * Search for events matching any of the provided terms (OR logic)
- * Each term is processed independently and results are merged
+ * Terms run in parallel and results are merged in seed order
  */
 export async function searchByAnyTerms(
   terms: string[],
@@ -20,24 +20,20 @@ export async function searchByAnyTerms(
   fallbackRelaySetFactory?: () => Promise<NDKRelaySet>,
   onPartial?: (events: NDKEvent[]) => void
 ): Promise<NDKEvent[]> {
-  const seen = new Set<string>();
-  const merged: NDKEvent[] = [];
-  let fallbackRelaySet: NDKRelaySet | null = null;
+  let fallbackRelaySetPromise: Promise<NDKRelaySet | null> | null = null;
 
-  const ensureFallbackRelaySet = async (): Promise<NDKRelaySet | null> => {
-    if (!fallbackRelaySetFactory) return null;
-    if (!fallbackRelaySet) {
-      try {
-        fallbackRelaySet = await fallbackRelaySetFactory();
-      } catch (error) {
+  const ensureFallbackRelaySet = (): Promise<NDKRelaySet | null> => {
+    if (!fallbackRelaySetFactory) return Promise.resolve(null);
+    if (!fallbackRelaySetPromise) {
+      fallbackRelaySetPromise = fallbackRelaySetFactory().catch((error) => {
         console.warn('Failed to create fallback relay set:', error);
         return null;
-      }
+      });
     }
-    return fallbackRelaySet;
+    return fallbackRelaySetPromise;
   };
 
-  for (const term of terms) {
+  const searchTerm = async (term: string): Promise<NDKEvent[]> => {
     try {
       const normalizedTerm = term.replace(/by:\s*(#\w+)/gi, (_m, tag: string) => tag);
       const hasLogicalOperators = /\b(OR|AND)\b|"|\(|\)/i.test(normalizedTerm);
@@ -93,7 +89,7 @@ export async function searchByAnyTerms(
         // Only skip if we couldn't resolve ANY authors
         if (authors.length === 0) {
           console.warn(`No authors could be resolved for term: ${normalizedTerm}`);
-          continue;
+          return [];
         }
         
         // Log which authors were resolved vs which failed
@@ -135,21 +131,27 @@ export async function searchByAnyTerms(
 
       try {
         const targetRelaySet = await selectRelaySet();
-        const res = await subscribeAndCollect(filter, { timeoutMs: 10000, relaySet: targetRelaySet, abortSignal, onPartial });
-        for (const evt of res) {
-          if (!seen.has(evt.id)) { seen.add(evt.id); merged.push(evt); }
-        }
+        return await subscribeAndCollect(filter, { timeoutMs: 10000, relaySet: targetRelaySet, abortSignal, onPartial });
       } catch (error) {
         console.warn(`Search failed for term "${normalizedTerm}":`, error);
-        // Continue with other terms even if one fails
+        return [];
       }
     } catch (error) {
       // Don't log aborted searches as errors
-      if (error instanceof Error && error.message === 'Search aborted') {
-        return merged; // Return what we have so far
+      if (!(error instanceof Error && error.message === 'Search aborted')) {
+        console.warn('Search term failed:', term, error);
       }
-      // Log other errors but continue
-      console.warn('Search term failed:', term, error);
+      return [];
+    }
+  };
+
+  const perTermResults = await Promise.all(terms.map(searchTerm));
+
+  const seen = new Set<string>();
+  const merged: NDKEvent[] = [];
+  for (const res of perTermResults) {
+    for (const evt of res) {
+      if (!seen.has(evt.id)) { seen.add(evt.id); merged.push(evt); }
     }
   }
   return merged;

--- a/src/lib/search/termSearch.ts
+++ b/src/lib/search/termSearch.ts
@@ -17,7 +17,8 @@ export async function searchByAnyTerms(
   abortSignal?: AbortSignal,
   nip50Extensions?: Nip50Extensions,
   baseFilter?: Partial<NDKFilter>,
-  fallbackRelaySetFactory?: () => Promise<NDKRelaySet>
+  fallbackRelaySetFactory?: () => Promise<NDKRelaySet>,
+  onPartial?: (events: NDKEvent[]) => void
 ): Promise<NDKEvent[]> {
   const seen = new Set<string>();
   const merged: NDKEvent[] = [];
@@ -134,7 +135,7 @@ export async function searchByAnyTerms(
 
       try {
         const targetRelaySet = await selectRelaySet();
-        const res = await subscribeAndCollect(filter, 10000, targetRelaySet, abortSignal);
+        const res = await subscribeAndCollect(filter, { timeoutMs: 10000, relaySet: targetRelaySet, abortSignal, onPartial });
         for (const evt of res) {
           if (!seen.has(evt.id)) { seen.add(evt.id); merged.push(evt); }
         }

--- a/src/lib/search/types.ts
+++ b/src/lib/search/types.ts
@@ -1,13 +1,11 @@
 import { NDKEvent, NDKFilter, NDKRelaySet } from '@nostr-dev-kit/ndk';
 import { Nip50Extensions } from './searchUtils';
 
-// Streaming search options
-export interface StreamingSearchOptions {
+// Options accepted by searchEvents
+export interface SearchOptions {
   exact?: boolean;
-  streaming?: boolean;
-  maxResults?: number;
-  timeoutMs?: number;
-  onResults?: (results: NDKEvent[], isComplete: boolean) => void;
+  // Called with partial results while subscriptions are still collecting
+  onPartialResults?: (results: NDKEvent[]) => void;
   // Called when profile search results are re-ranked after NIP-05 verifications land
   onProfileResultsUpdate?: (results: NDKEvent[]) => void;
 }
@@ -19,11 +17,11 @@ export interface SearchContext {
   nip50Extensions?: Nip50Extensions;
   chosenRelaySet: NDKRelaySet;
   relaySetOverride?: NDKRelaySet;
-  isStreaming: boolean;
-  streamingOptions?: StreamingSearchOptions;
   abortSignal?: AbortSignal;
   limit: number;
   extensionFilters?: Array<(content: string) => boolean>;
+  // Shared partial-results emitter (already merged across subscriptions)
+  onPartialResults?: (results: NDKEvent[]) => void;
   onProfileResultsUpdate?: (results: NDKEvent[]) => void;
 }
 

--- a/src/lib/search/urlSearch.ts
+++ b/src/lib/search/urlSearch.ts
@@ -1,50 +1,30 @@
-import { NDKEvent, NDKRelaySet } from '@nostr-dev-kit/ndk';
-import { 
-  Nip50Extensions, 
-  sortEventsNewestFirst, 
-  buildSearchQueryWithExtensions,
-  subscribeAndStream,
-  subscribeAndCollect
+import { NDKEvent } from '@nostr-dev-kit/ndk';
+import {
+  sortEventsNewestFirst,
+  buildSearchQueryWithExtensions
 } from './searchUtils';
-
-// Use the StreamingSearchOptions from the main search module
-type StreamingSearchOptions = {
-  exact?: boolean;
-  streaming?: boolean;
-  maxResults?: number;
-  timeoutMs?: number;
-  onResults?: (results: NDKEvent[], isComplete: boolean) => void;
-};
+import { subscribeAndCollect } from './subscriptions';
+import { SearchContext } from './types';
 
 export async function searchUrlEvents(
   cleanedQuery: string,
-  effectiveKinds: number[],
-  nip50Extensions: Nip50Extensions,
-  limit: number,
-  isStreaming: boolean,
-  streamingOptions: StreamingSearchOptions | undefined,
-  chosenRelaySet: NDKRelaySet,
-  abortSignal?: AbortSignal
+  context: SearchContext
 ): Promise<NDKEvent[]> {
+  const { effectiveKinds, nip50Extensions, limit, chosenRelaySet, abortSignal, onPartialResults } = context;
+
   // Search for the URL content (protocol stripping now handled by replacement rules)
-  const searchQuery = buildSearchQueryWithExtensions(`"${cleanedQuery}"`, nip50Extensions);
-  
-  const results = isStreaming 
-    ? await subscribeAndStream({
-        kinds: effectiveKinds,
-        search: searchQuery
-      }, {
-        timeoutMs: streamingOptions?.timeoutMs || 30000,
-        maxResults: streamingOptions?.maxResults || 1000,
-        onResults: streamingOptions?.onResults,
-        relaySet: chosenRelaySet,
-        abortSignal
-      })
-    : await subscribeAndCollect({
-        kinds: effectiveKinds,
-        search: searchQuery,
-        limit: Math.max(limit, 200)
-      }, 8000, chosenRelaySet, abortSignal);
-  
+  const searchQuery = buildSearchQueryWithExtensions(`"${cleanedQuery}"`, nip50Extensions || {});
+
+  const results = await subscribeAndCollect({
+    kinds: effectiveKinds,
+    search: searchQuery,
+    limit: Math.max(limit, 200)
+  }, {
+    timeoutMs: 8000,
+    relaySet: chosenRelaySet,
+    abortSignal,
+    onPartial: onPartialResults
+  });
+
   return sortEventsNewestFirst(results).slice(0, limit);
 }


### PR DESCRIPTION
Search results now render incrementally as relays deliver events instead of waiting for the slowest relay. The unused `subscribeAndStream` live path was folded into `subscribeAndCollect`, which emits deduped, sorted partials (throttled to 500ms) through a single `onPartialResults` callback threaded from `searchEvents` to the UI; the awaited final result stays authoritative. On top of that, two latency fixes: relay info lookups are negative-cached with stale-while-revalidate so dead relays no longer block relay set construction on every search, and OR seeds run in parallel instead of sequentially.

- `getRelayInfo`: 10min negative cache for failed NIP-11 lookups, 1h success TTL, deduped in-flight checks, background refresh of stale entries
- `SearchContext` simplified: `isStreaming`/`streamingOptions` replaced by one `onPartialResults` emitter shared across all subscriptions of a search
- Parallel OR seeds bound multi-seed queries like `has:image` (6 seeds) to one collect timeout instead of six

Build preview:
- [/?q=has:image](https://ants-git-streaming-search-dergigis-projects.vercel.app/?q=has:image)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Extended relay information caching from 1 minute to 1 hour, reducing network requests.
  * Added negative caching for failed relay lookups (10-minute duration) to avoid repeated failures.
  * Implemented background refresh of relay information, allowing stale data to be returned immediately while updates fetch asynchronously.

* **New Features**
  * Search now displays partial results incrementally as they become available, providing faster feedback during queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->