### PR TITLE
fix: resolve profile picture on login restore

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { restoreLogin, getStoredPubkey } from '@/lib/nip07';
-import { ndk } from '@/lib/ndk';
+import { ndk, connect } from '@/lib/ndk';
 import { useState, useEffect } from 'react';
 import { NDKUser } from '@nostr-dev-kit/ndk';
 import { useRouter } from 'next/navigation';
@@ -20,11 +20,17 @@ export function Header() {
   // Restore login state on mount
   useEffect(() => {
     const fetchProfileInBackground = (u: NDKUser) => {
-      u.fetchProfile().then(() => {
-        // Bump avatar version to force a re-render even if the user object identity is unchanged
-        setAvatarVersion(v => v + 1);
-        setUser(u);
-      }).catch(() => {});
+      // Ensure at least one relay is connected before fetching; otherwise the
+      // profile resolves empty and the avatar falls back to npub initials.
+      connect()
+        .catch(() => {})
+        .then(() => u.fetchProfile())
+        .then(() => {
+          // Bump avatar version to force a re-render even if the user object identity is unchanged
+          setAvatarVersion(v => v + 1);
+          setUser(u);
+        })
+        .catch(() => {});
     };
 
     const applyLoggedOut = () => {
@@ -63,6 +69,7 @@ export function Header() {
           setCurrentUser(u);
           if (u) {
             try { 
+              try { await connect(); } catch {}
               await u.fetchProfile();
               // Bump avatar version to force a re-render even if the user object identity is unchanged
               setAvatarVersion(v => v + 1);


### PR DESCRIPTION
The header avatar fetched the user's profile without waiting for a relay connection, so on login (and on restored sessions) the profile resolved empty and the avatar fell back to the npub initials, showing `NP` in the top-right corner. The fix awaits `connect()` before calling `fetchProfile()`, matching what other call sites like `useNostrUser` and `useProfileScope` already do. Since `connect()` returns as soon as the first relay is up, the instant optimistic login render is unaffected.

- Await `connect()` in `fetchProfileInBackground` on mount before fetching the profile
- Apply the same fix in the `nip07:auth-change` handler

Build preview:
- [/](https://ants-git-fix-login-pp-loading-dergigis-projects.vercel.app/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of profile loading by ensuring proper connection establishment before fetching user information during app startup and authentication changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->