### PR TITLE
feat: add article card portals menu

### DIFF
--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -64,7 +64,9 @@ export default function ArticleCard({
     if (!articleNostrId) return { portalItems: [], clientItems: [] };
 
     const items = createEventExplorerItems(articleNostrId);
-    const articleItems = meta.naddr ? createArticleExplorerItems(meta.naddr) : [];
+    const articleItems = meta.naddr
+      ? createArticleExplorerItems(meta.naddr, event.pubkey, meta.dTag)
+      : [];
     return {
       portalItems: [...articleItems, ...items.slice(0, -2)],
       clientItems: items.slice(-2),

--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -1,15 +1,20 @@
 'use client';
 
 import { NDKEvent } from '@nostr-dev-kit/ndk';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronDown, faChevronUp, faNewspaper } from '@fortawesome/free-solid-svg-icons';
+import { nip19 } from 'nostr-tools';
 import AuthorBadge from '@/components/AuthorBadge';
 import Nip05Display from '@/components/Nip05Display';
 import CardActions from '@/components/CardActions';
 import ArticleMarkdown from '@/components/ArticleMarkdown';
+import ExplorerPortalMenu, { type ExplorerMenuItem } from '@/components/ExplorerPortalMenu';
+import RawEventJson from '@/components/RawEventJson';
 import Image from 'next/image';
+import { createEventExplorerItems } from '@/lib/portals';
 import { extractArticleMetadata, formatArticleDate, truncateMarkdown } from '@/lib/utils/articleUtils';
+import { calculateAbsoluteMenuPosition } from '@/lib/utils';
 import { NDKUser } from '@nostr-dev-kit/ndk';
 import { ndk } from '@/lib/ndk';
 
@@ -31,6 +36,10 @@ export default function ArticleCard({
   defaultExpanded = false,
 }: ArticleCardProps) {
   const [expanded, setExpanded] = useState(defaultExpanded);
+  const [showPortalMenu, setShowPortalMenu] = useState(false);
+  const [menuPosition, setMenuPosition] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
+  const [showRaw, setShowRaw] = useState(false);
+  const portalButtonRef = useRef<HTMLButtonElement>(null);
   const meta = extractArticleMetadata(event);
   const fallbackUser = new NDKUser({ pubkey: event.pubkey });
   fallbackUser.ndk = ndk;
@@ -40,25 +49,41 @@ export default function ArticleCard({
   const truncated = truncateMarkdown(contentPreview);
   const shouldTruncate = truncated.length < contentPreview.length;
   const displayContent = expanded ? contentPreview : truncated;
+  const articleNostrId = meta.naddr || encodeNevent(event.id);
+  const articleNevent = event.id ? encodeNevent(event.id) : '';
 
   const baseClasses = 'relative p-4 bg-[#2d2d2d] border border-[#3d3d3d]';
   const containerClasses = className
     ? `${baseClasses} ${className}`
     : `${baseClasses} rounded-lg`;
 
+  const buildMenuItems = (): { portalItems: ExplorerMenuItem[]; clientItems: ExplorerMenuItem[] } => {
+    if (!articleNostrId) return { portalItems: [], clientItems: [] };
+
+    const items = createEventExplorerItems(articleNostrId);
+    return {
+      portalItems: items.slice(0, -2),
+      clientItems: items.slice(-2),
+    };
+  };
+
   return (
     <div className={containerClasses}>
-      <div className="space-y-3">
-        <ArticleHeader meta={meta} user={user} onAuthorClick={onAuthorClick} />
-        <ArticleBody
-          meta={meta}
-          displayContent={displayContent}
-          shouldTruncate={shouldTruncate}
-          expanded={expanded}
-          setExpanded={setExpanded}
-        />
-        <ArticleTopics topics={meta.topics} />
-      </div>
+      {showRaw ? (
+        <RawEventJson event={event} />
+      ) : (
+        <div className="space-y-3">
+          <ArticleHeader meta={meta} user={user} onAuthorClick={onAuthorClick} />
+          <ArticleBody
+            meta={meta}
+            displayContent={displayContent}
+            shouldTruncate={shouldTruncate}
+            expanded={expanded}
+            setExpanded={setExpanded}
+          />
+          <ArticleTopics topics={meta.topics} />
+        </div>
+      )}
       {showFooter && (
         <div className="mt-4 text-xs text-gray-300 bg-[#2d2d2d] border-t border-[#3d3d3d] -mx-4 -mb-4 px-4 py-2 flex items-center gap-3 flex-wrap rounded-b-lg">
           <div className="flex items-center gap-2 min-h-[1rem]">
@@ -71,12 +96,50 @@ export default function ArticleCard({
               eventId={event?.id}
               profilePubkey={event?.author?.pubkey}
               eventKind={event?.kind}
+              nostrId={meta.naddr || undefined}
+              copyTitle={meta.naddr ? 'Copy naddr' : undefined}
+              secondaryCopyText={meta.naddr && articleNevent ? `nostr:${articleNevent}` : undefined}
+              secondaryCopyTitle="Copy nevent"
+              externalHref={articleNostrId ? `nostr:${articleNostrId}` : undefined}
+              externalTitle={meta.naddr ? 'Open article in native client' : undefined}
+              onToggleMenu={articleNostrId ? () => {
+                if (portalButtonRef.current) {
+                  const rect = portalButtonRef.current.getBoundingClientRect();
+                  setMenuPosition(calculateAbsoluteMenuPosition(rect));
+                }
+                setShowPortalMenu((v) => !v);
+              } : undefined}
+              menuButtonRef={portalButtonRef}
             />
           </div>
         </div>
       )}
+
+      {showPortalMenu && articleNostrId && (() => {
+        const { portalItems, clientItems } = buildMenuItems();
+        return (
+          <ExplorerPortalMenu
+            position={menuPosition}
+            onClose={() => setShowPortalMenu(false)}
+            portalItems={portalItems}
+            clientItems={clientItems}
+            showRaw={showRaw}
+            onToggleRaw={() => setShowRaw((v) => !v)}
+          />
+        );
+      })()}
     </div>
   );
+}
+
+function encodeNevent(eventId: string | undefined): string {
+  if (!eventId) return '';
+
+  try {
+    return nip19.neventEncode({ id: eventId });
+  } catch {
+    return '';
+  }
 }
 
 function ArticleHeader({

--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -64,9 +64,7 @@ export default function ArticleCard({
     if (!articleNostrId) return { portalItems: [], clientItems: [] };
 
     const items = createEventExplorerItems(articleNostrId);
-    const articleItems = meta.naddr
-      ? createArticleExplorerItems(meta.naddr, event.pubkey, meta.dTag)
-      : [];
+    const articleItems = meta.naddr ? createArticleExplorerItems(meta.naddr) : [];
     return {
       portalItems: [...articleItems, ...items.slice(0, -2)],
       clientItems: items.slice(-2),

--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -27,6 +27,9 @@ interface ArticleCardProps {
   defaultExpanded?: boolean;
 }
 
+/**
+ * Render a NIP-23 article card with article-aware portal actions and raw-event inspection.
+ */
 export default function ArticleCard({
   event,
   onAuthorClick,
@@ -133,6 +136,9 @@ export default function ArticleCard({
   );
 }
 
+/**
+ * Safely encode a raw event id as `nevent`, returning an empty string when encoding fails.
+ */
 function encodeNevent(eventId: string | undefined): string {
   if (!eventId) return '';
 
@@ -143,6 +149,9 @@ function encodeNevent(eventId: string | undefined): string {
   }
 }
 
+/**
+ * Render the article header with title, author metadata, and optional summary.
+ */
 function ArticleHeader({
   meta,
   user,
@@ -189,6 +198,9 @@ function ArticleHeader({
   );
 }
 
+/**
+ * Render the cover image and expandable markdown preview for an article.
+ */
 function ArticleBody({
   meta,
   displayContent,
@@ -250,6 +262,9 @@ function ArticleBody({
   );
 }
 
+/**
+ * Render topic tags for a NIP-23 article.
+ */
 function ArticleTopics({ topics }: { topics: string[] }) {
   if (topics.length === 0) return null;
 

--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -12,7 +12,7 @@ import ArticleMarkdown from '@/components/ArticleMarkdown';
 import ExplorerPortalMenu, { type ExplorerMenuItem } from '@/components/ExplorerPortalMenu';
 import RawEventJson from '@/components/RawEventJson';
 import Image from 'next/image';
-import { createEventExplorerItems } from '@/lib/portals';
+import { createArticleExplorerItems, createEventExplorerItems } from '@/lib/portals';
 import { extractArticleMetadata, formatArticleDate, truncateMarkdown } from '@/lib/utils/articleUtils';
 import { calculateAbsoluteMenuPosition } from '@/lib/utils';
 import { NDKUser } from '@nostr-dev-kit/ndk';
@@ -61,8 +61,9 @@ export default function ArticleCard({
     if (!articleNostrId) return { portalItems: [], clientItems: [] };
 
     const items = createEventExplorerItems(articleNostrId);
+    const articleItems = meta.naddr ? createArticleExplorerItems(meta.naddr) : [];
     return {
-      portalItems: items.slice(0, -2),
+      portalItems: [...articleItems, ...items.slice(0, -2)],
       clientItems: items.slice(-2),
     };
   };

--- a/src/components/CardActions.tsx
+++ b/src/components/CardActions.tsx
@@ -89,7 +89,7 @@ const CardActions = forwardRef<HTMLDivElement, Props>(function CardActions(
           <FontAwesomeIcon icon={faMobileScreenButton} className="text-xs" />
         </IconButton>
       ) : null}
-      {(eventId || (eventKind === 0 && profilePubkey)) ? (
+      {defaultNostrId ? (
         <IconButton
           title="Open with njump.to"
           onClick={(e) => {

--- a/src/components/CardActions.tsx
+++ b/src/components/CardActions.tsx
@@ -11,6 +11,10 @@ type Props = {
   eventId?: string;
   profilePubkey?: string;
   eventKind?: number;
+  nostrId?: string;
+  copyTitle?: string;
+  secondaryCopyText?: string;
+  secondaryCopyTitle?: string;
   onToggleMenu?: () => void;
   menuButtonRef?: React.RefObject<HTMLButtonElement | null>;
   className?: string;
@@ -25,6 +29,10 @@ const CardActions = forwardRef<HTMLDivElement, Props>(function CardActions(
     eventId,
     profilePubkey,
     eventKind,
+    nostrId,
+    copyTitle,
+    secondaryCopyText,
+    secondaryCopyTitle,
     onToggleMenu,
     menuButtonRef,
     className,
@@ -35,10 +43,12 @@ const CardActions = forwardRef<HTMLDivElement, Props>(function CardActions(
   }: Props,
   ref
 ) {
-  const neventHref = eventId ? `nostr:${nip19.neventEncode({ id: eventId })}` : undefined;
+  const encodedEventId = eventId ? nip19.neventEncode({ id: eventId }) : undefined;
   const nprofile = profilePubkey ? nip19.nprofileEncode({ pubkey: profilePubkey }) : undefined;
+  const defaultNostrId = eventKind === 0 ? nprofile : (nostrId || encodedEventId);
+  const copyText = defaultNostrId ? `nostr:${defaultNostrId}` : undefined;
   const fallbackTitle = eventId ? 'Open in native client' : 'Open external';
-  const href = externalHref || neventHref;
+  const href = externalHref || (defaultNostrId ? `nostr:${defaultNostrId}` : undefined);
   const title = externalTitle || fallbackTitle;
   const target = externalTarget || (href && href.startsWith('http') ? '_blank' : undefined);
 
@@ -46,16 +56,17 @@ const CardActions = forwardRef<HTMLDivElement, Props>(function CardActions(
 
   return (
     <div ref={ref} className={`flex items-center gap-2 ${className || ''}`.trim()}>
-      {eventKind === 0 && nprofile ? (
+      {copyText ? (
         <CopyButton
-          text={`nostr:${nprofile}`}
-          title="Copy nprofile"
+          text={copyText}
+          title={copyTitle || (eventKind === 0 ? 'Copy nprofile' : 'Copy nevent')}
           className="border-0 text-gray-300 hover:bg-[#3a3a3a]"
         />
-      ) : eventId ? (
+      ) : null}
+      {secondaryCopyText ? (
         <CopyButton
-          text={String(neventHref)}
-          title="Copy nevent"
+          text={secondaryCopyText}
+          title={secondaryCopyTitle || 'Copy'}
           className="border-0 text-gray-300 hover:bg-[#3a3a3a]"
         />
       ) : null}
@@ -84,11 +95,7 @@ const CardActions = forwardRef<HTMLDivElement, Props>(function CardActions(
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
-            const njumpUrl = eventKind === 0 && nprofile 
-              ? `https://njump.to/${nprofile}`
-              : eventId 
-              ? `https://njump.to/${nip19.neventEncode({ id: eventId })}`
-              : null;
+            const njumpUrl = defaultNostrId ? `https://njump.to/${defaultNostrId}` : null;
             if (njumpUrl) {
               window.open(njumpUrl, '_blank', 'noopener,noreferrer');
             }

--- a/src/components/CardActions.tsx
+++ b/src/components/CardActions.tsx
@@ -24,6 +24,9 @@ type Props = {
   onExternalClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
 };
 
+/**
+ * Shared action cluster for cards that expose copy, native-client, portal, and external-link affordances.
+ */
 const CardActions = forwardRef<HTMLDivElement, Props>(function CardActions(
   {
     eventId,

--- a/src/lib/portals.ts
+++ b/src/lib/portals.ts
@@ -10,7 +10,6 @@ export const PROFILE_EXPLORERS: readonly ExplorerLink[] = [
   { name: 'nostr.at', base: 'https://nostr.at/' },
   { name: 'nostr.eu', base: 'https://nostr.eu/' },
   { name: 'nostr.ae', base: 'https://nostr.ae/' },
-  { name: 'nostr.band', base: 'https://nostr.band/' },
   { name: 'npub.world', base: 'https://npub.world/' },
   { name: 'nosta.me', base: 'https://nosta.me/' },
   { name: 'castr.me', base: 'https://castr.me/' },
@@ -26,11 +25,16 @@ export const EVENT_EXPLORERS: readonly ExplorerLink[] = [
   { name: 'nostr.at', base: 'https://nostr.at/' },
   { name: 'nostr.eu', base: 'https://nostr.eu/' },
   { name: 'nostr.ae', base: 'https://nostr.ae/' },
-  { name: 'nostr.band', base: 'https://nostr.band/' },
   { name: 'nostx.io', base: 'https://nostx.io/' },
 ];
 
-export type ExplorerItem = { name: string; href: string };
+export const ARTICLE_EXPLORERS: readonly ExplorerLink[] = [
+  { name: 'Boris', base: 'https://read.withboris.com/a/' },
+  { name: 'Habla', base: 'https://habla.news/a/' },
+  { name: 'Primal', base: 'https://primal.net/e/' },
+] as const;
+
+export type ExplorerItem = { name: string; href: string; dividerAfter?: boolean };
 
 export function createProfileExplorerItems(npub: string, pubkey?: string): readonly ExplorerItem[] {
   const items: ExplorerItem[] = PROFILE_EXPLORERS.map((p) => ({ name: p.name, href: `${p.base}${npub}` }));
@@ -58,4 +62,13 @@ export function createEventExplorerItems(nevent: string): readonly ExplorerItem[
   return items;
 }
 
-
+/**
+ * Build article-specific portals that render NIP-23 content well from an `naddr`.
+ */
+export function createArticleExplorerItems(naddr: string): readonly ExplorerItem[] {
+  return ARTICLE_EXPLORERS.map((p, idx) => ({
+    name: p.name,
+    href: `${p.base}${naddr}`,
+    dividerAfter: idx === ARTICLE_EXPLORERS.length - 1,
+  }));
+}

--- a/src/lib/portals.ts
+++ b/src/lib/portals.ts
@@ -71,27 +71,11 @@ export function createEventExplorerItems(nevent: string): readonly ExplorerItem[
 /**
  * Build article-specific portals that render NIP-23 content well from an `naddr`.
  */
-export function createArticleExplorerItems(
-  naddr: string,
-  pubkey?: string,
-  dTag?: string,
-): readonly ExplorerItem[] {
+export function createArticleExplorerItems(naddr: string): readonly ExplorerItem[] {
   const items: ExplorerItem[] = ARTICLE_EXPLORERS.map((p) => ({
     name: p.name,
     href: `${p.base}${naddr}`,
   }));
-
-  if (pubkey && dTag) {
-    try {
-      const npub = nip19.npubEncode(pubkey);
-      items.splice(2, 0, {
-        name: 'Imwald',
-        href: `https://blog.imwald.eu/p/${npub}/d/${encodeURIComponent(dTag)}`,
-      });
-    } catch {
-      // encoding failed, skip Imwald
-    }
-  }
 
   return items.map((item, idx) => ({
     ...item,

--- a/src/lib/portals.ts
+++ b/src/lib/portals.ts
@@ -36,6 +36,9 @@ export const ARTICLE_EXPLORERS: readonly ExplorerLink[] = [
 
 export type ExplorerItem = { name: string; href: string; dividerAfter?: boolean };
 
+/**
+ * Build profile portal links from an `npub`, preferring `nprofile` for client deep links when possible.
+ */
 export function createProfileExplorerItems(npub: string, pubkey?: string): readonly ExplorerItem[] {
   const items: ExplorerItem[] = PROFILE_EXPLORERS.map((p) => ({ name: p.name, href: `${p.base}${npub}` }));
   let nprofile: string | null = null;
@@ -55,6 +58,9 @@ export function createProfileExplorerItems(npub: string, pubkey?: string): reado
   return items;
 }
 
+/**
+ * Build generic event portal links from a shareable event identifier.
+ */
 export function createEventExplorerItems(nevent: string): readonly ExplorerItem[] {
   const items: ExplorerItem[] = EVENT_EXPLORERS.map((p) => ({ name: p.name, href: `${p.base}${nevent}` }));
   items.push({ name: 'Web Client', href: `web+nostr:${nevent}` });

--- a/src/lib/portals.ts
+++ b/src/lib/portals.ts
@@ -30,7 +30,6 @@ export const EVENT_EXPLORERS: readonly ExplorerLink[] = [
 
 export const ARTICLE_EXPLORERS: readonly ExplorerLink[] = [
   { name: 'Boris', base: 'https://read.withboris.com/a/' },
-  { name: 'Habla', base: 'https://habla.news/a/' },
   { name: 'Primal', base: 'https://primal.net/e/' },
 ] as const;
 
@@ -71,10 +70,30 @@ export function createEventExplorerItems(nevent: string): readonly ExplorerItem[
 /**
  * Build article-specific portals that render NIP-23 content well from an `naddr`.
  */
-export function createArticleExplorerItems(naddr: string): readonly ExplorerItem[] {
-  return ARTICLE_EXPLORERS.map((p, idx) => ({
+export function createArticleExplorerItems(
+  naddr: string,
+  pubkey?: string,
+  dTag?: string,
+): readonly ExplorerItem[] {
+  const items: ExplorerItem[] = ARTICLE_EXPLORERS.map((p) => ({
     name: p.name,
     href: `${p.base}${naddr}`,
-    dividerAfter: idx === ARTICLE_EXPLORERS.length - 1,
+  }));
+
+  if (pubkey && dTag) {
+    try {
+      const npub = nip19.npubEncode(pubkey);
+      items.splice(1, 0, {
+        name: 'Imwald',
+        href: `https://blog.imwald.eu/p/${npub}/d/${encodeURIComponent(dTag)}`,
+      });
+    } catch {
+      // encoding failed, skip Imwald
+    }
+  }
+
+  return items.map((item, idx) => ({
+    ...item,
+    dividerAfter: idx === items.length - 1,
   }));
 }

--- a/src/lib/portals.ts
+++ b/src/lib/portals.ts
@@ -30,6 +30,7 @@ export const EVENT_EXPLORERS: readonly ExplorerLink[] = [
 
 export const ARTICLE_EXPLORERS: readonly ExplorerLink[] = [
   { name: 'Boris', base: 'https://read.withboris.com/a/' },
+  { name: 'Habla', base: 'https://habla.coracle.social/a/' },
   { name: 'Primal', base: 'https://primal.net/e/' },
 ] as const;
 
@@ -83,7 +84,7 @@ export function createArticleExplorerItems(
   if (pubkey && dTag) {
     try {
       const npub = nip19.npubEncode(pubkey);
-      items.splice(1, 0, {
+      items.splice(2, 0, {
         name: 'Imwald',
         href: `https://blog.imwald.eu/p/${npub}/d/${encodeURIComponent(dTag)}`,
       });


### PR DESCRIPTION
This adds the missing article-card actions for `kind:30023` results by wiring the shared portal menu and raw JSON toggle into `ArticleCard`, while using the article `naddr` for article-specific sharing and keeping `nevent` copy available. Fixes #242.

- add the existing three-dot portals menu to long-form article cards
- use `naddr` for native client and article portals, with separate `naddr` and `nevent` copy buttons
- reuse the existing raw JSON view from the menu so article cards match note-card interactions more closely

Build preview: [`is:article by:dergigi.com`](https://ants-git-fix-issue-242-dergigis-projects.vercel.app/?q=is%3Aarticle+by%3Adergigi.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive portal explorer menu for discovering Nostr articles across integrated clients, with improved positioning.
  * Introduced an optional raw event JSON viewer for deeper technical inspection.
  * Enhanced copy button and Nostr linking with customizable labels/text and support for direct Nostr identifiers.
  * Added article-specific portal explorer link generation.
* **Changes**
  * Removed one profile explorer entry from the portal set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
