### PR TITLE
perf: make first search results appear near-instantly

### DIFF
--- a/.cursor/rules/nip50-text-search.mdc
+++ b/.cursor/rules/nip50-text-search.mdc
@@ -1,0 +1,11 @@
+---
+description: Text searches must only use NIP-50 relays
+alwaysApply: true
+---
+
+Text searches (anything using the `search` filter field) MUST only go to relays that support NIP-50. Relays without NIP-50 support ignore the `search` field and return arbitrary events matching the rest of the filter, polluting the results.
+
+- Always pass an explicit NIP-50 relay set (see `getNip50SearchRelaySet()` in `src/lib/relays/nip50.ts`) when subscribing with a `search` filter.
+- Never let a `search` subscription fall through to the default pool or an unfiltered relay set.
+- Direct lookups (ids, authors, kinds without `search`) may use the default relay set.
+- `subscribeAndCollect` in `src/lib/search/subscriptions.ts` enforces this as the choke point via `restrictToNip50Relays()`; keep that enforcement in place when refactoring, and route new event subscriptions with `search` filters through it.

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { restoreLogin } from '@/lib/nip07';
+import { restoreLogin, getStoredPubkey } from '@/lib/nip07';
+import { ndk } from '@/lib/ndk';
 import { useState, useEffect } from 'react';
 import { NDKUser } from '@nostr-dev-kit/ndk';
 import { useRouter } from 'next/navigation';
@@ -18,33 +19,40 @@ export function Header() {
 
   // Restore login state on mount
   useEffect(() => {
-    const initLogin = async () => {
-      try {
-        const restoredUser = await restoreLogin();
-        // Set user immediately for fast UI feedback
-        setUser(restoredUser);
-        setCurrentUser(restoredUser);
-        if (restoredUser) {
-          setLoginState('logged-in');
-          // Fetch the user's profile in the background to update display details
-          try { 
-            await restoredUser.fetchProfile();
-            // Bump avatar version to force a re-render even if the user object identity is unchanged
-            setAvatarVersion(v => v + 1);
-            setUser(restoredUser);
-          } catch {}
-        } else {
-          setLoginState('logged-out');
-          setCurrentUser(null);
-        }
-      } catch (error) {
-        console.error('Failed to restore login:', error);
-      } finally {
-        setIsLoading(false);
-      }
+    const fetchProfileInBackground = (u: NDKUser) => {
+      u.fetchProfile().then(() => {
+        // Bump avatar version to force a re-render even if the user object identity is unchanged
+        setAvatarVersion(v => v + 1);
+        setUser(u);
+      }).catch(() => {});
     };
 
-    initLogin();
+    const applyLoggedOut = () => {
+      setUser(null);
+      setCurrentUser(null);
+      setLoginState('logged-out');
+    };
+
+    // Show the logged-in state instantly from the stored pubkey, then verify
+    // the extension and fetch the profile in the background.
+    const storedPubkey = getStoredPubkey();
+    if (storedPubkey) {
+      const optimisticUser = ndk.getUser({ pubkey: storedPubkey });
+      setUser(optimisticUser);
+      setCurrentUser(optimisticUser);
+      setLoginState('logged-in');
+      setIsLoading(false);
+      fetchProfileInBackground(optimisticUser);
+      restoreLogin().then((restoredUser) => {
+        if (!restoredUser) applyLoggedOut();
+      }).catch((error) => {
+        console.error('Failed to restore login:', error);
+        applyLoggedOut();
+      });
+    } else {
+      applyLoggedOut();
+      setIsLoading(false);
+    }
     // Listen for external auth changes (e.g., slash-commands)
     const onAuthChange = () => {
       (async () => {

--- a/src/hooks/useSearchExecution.ts
+++ b/src/hooks/useSearchExecution.ts
@@ -11,7 +11,8 @@ import { extractRelaySourcesFromEvent, createRelaySet } from '@/lib/urlUtils';
 import { extractNip19Identifiers, decodeNip19Identifier } from '@/lib/utils/nostrIdentifiers';
 import { getCurrentProfileNpub, toImplicitUrlQuery, ensureAuthorForBackend } from '@/lib/search/queryTransforms';
 import { getProfileScopeIdentifiers, hasProfileScope } from '@/lib/search/profileScope';
-import { relaySets, getNip50SearchRelaySet } from '@/lib/relays';
+import { relaySets, getNip50SearchRelaySet, prewarmSearchRelaySet } from '@/lib/relays';
+import { loadRules } from '@/lib/search/replacements';
 import { isSlashCommand, isUrlQuery, buildCli } from '@/lib/utils/searchViewUtils';
 import { getStoredPubkey } from '@/lib/nip07';
 import { type SearchViewRefs } from '@/hooks/useSearchViewRefs';
@@ -359,6 +360,11 @@ export function useSearchExecution(options: SearchExecutionOptions) {
 
   // Connect NDK on mount and run the initial query for direct lookups
   useEffect(() => {
+    // Resolve the NIP-50 relay set and replacement rules while the user is
+    // still typing so the first search doesn't pay for them.
+    prewarmSearchRelaySet();
+    void loadRules().catch(() => {});
+
     const initializeNDK = async () => {
       setIsConnecting(true);
       const connectionResult = await connect(8000); // 8 second timeout for more reliable initial connect

--- a/src/hooks/useSearchExecution.ts
+++ b/src/hooks/useSearchExecution.ts
@@ -11,8 +11,8 @@ import { extractRelaySourcesFromEvent, createRelaySet } from '@/lib/urlUtils';
 import { extractNip19Identifiers, decodeNip19Identifier } from '@/lib/utils/nostrIdentifiers';
 import { getCurrentProfileNpub, toImplicitUrlQuery, ensureAuthorForBackend } from '@/lib/search/queryTransforms';
 import { getProfileScopeIdentifiers, hasProfileScope } from '@/lib/search/profileScope';
-import { relaySets, getNip50SearchRelaySet, prewarmSearchRelaySet } from '@/lib/relays';
-import { loadRules } from '@/lib/search/replacements';
+import { relaySets, getNip50SearchRelaySet } from '@/lib/relays';
+import { prewarmSearchRuntime } from '@/lib/search/prewarm';
 import { isSlashCommand, isUrlQuery, buildCli } from '@/lib/utils/searchViewUtils';
 import { getStoredPubkey } from '@/lib/nip07';
 import { type SearchViewRefs } from '@/hooks/useSearchViewRefs';
@@ -358,13 +358,9 @@ export function useSearchExecution(options: SearchExecutionOptions) {
     }
   }, [setQueryAndNavigateToRoot, handleSearch]);
 
-  // Connect NDK on mount and run the initial query for direct lookups
+  // Prewarm search, connect NDK on mount, and run the initial query for direct lookups
   useEffect(() => {
-    // Resolve the NIP-50 relay set and replacement rules while the user is
-    // still typing so the first search doesn't pay for them.
-    prewarmSearchRelaySet();
-    void loadRules().catch(() => {});
-
+    prewarmSearchRuntime();
     const initializeNDK = async () => {
       setIsConnecting(true);
       const connectionResult = await connect(8000); // 8 second timeout for more reliable initial connect

--- a/src/lib/ndk/cache.ts
+++ b/src/lib/ndk/cache.ts
@@ -17,7 +17,9 @@ const sanitizeFilterArrays = (filters: Array<Record<string, unknown>>): void => 
     for (const key of Object.keys(filter)) {
       const value = filter[key];
       if (Array.isArray(value) && value.some((v) => v === undefined || v === null)) {
-        console.warn('Dropping undefined values from filter before cache query:', key, JSON.stringify(filter));
+        const droppedCount = value.filter((v) => v === undefined || v === null).length;
+        // Don't log filter contents; authors/ids arrays contain user identifiers
+        console.warn(`Dropping ${droppedCount} undefined/null value(s) from filter key: ${key}`);
         filter[key] = value.filter((v) => v !== undefined && v !== null);
       }
     }

--- a/src/lib/ndk/cache.ts
+++ b/src/lib/ndk/cache.ts
@@ -7,6 +7,33 @@ export const cacheAdapter = new NDKCacheAdapterSqliteWasm({
   dbName: 'ants-ndk-cache',
   wasmUrl: '/ndk/sql-wasm.wasm'
 });
+
+// sql.js throws a bare string ("Wrong API use: tried to bind a value of an
+// unknown type") when a filter array contains undefined. NDK calls query()
+// synchronously inside a setTimeout, so that throw is uncaught and used to
+// disable the whole cache. Sanitize filters and degrade to a cache miss.
+const sanitizeFilterArrays = (filters: Array<Record<string, unknown>>): void => {
+  for (const filter of filters) {
+    for (const key of Object.keys(filter)) {
+      const value = filter[key];
+      if (Array.isArray(value) && value.some((v) => v === undefined || v === null)) {
+        console.warn('Dropping undefined values from filter before cache query:', key, JSON.stringify(filter));
+        filter[key] = value.filter((v) => v !== undefined && v !== null);
+      }
+    }
+  }
+};
+
+const originalQuery = cacheAdapter.query.bind(cacheAdapter);
+cacheAdapter.query = ((subscription: Parameters<typeof originalQuery>[0]) => {
+  try {
+    sanitizeFilterArrays(subscription.filters as unknown as Array<Record<string, unknown>>);
+    return originalQuery(subscription);
+  } catch (error) {
+    console.warn('Cache query failed, continuing without cached results:', error);
+    return [];
+  }
+}) as typeof cacheAdapter.query;
 let cacheInitialized = false;
 let cacheDisabledDueToError = false;
 let cacheErrorHandlersInstalled = false;

--- a/src/lib/ndk/connection.ts
+++ b/src/lib/ndk/connection.ts
@@ -1,3 +1,4 @@
+import { NDKSubscriptionCacheUsage } from '@nostr-dev-kit/ndk';
 import { RELAYS } from '../relays/config';
 import { RELAY_MONITORING_INTERVAL, RELAY_PING_TIMEOUT } from '../constants';
 import { ndk } from './index';
@@ -127,7 +128,7 @@ async function measureRelayPing(relayUrl: string): Promise<number> {
       // (NDK's "BUG: No filters to merge!").
       const sub = safeSubscribe([{ kinds: [1], limit: 1 }], {
         closeOnEose: true,
-        cacheUsage: 'ONLY_RELAY' as const,
+        cacheUsage: NDKSubscriptionCacheUsage.ONLY_RELAY,
         relayUrls: [relayUrl]
       });
 

--- a/src/lib/ndk/connection.ts
+++ b/src/lib/ndk/connection.ts
@@ -298,7 +298,11 @@ export const connect = async (timeoutMs: number = 8000): Promise<ConnectionStatu
 // browser) so relays are usually up by the time the first search runs.
 // Opening websockets doesn't touch the cache adapter, so run both in
 // parallel instead of serializing the WASM SQLite init before connecting.
+// Deferred by a microtask: this module is part of an import cycle with
+// ndk/index, so `ndk` isn't initialized until the module graph finishes.
 if (typeof window !== 'undefined') {
-  void ensureCacheInitialized().catch(() => {});
-  startNdkConnect();
+  queueMicrotask(() => {
+    void ensureCacheInitialized().catch(() => {});
+    startNdkConnect();
+  });
 }

--- a/src/lib/ndk/connection.ts
+++ b/src/lib/ndk/connection.ts
@@ -13,10 +13,41 @@ export interface ConnectionStatus {
   relayPings?: Map<string, number>; // Relay URL -> ping time in ms
 }
 
-// Helper function to create timeout promise
-const createTimeoutPromise = (timeoutMs: number): Promise<never> => {
-  return new Promise<never>((_, reject) => {
-    setTimeout(() => reject(new Error('Connection timeout')), timeoutMs);
+// ndk.connect() only resolves once ALL relays respond, so a single dead relay
+// stalls it until the timeout. We start it once (fire-and-forget) and instead
+// wait for the first relay to come up before letting searches proceed.
+let ndkConnectStarted = false;
+const startNdkConnect = (): void => {
+  if (ndkConnectStarted) return;
+  ndkConnectStarted = true;
+  ndk.connect().catch((error) => {
+    console.warn('NDK connect error (continuing with available relays):', error);
+  });
+};
+
+const hasConnectedRelay = (): boolean => {
+  const relays = ndk.pool?.relays;
+  if (!relays) return false;
+  return Array.from(relays.values()).some((relay) => relay.status === 1);
+};
+
+// Resolves true as soon as at least one relay is connected, false on timeout
+const waitForFirstRelayConnection = (timeoutMs: number): Promise<boolean> => {
+  if (hasConnectedRelay()) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    const pool = ndk.pool;
+    const cleanup = () => {
+      clearTimeout(timer);
+      clearInterval(poll);
+      try { pool?.off('relay:connect', onConnect); } catch {}
+    };
+    const onConnect = () => { cleanup(); resolve(true); };
+    const timer = setTimeout(() => { cleanup(); resolve(hasConnectedRelay()); }, timeoutMs);
+    // Poll as a fallback in case the pool event is missed
+    const poll = setInterval(() => {
+      if (hasConnectedRelay()) { cleanup(); resolve(true); }
+    }, 100);
+    try { pool?.on('relay:connect', onConnect); } catch {}
   });
 };
 
@@ -58,19 +89,12 @@ const finalizeConnectionResult = (connectedRelays: string[], connectingRelays: s
   return result;
 };
 
-// Reusable connection function with timeout
+// Reusable connection function with timeout: returns as soon as one relay is up
 export const connectWithTimeout = async (timeoutMs: number = 5000): Promise<void> => {
   // Always initialize cache before attempting to connect or racing with timeout
   await ensureCacheInitialized();
-  try {
-    await Promise.race([
-      ndk.connect(),
-      createTimeoutPromise(timeoutMs)
-    ]);
-  } catch (error) {
-    console.warn('NDK connection failed, but continuing with available relays:', error);
-    // Don't throw - let the search continue with whatever relays are available
-  }
+  startNdkConnect();
+  await waitForFirstRelayConnection(timeoutMs);
 };
 
 // Track recent relay activity (last event timestamp per relay)
@@ -166,7 +190,8 @@ export function getRecentlyActiveRelays(windowMs: number = ACTIVITY_WINDOW_MS): 
   return urls.sort((a, b) => a.localeCompare(b));
 }
 
-const checkRelayStatus = async (): Promise<ConnectionStatus> => {
+// Synchronous pool inspection, no network round-trips
+const getRelayStatusSnapshot = (): ConnectionStatus => {
   const connectedRelays: string[] = [];
   const connectingRelays: string[] = [];
   const failedRelays: string[] = [];
@@ -202,17 +227,19 @@ const checkRelayStatus = async (): Promise<ConnectionStatus> => {
     }
   }
 
-  // Measure ping times for connected relays
-  const relayPings = connectedRelays.length > 0 ? await measureAllRelayPings() : new Map();
-
   return {
     success: connectedRelays.length > 0,
     connectedRelays,
     connectingRelays,
     failedRelays,
-    timeout: false,
-    relayPings
+    timeout: false
   };
+};
+
+const checkRelayStatus = async (): Promise<ConnectionStatus> => {
+  const status = getRelayStatusSnapshot();
+  const relayPings = status.connectedRelays.length > 0 ? await measureAllRelayPings() : new Map<string, number>();
+  return { ...status, relayPings };
 };
 
 // Start background relay monitoring
@@ -245,33 +272,31 @@ export const startRelayMonitoring = () => {
 };
 
 export const connect = async (timeoutMs: number = 8000): Promise<ConnectionStatus> => {
-  let timeout = false;
+  // Ensure cache is initialized even if the connection times out
+  await ensureCacheInitialized();
+  startNdkConnect();
 
-  try {
-    // Ensure cache is initialized even if the connection times out
-    await ensureCacheInitialized();
-    // Race between connection and timeout
-    await Promise.race([
-      ndk.connect(),
-      createTimeoutPromise(timeoutMs)
-    ]);
+  // Return as soon as the first relay is up; remaining relays keep connecting
+  // in the background and surface via the monitoring interval.
+  const connected = await waitForFirstRelayConnection(timeoutMs);
+  const status = getRelayStatusSnapshot();
 
-    // Give relays a moment to establish connections after ndk.connect() returns
-    await new Promise(resolve => setTimeout(resolve, 1000));
-
-    // Check which relays actually connected
-    const status = await checkRelayStatus();
-    // Do not change the example on connect; keep current selection
-
-    return finalizeConnectionResult(status.connectedRelays, status.connectingRelays, status.failedRelays, false, status.relayPings);
-  } catch (error) {
-    console.warn('NDK connection failed or timed out:', error);
-    timeout = true;
-
-    // Check which relays we can still access
-    const status = await checkRelayStatus();
-    // Do not change the example on failed connect either
-
-    return finalizeConnectionResult(status.connectedRelays, status.connectingRelays, status.failedRelays, timeout, status.relayPings);
+  // Measure pings in the background so they don't delay the first search
+  if (status.connectedRelays.length > 0) {
+    void measureAllRelayPings().then((pings) => {
+      if (globalConnectionStatus) {
+        updateConnectionStatus({ ...globalConnectionStatus, relayPings: pings });
+      }
+    }).catch(() => {});
   }
+
+  return finalizeConnectionResult(status.connectedRelays, status.connectingRelays, status.failedRelays, !connected);
 };
+
+// Kick off the relay connection as early as possible (at module load in the
+// browser) so relays are usually up by the time the first search runs.
+if (typeof window !== 'undefined') {
+  void ensureCacheInitialized()
+    .catch(() => {})
+    .then(() => startNdkConnect());
+}

--- a/src/lib/ndk/connection.ts
+++ b/src/lib/ndk/connection.ts
@@ -296,8 +296,9 @@ export const connect = async (timeoutMs: number = 8000): Promise<ConnectionStatu
 
 // Kick off the relay connection as early as possible (at module load in the
 // browser) so relays are usually up by the time the first search runs.
+// Opening websockets doesn't touch the cache adapter, so run both in
+// parallel instead of serializing the WASM SQLite init before connecting.
 if (typeof window !== 'undefined') {
-  void ensureCacheInitialized()
-    .catch(() => {})
-    .then(() => startNdkConnect());
+  void ensureCacheInitialized().catch(() => {});
+  startNdkConnect();
 }

--- a/src/lib/ndk/connection.ts
+++ b/src/lib/ndk/connection.ts
@@ -31,23 +31,20 @@ const hasConnectedRelay = (): boolean => {
   return Array.from(relays.values()).some((relay) => relay.status === 1);
 };
 
-// Resolves true as soon as at least one relay is connected, false on timeout
+// Resolves true as soon as at least one relay is connected, false on timeout.
+// Detection is poll-based on purpose: adding/removing pool listeners can
+// corrupt tseep's baked listener collection when done mid-emit.
 const waitForFirstRelayConnection = (timeoutMs: number): Promise<boolean> => {
   if (hasConnectedRelay()) return Promise.resolve(true);
   return new Promise((resolve) => {
-    const pool = ndk.pool;
-    const cleanup = () => {
-      clearTimeout(timer);
-      clearInterval(poll);
-      try { pool?.off('relay:connect', onConnect); } catch {}
-    };
-    const onConnect = () => { cleanup(); resolve(true); };
-    const timer = setTimeout(() => { cleanup(); resolve(hasConnectedRelay()); }, timeoutMs);
-    // Poll as a fallback in case the pool event is missed
+    const started = Date.now();
     const poll = setInterval(() => {
-      if (hasConnectedRelay()) { cleanup(); resolve(true); }
-    }, 100);
-    try { pool?.on('relay:connect', onConnect); } catch {}
+      const connected = hasConnectedRelay();
+      if (connected || Date.now() - started >= timeoutMs) {
+        clearInterval(poll);
+        resolve(connected);
+      }
+    }, 50);
   });
 };
 
@@ -125,9 +122,13 @@ async function measureRelayPing(relayUrl: string): Promise<number> {
         resolve(-1); // Timeout
       }, RELAY_PING_TIMEOUT);
 
+      // Scope to the measured relay only; a pool-wide sub would EOSE on the
+      // fastest relay and leave late relays executing an emptied subscription
+      // (NDK's "BUG: No filters to merge!").
       const sub = safeSubscribe([{ kinds: [1], limit: 1 }], {
         closeOnEose: true,
-        cacheUsage: 'ONLY_RELAY' as const
+        cacheUsage: 'ONLY_RELAY' as const,
+        relayUrls: [relayUrl]
       });
 
       if (sub) {

--- a/src/lib/nip07.ts
+++ b/src/lib/nip07.ts
@@ -1,5 +1,5 @@
 import { NDKNip07Signer, NDKUser } from '@nostr-dev-kit/ndk';
-import { ndk, connect } from './ndk';
+import { ndk } from './ndk';
 import { clearAllProfileCaches } from './profile/cache';
 import { clearRelayCaches } from './relays';
 
@@ -19,9 +19,7 @@ export async function login(): Promise<NDKUser | null> {
   }
 
   try {
-    // Ensure NDK is connected
-    await connect();
-    
+    // No need to wait for relays here; the signer only talks to the extension
     const signer = new NDKNip07Signer();
     const user = await signer.blockUntilReady();
     
@@ -75,6 +73,17 @@ export function logout(): void {
   emitAuthChange();
 }
 
+// Extensions inject window.nostr asynchronously; poll briefly instead of
+// failing when restore runs before the injection happened.
+async function waitForNip07Extension(timeoutMs: number = 3000): Promise<boolean> {
+  const start = Date.now();
+  while (!(window as { nostr?: unknown }).nostr) {
+    if (Date.now() - start >= timeoutMs) return false;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return true;
+}
+
 export async function restoreLogin(): Promise<NDKUser | null> {
   const storedPubkey = getStoredPubkey();
   if (!storedPubkey) {
@@ -82,16 +91,12 @@ export async function restoreLogin(): Promise<NDKUser | null> {
   }
 
   try {
-    // Check if NIP-07 extension is available
-    if (!(window as { nostr?: unknown }).nostr) {
+    if (!(await waitForNip07Extension())) {
       console.warn('NIP-07 extension not available, cannot restore login');
       return null;
     }
 
-    // Ensure NDK is connected
-    await connect();
-
-    // Create a new signer and restore the connection
+    // Restore the signer; no need to wait for relay connections
     const signer = new NDKNip07Signer();
     const user = await signer.blockUntilReady();
     

--- a/src/lib/relays/index.ts
+++ b/src/lib/relays/index.ts
@@ -3,11 +3,12 @@ import { ndk, ensureCacheInitialized } from '../ndk';
 import { RELAYS } from './config';
 import { extendWithUserAndPremium, clearUserRelayCache } from './userDiscovery';
 import { clearRelayInfoCache } from './infoCache';
+import { clearSearchRelayUrlCache } from './nip50';
 
 export { RELAYS, createRelaySet } from './config';
 export { discoverUserRelays, extendWithUserAndPremium } from './userDiscovery';
 export { relayInfoCache, getRelayInfo, clearRelayInfoCache, type RelayInfo } from './infoCache';
-export { checkNip50Support, filterNip50Relays, getNip50RelaySet, getNip50SearchRelaySet } from './nip50';
+export { checkNip50Support, filterNip50Relays, getNip50RelaySet, getNip50SearchRelaySet, prewarmSearchRelaySet } from './nip50';
 
 // Pre-configured relay sets
 export const relaySets = {
@@ -30,4 +31,5 @@ export const relaySets = {
 export function clearRelayCaches(): void {
   clearRelayInfoCache();
   clearUserRelayCache();
+  clearSearchRelayUrlCache();
 }

--- a/src/lib/relays/infoCache.ts
+++ b/src/lib/relays/infoCache.ts
@@ -54,12 +54,19 @@ if (hasLocalStorage()) {
   loadCacheFromStorage();
 }
 
+// NDK pool relay URLs carry a trailing slash while configured URLs don't;
+// normalize so both map to one cache entry instead of two HTTP checks.
+function normalizeCacheUrl(relayUrl: string): string {
+  return relayUrl.replace(/\/+$/, '');
+}
+
 // Get complete relay information using multiple detection methods.
 // Stale-while-revalidate: a cached entry (even expired) is returned
 // immediately and refreshed in the background; only relays never seen
 // before block on the HTTP check. Failed lookups are negative-cached
 // so dead relays don't delay every search.
-export async function getRelayInfo(relayUrl: string): Promise<RelayInfo> {
+export async function getRelayInfo(rawRelayUrl: string): Promise<RelayInfo> {
+  const relayUrl = normalizeCacheUrl(rawRelayUrl);
   const cached = relayInfoCache.get(relayUrl);
   if (cached) {
     const ttl = cached.failed ? NEGATIVE_CACHE_DURATION_MS : CACHE_DURATION_MS;
@@ -83,8 +90,8 @@ function refreshRelayInfo(relayUrl: string): Promise<RelayInfo> {
       });
 
       const relayInfoPromise = (async () => {
-        // Method 1: Check NDK's cached relay info
-        const relay = ndk.pool?.relays?.get(relayUrl);
+        // Method 1: Check NDK's cached relay info (pool keys use trailing slash)
+        const relay = ndk.pool?.relays?.get(relayUrl) || ndk.pool?.relays?.get(`${relayUrl}/`);
         if (relay) {
           // Check if relay has info cached from NIP-11
           const relayInfo = (relay as { info?: { supported_nips?: number[] } }).info;

--- a/src/lib/relays/nip50.ts
+++ b/src/lib/relays/nip50.ts
@@ -3,7 +3,7 @@ import { getStoredPubkey } from '../nip07';
 import { getUserRelayAdditions } from '../storage';
 import { RELAYS, createRelaySet } from './config';
 import { getRelayInfo } from './infoCache';
-import { discoverUserRelays, extendWithUserAndPremium } from './userDiscovery';
+import { extendWithUserAndPremium } from './userDiscovery';
 
 // Check whether a relay supports NIP-50
 export async function checkNip50Support(relayUrl: string): Promise<{ supportsNip50: boolean; supportedNips: number[] }> {
@@ -85,24 +85,11 @@ function searchRelayCacheKey(): string {
   return `${pubkey}|${manual}`;
 }
 
-async function gatherCandidateRelays(): Promise<string[]> {
-  const pubkey = getStoredPubkey();
-
-  // Start with hardcoded search relays
-  const allSearchRelays: string[] = [...RELAYS.SEARCH];
-
-  // Add user's search relays if logged in
-  if (pubkey) {
-    try {
-      const { searchRelays } = await discoverUserRelays(pubkey);
-      allSearchRelays.push(...searchRelays);
-    } catch (error) {
-      console.warn('[NIP-51] Failed to discover user search relays:', error);
-    }
-  }
-
-  // All relays (including user relays); NIP-50 filtering happens afterwards
-  return extendWithUserAndPremium(allSearchRelays);
+function gatherCandidateRelays(): Promise<string[]> {
+  // Curated search relays plus the user's relays, manual additions, premium
+  // relays, and NIP-51 search relays (single discovery call for logged-in
+  // users). NIP-50 filtering happens afterwards.
+  return extendWithUserAndPremium([...RELAYS.SEARCH], { includeSearchRelays: true });
 }
 
 // On a cold NIP-11 cache, waiting for every relay check means the slowest
@@ -151,7 +138,9 @@ async function getSearchRelayUrls(): Promise<string[]> {
   const early = (async () => {
     const candidates = await gatherCandidateRelays();
 
-    // Full resolution caches its result so later searches use the whole set
+    // Both paths probe the same candidates, but getRelayInfo() dedupes
+    // concurrent lookups per relay, so each relay is checked once.
+    // Full resolution caches its result so later searches use the whole set.
     const full = filterNip50Relays(candidates)
       .then((urls) => {
         if (urls.length > 0) cachedSearchRelayUrls = { key, urls, timestamp: Date.now() };

--- a/src/lib/relays/nip50.ts
+++ b/src/lib/relays/nip50.ts
@@ -85,7 +85,7 @@ function searchRelayCacheKey(): string {
   return `${pubkey}|${manual}`;
 }
 
-async function resolveSearchRelayUrls(): Promise<string[]> {
+async function gatherCandidateRelays(): Promise<string[]> {
   const pubkey = getStoredPubkey();
 
   // Start with hardcoded search relays
@@ -101,10 +101,39 @@ async function resolveSearchRelayUrls(): Promise<string[]> {
     }
   }
 
-  // Get all relays (including user relays) but filter for NIP-50 support
-  const allRelays = await extendWithUserAndPremium(allSearchRelays);
+  // All relays (including user relays); NIP-50 filtering happens afterwards
+  return extendWithUserAndPremium(allSearchRelays);
+}
 
-  return filterNip50Relays(allRelays);
+// On a cold NIP-11 cache, waiting for every relay check means the slowest
+// (or dead) relay gates the first search. Resolve early once this many
+// relays are confirmed; the full check keeps running and updates the cache.
+const EARLY_RELAY_TARGET = 3;
+
+function filterNip50RelaysEarly(relayUrls: string[], full: Promise<string[]>): Promise<string[]> {
+  return new Promise<string[]>((resolve) => {
+    let done = false;
+    const confirmed: string[] = [];
+    const finish = (urls: string[]) => {
+      if (done) return;
+      done = true;
+      resolve(urls);
+    };
+
+    for (const url of relayUrls) {
+      void checkNip50Support(url)
+        .then((info) => {
+          if (done || !info.supportsNip50) return;
+          confirmed.push(url);
+          if (confirmed.length >= EARLY_RELAY_TARGET) finish([...confirmed]);
+        })
+        .catch(() => {});
+    }
+
+    // Whatever the full pipeline produces (including its <3 relay fallback
+    // probing) always wins if the early target was never reached.
+    void full.then(finish).catch(() => finish(confirmed.length > 0 ? [...confirmed] : []));
+  });
 }
 
 async function getSearchRelayUrls(): Promise<string[]> {
@@ -119,17 +148,27 @@ async function getSearchRelayUrls(): Promise<string[]> {
     return inFlightSearchRelayUrls.promise;
   }
 
-  const promise = resolveSearchRelayUrls()
-    .then((urls) => {
-      cachedSearchRelayUrls = { key, urls, timestamp: Date.now() };
-      return urls;
-    })
-    .finally(() => {
-      if (inFlightSearchRelayUrls?.key === key) inFlightSearchRelayUrls = null;
-    });
+  const early = (async () => {
+    const candidates = await gatherCandidateRelays();
 
-  inFlightSearchRelayUrls = { key, promise };
-  return promise;
+    // Full resolution caches its result so later searches use the whole set
+    const full = filterNip50Relays(candidates)
+      .then((urls) => {
+        if (urls.length > 0) cachedSearchRelayUrls = { key, urls, timestamp: Date.now() };
+        return urls;
+      })
+      .finally(() => {
+        if (inFlightSearchRelayUrls?.key === key) inFlightSearchRelayUrls = null;
+      });
+
+    return filterNip50RelaysEarly(candidates, full);
+  })().catch((error) => {
+    if (inFlightSearchRelayUrls?.key === key) inFlightSearchRelayUrls = null;
+    throw error;
+  });
+
+  inFlightSearchRelayUrls = { key, promise: early };
+  return early;
 }
 
 // Enhanced search relay set that filters for NIP-50 support

--- a/src/lib/relays/nip50.ts
+++ b/src/lib/relays/nip50.ts
@@ -1,5 +1,6 @@
 import { NDKRelaySet } from '@nostr-dev-kit/ndk';
 import { getStoredPubkey } from '../nip07';
+import { getUserRelayAdditions } from '../storage';
 import { RELAYS, createRelaySet } from './config';
 import { getRelayInfo } from './infoCache';
 import { discoverUserRelays, extendWithUserAndPremium } from './userDiscovery';
@@ -70,8 +71,21 @@ export async function getNip50RelaySet(relayUrls: string[]): Promise<NDKRelaySet
   return createRelaySet(nip50Relays);
 }
 
-// Enhanced search relay set that filters for NIP-50 support
-export async function getNip50SearchRelaySet(): Promise<NDKRelaySet> {
+// Resolving the search relay set involves NIP-51 list fetches and NIP-11
+// checks, so memoize the resolved URLs per login/manual-relay state. The
+// underlying caches handle staleness; this just keeps repeat searches from
+// re-awaiting the whole pipeline.
+const SEARCH_RELAY_URLS_TTL_MS = 60_000;
+let cachedSearchRelayUrls: { key: string; urls: string[]; timestamp: number } | null = null;
+let inFlightSearchRelayUrls: { key: string; promise: Promise<string[]> } | null = null;
+
+function searchRelayCacheKey(): string {
+  const pubkey = getStoredPubkey() || 'anon';
+  const manual = getUserRelayAdditions().slice().sort().join(',');
+  return `${pubkey}|${manual}`;
+}
+
+async function resolveSearchRelayUrls(): Promise<string[]> {
   const pubkey = getStoredPubkey();
 
   // Start with hardcoded search relays
@@ -90,7 +104,47 @@ export async function getNip50SearchRelaySet(): Promise<NDKRelaySet> {
   // Get all relays (including user relays) but filter for NIP-50 support
   const allRelays = await extendWithUserAndPremium(allSearchRelays);
 
-  const nip50Relays = await filterNip50Relays(allRelays);
+  return filterNip50Relays(allRelays);
+}
 
+async function getSearchRelayUrls(): Promise<string[]> {
+  const key = searchRelayCacheKey();
+
+  if (cachedSearchRelayUrls && cachedSearchRelayUrls.key === key
+    && (Date.now() - cachedSearchRelayUrls.timestamp) < SEARCH_RELAY_URLS_TTL_MS) {
+    return cachedSearchRelayUrls.urls;
+  }
+
+  if (inFlightSearchRelayUrls && inFlightSearchRelayUrls.key === key) {
+    return inFlightSearchRelayUrls.promise;
+  }
+
+  const promise = resolveSearchRelayUrls()
+    .then((urls) => {
+      cachedSearchRelayUrls = { key, urls, timestamp: Date.now() };
+      return urls;
+    })
+    .finally(() => {
+      if (inFlightSearchRelayUrls?.key === key) inFlightSearchRelayUrls = null;
+    });
+
+  inFlightSearchRelayUrls = { key, promise };
+  return promise;
+}
+
+// Enhanced search relay set that filters for NIP-50 support
+export async function getNip50SearchRelaySet(): Promise<NDKRelaySet> {
+  const nip50Relays = await getSearchRelayUrls();
   return createRelaySet(nip50Relays);
+}
+
+// Resolve (and cache) the search relay set ahead of the first search so the
+// NIP-11/NIP-51 round-trips happen while the user is still typing.
+export function prewarmSearchRelaySet(): void {
+  void getSearchRelayUrls().catch(() => {});
+}
+
+export function clearSearchRelayUrlCache(): void {
+  cachedSearchRelayUrls = null;
+  inFlightSearchRelayUrls = null;
 }

--- a/src/lib/relays/nip50.ts
+++ b/src/lib/relays/nip50.ts
@@ -178,9 +178,13 @@ export async function getNip50SearchRelaySet(): Promise<NDKRelaySet> {
 }
 
 // Resolve (and cache) the search relay set ahead of the first search so the
-// NIP-11/NIP-51 round-trips happen while the user is still typing.
+// NIP-11/NIP-51 round-trips happen while the user is still typing. Creating
+// the relay set also opens the websockets, so the first search doesn't pay
+// for the connection handshakes either.
 export function prewarmSearchRelaySet(): void {
-  void getSearchRelayUrls().catch(() => {});
+  void getSearchRelayUrls()
+    .then((urls) => createRelaySet(urls))
+    .catch(() => {});
 }
 
 export function clearSearchRelayUrlCache(): void {

--- a/src/lib/relays/userDiscovery.ts
+++ b/src/lib/relays/userDiscovery.ts
@@ -75,9 +75,11 @@ export async function discoverUserRelays(pubkey: string): Promise<{
 
   try {
     // kind:10002 relay list, kind:10006 blocked relays, kind:10007 search relays
-    const userRelays = await fetchKindList(10002, pubkey);
-    const blockedRelays = await fetchKindList(10006, pubkey);
-    const searchRelays = await fetchKindList(10007, pubkey);
+    const [userRelays, blockedRelays, searchRelays] = await Promise.all([
+      fetchKindList(10002, pubkey),
+      fetchKindList(10006, pubkey),
+      fetchKindList(10007, pubkey)
+    ]);
 
     const result = { userRelays, blockedRelays, searchRelays };
 

--- a/src/lib/search/prewarm.ts
+++ b/src/lib/search/prewarm.ts
@@ -1,0 +1,12 @@
+import { prewarmSearchRelaySet } from '../relays';
+import { loadRules } from './replacements';
+
+/**
+ * Kick off the work the first search would otherwise block on (NIP-50 relay
+ * set resolution, search relay websockets, replacement rules) so it happens
+ * while the user is still typing. Fire-and-forget.
+ */
+export function prewarmSearchRuntime(): void {
+  prewarmSearchRelaySet();
+  void loadRules().catch(() => {});
+}

--- a/src/lib/search/replacements.ts
+++ b/src/lib/search/replacements.ts
@@ -1,6 +1,23 @@
 let cachedRules: Array<{ kind: string; key: string; expansion: string }> | null = null;
 let cachedDirectRules: Array<{ pattern: string; replacement: string }> | null = null;
 
+// Both rule sets parse the same file; fetch it once and share the result
+let replacementsTextPromise: Promise<string> | null = null;
+
+function fetchReplacementsText(): Promise<string> {
+  if (!replacementsTextPromise) {
+    replacementsTextPromise = (async () => {
+      const res = await fetch('/replacements.txt', { cache: 'no-store' });
+      if (!res.ok) throw new Error('failed');
+      return res.text();
+    })().catch((error) => {
+      replacementsTextPromise = null;
+      throw error;
+    });
+  }
+  return replacementsTextPromise;
+}
+
 function parseLine(line: string): { kind: string; key: string; expansion: string } | null {
   const trimmed = line.trim();
   if (!trimmed || trimmed.startsWith('#')) return null;
@@ -43,9 +60,7 @@ function parseDirectLine(line: string): { pattern: string; replacement: string }
 export async function loadRules(): Promise<Array<{ kind: string; key: string; expansion: string }>> {
   if (cachedRules) return cachedRules;
   try {
-    const res = await fetch('/replacements.txt', { cache: 'no-store' });
-    if (!res.ok) throw new Error('failed');
-    const txt = await res.text();
+    const txt = await fetchReplacementsText();
     const rules: Array<{ kind: string; key: string; expansion: string }> = [];
     for (const raw of txt.split(/\r?\n/)) {
       const r = parseLine(raw);
@@ -62,9 +77,7 @@ export async function loadRules(): Promise<Array<{ kind: string; key: string; ex
 async function loadDirectRules(): Promise<Array<{ pattern: string; replacement: string }>> {
   if (cachedDirectRules) return cachedDirectRules;
   try {
-    const res = await fetch('/replacements.txt', { cache: 'no-store' });
-    if (!res.ok) throw new Error('failed');
-    const txt = await res.text();
+    const txt = await fetchReplacementsText();
     const rules: Array<{ pattern: string; replacement: string }> = [];
     for (const raw of txt.split(/\r?\n/)) {
       const r = parseDirectLine(raw);

--- a/src/lib/search/subscriptions.ts
+++ b/src/lib/search/subscriptions.ts
@@ -3,7 +3,7 @@ import { safeSubscribe, isValidFilter, markRelayActivity } from '../ndk';
 import { normalizeRelayUrl } from '../urlUtils';
 import { trackEventRelay } from '../eventRelayTracking';
 import { sortEventsNewestFirst } from '../utils/searchUtils';
-import { RELAYS, createRelaySet, filterNip50Relays } from '../relays';
+import { createRelaySet, filterNip50Relays, getNip50SearchRelaySet } from '../relays';
 import { getSearchRelaySet } from './relayManagement';
 
 /**
@@ -20,10 +20,12 @@ async function restrictToNip50Relays(relaySet: NDKRelaySet): Promise<NDKRelaySet
     if (nip50Urls.length === urls.length) return relaySet;
     if (nip50Urls.length > 0) return createRelaySet(nip50Urls);
   } catch (error) {
-    console.warn('NIP-50 relay filtering failed, using curated search relays:', error);
+    console.warn('NIP-50 relay filtering failed, resolving curated NIP-50 search relays:', error);
   }
-  // Never fall back to non-NIP-50 relays; use the curated search relays instead
-  return createRelaySet([...RELAYS.SEARCH]);
+  // Never fall back to unverified relays; resolve the curated set through the
+  // NIP-50 pipeline (memoized) so even the error path honors the invariant.
+  // An empty set (no results) is preferable to polluted results.
+  return getNip50SearchRelaySet().catch(() => createRelaySet([]));
 }
 
 const PARTIAL_EMIT_INTERVAL_MS = 500;

--- a/src/lib/search/subscriptions.ts
+++ b/src/lib/search/subscriptions.ts
@@ -3,7 +3,28 @@ import { safeSubscribe, isValidFilter, markRelayActivity } from '../ndk';
 import { normalizeRelayUrl } from '../urlUtils';
 import { trackEventRelay } from '../eventRelayTracking';
 import { sortEventsNewestFirst } from '../utils/searchUtils';
+import { RELAYS, createRelaySet, filterNip50Relays } from '../relays';
 import { getSearchRelaySet } from './relayManagement';
+
+/**
+ * Text searches MUST only go to NIP-50 relays. Relays without NIP-50 support
+ * ignore the `search` field and return arbitrary events matching the rest of
+ * the filter, polluting the results. This is the single choke point for all
+ * event subscriptions, so every `search` filter gets restricted here no
+ * matter which relay set (broad, user, fallback) the caller picked.
+ */
+async function restrictToNip50Relays(relaySet: NDKRelaySet): Promise<NDKRelaySet> {
+  try {
+    const urls = Array.from(relaySet.relays).map((relay) => relay.url);
+    const nip50Urls = await filterNip50Relays(urls);
+    if (nip50Urls.length === urls.length) return relaySet;
+    if (nip50Urls.length > 0) return createRelaySet(nip50Urls);
+  } catch (error) {
+    console.warn('NIP-50 relay filtering failed, using curated search relays:', error);
+  }
+  // Never fall back to non-NIP-50 relays; use the curated search relays instead
+  return createRelaySet([...RELAYS.SEARCH]);
+}
 
 const PARTIAL_EMIT_INTERVAL_MS = 500;
 
@@ -89,6 +110,10 @@ export async function subscribeAndCollect(filter: NDKFilter, options: CollectOpt
         console.warn('Failed to resolve relay set in subscribeAndCollect:', error);
         resolve([]);
         return;
+      }
+
+      if (filter.search) {
+        rs = await restrictToNip50Relays(rs);
       }
 
       // An abort may have fired while awaiting the relay set


### PR DESCRIPTION
Cuts search time-to-first-result from ~6s to ~0.5s on a cold cache. Streaming rendering was already in place; the latency came from work that ran before the search subscription even opened: duplicate NIP-11 checks (the relay info cache treated `wss://relay` and `wss://relay/` as different relays), relay set resolution that waited for the slowest relay's HTTP timeout, and nothing being prewarmed while the user types.

- Resolve the search relay set early once three NIP-50 relays confirm; the full check continues in the background and feeds a memoized cache (60s TTL, in-flight dedupe)
- Prewarm on mount: relay set resolution, websockets to search relays, and `replacements.txt`; NIP-51 relay list fetches now run in parallel
- Normalize trailing slashes in the NIP-11 cache key and open relay websockets in parallel with the WASM SQLite cache init on page load

Build preview:
- [/?q=bitcoin](https://ants-git-instant-results-dergigis-projects.vercel.app/?q=bitcoin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Relay connection status now includes response time measurements.

* **Performance**
  * Faster login restoration with optimistic UI loading.
  * Search execution prewarmed to reduce first-search latency.
  * Searches can proceed after first relay connects.
  * Authentication flow no longer requires relay connection.

* **Bug Fixes**
  * Improved cache reliability and relay URL handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->