### PR TITLE
fix: render footnotes in article view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
         "relative-time-format": "^1.1.11",
+        "remark-gfm": "^4.0.1",
         "string-similarity": "^4.0.4"
       },
       "devDependencies": {
@@ -8129,6 +8130,16 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -8185,6 +8196,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8404,6 +8516,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -9598,7 +9831,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9904,6 +10136,24 @@
       "integrity": "sha512-TH+oV/w77hjaB9xCzoFYJ/Icmr/12+02IAoCI/YGS2UBTbjCbBjHGEBxGnVy4EJvOR1qadGzyFRI6hGaJJG93Q==",
       "license": "MIT"
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -9931,6 +10181,21 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
     "relative-time-format": "^1.1.11",
+    "remark-gfm": "^4.0.1",
     "string-similarity": "^4.0.4"
   },
   "devDependencies": {

--- a/src/components/ArticleMarkdown.tsx
+++ b/src/components/ArticleMarkdown.tsx
@@ -3,6 +3,7 @@
 /* eslint-disable @next/next/no-img-element */
 
 import Markdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import remarkNostrLinks from '@/lib/remarkNostrLinks';
 import NostrProfileLink from '@/components/NostrProfileLink';
 
@@ -18,14 +19,14 @@ export default function ArticleMarkdown({ content }: ArticleMarkdownProps) {
   return (
     <div className="article-markdown prose prose-invert prose-sm max-w-none">
       <Markdown
-        remarkPlugins={[remarkNostrLinks]}
+        remarkPlugins={[remarkGfm, remarkNostrLinks]}
         components={{
           a: ({ href, title, children }) => {
             const isProfile = href?.startsWith('/p/');
             if (isProfile && title && href) {
               return <NostrProfileLink token={title} href={href} />;
             }
-            const isInternal = href?.startsWith('/');
+            const isInternal = href?.startsWith('/') || href?.startsWith('#');
             return (
               <a
                 href={href}

--- a/src/components/ArticleMarkdown.tsx
+++ b/src/components/ArticleMarkdown.tsx
@@ -11,81 +11,110 @@ interface ArticleMarkdownProps {
   content: string;
 }
 
+function joinClasses(...classes: Array<string | undefined>): string {
+  return classes.filter(Boolean).join(' ');
+}
+
+function withoutNode<T extends object>(props: T): T {
+  const domProps = { ...props } as T & { node?: unknown };
+  delete domProps.node;
+  return domProps;
+}
+
 /**
  * Renders markdown content for NIP-23 long-form articles.
  * Sanitizes links to open in new tabs and styles elements to match the app theme.
  */
 export default function ArticleMarkdown({ content }: ArticleMarkdownProps) {
+  const scrollToHash = (href: string) => {
+    const targetId = decodeURIComponent(href.slice(1));
+    const target = document.getElementById(targetId);
+    if (!target) return;
+
+    window.history.replaceState(null, '', href);
+    target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
   return (
     <div className="article-markdown prose prose-invert prose-sm max-w-none">
       <Markdown
         remarkPlugins={[remarkGfm, remarkNostrLinks]}
         components={{
-          a: ({ href, title, children }) => {
+          a: ({ href, title, children, className, ...props }) => {
             const isProfile = href?.startsWith('/p/');
             if (isProfile && title && href) {
               return <NostrProfileLink token={title} href={href} />;
             }
-            const isInternal = href?.startsWith('/') || href?.startsWith('#');
+            const isHashLink = href?.startsWith('#');
+            const isInternal = href?.startsWith('/') || isHashLink;
             return (
               <a
+                {...withoutNode(props)}
                 href={href}
                 target={isInternal ? undefined : '_blank'}
                 rel={isInternal ? undefined : 'noopener noreferrer'}
-                className="text-blue-400 hover:text-blue-300 hover:underline"
+                className={joinClasses(
+                  'text-blue-400 hover:text-blue-300 hover:underline',
+                  className,
+                )}
+                onClick={isHashLink && href ? (e) => {
+                  e.preventDefault();
+                  scrollToHash(href);
+                } : undefined}
               >
                 {children}
               </a>
             );
           },
-          h1: ({ children }) => (
-            <h1 className="text-xl font-bold text-gray-100 mt-4 mb-2">{children}</h1>
+          h1: ({ children, className, ...props }) => (
+            <h1 {...withoutNode(props)} className={joinClasses('text-xl font-bold text-gray-100 mt-4 mb-2', className)}>{children}</h1>
           ),
-          h2: ({ children }) => (
-            <h2 className="text-lg font-semibold text-gray-100 mt-3 mb-2">{children}</h2>
+          h2: ({ children, className, ...props }) => (
+            <h2 {...withoutNode(props)} className={joinClasses('text-lg font-semibold text-gray-100 mt-3 mb-2', className)}>{children}</h2>
           ),
-          h3: ({ children }) => (
-            <h3 className="text-base font-semibold text-gray-200 mt-3 mb-1">{children}</h3>
+          h3: ({ children, className, ...props }) => (
+            <h3 {...withoutNode(props)} className={joinClasses('text-base font-semibold text-gray-200 mt-3 mb-1', className)}>{children}</h3>
           ),
-          p: ({ children }) => (
-            <p className="text-gray-100 mb-2 leading-relaxed">{children}</p>
+          p: ({ children, className, ...props }) => (
+            <p {...withoutNode(props)} className={joinClasses('text-gray-100 mb-2 leading-relaxed', className)}>{children}</p>
           ),
-          ul: ({ children }) => (
-            <ul className="list-disc list-inside text-gray-100 mb-2 space-y-1">{children}</ul>
+          ul: ({ children, className, ...props }) => (
+            <ul {...withoutNode(props)} className={joinClasses('list-disc list-inside text-gray-100 mb-2 space-y-1', className)}>{children}</ul>
           ),
-          ol: ({ children }) => (
-            <ol className="list-decimal list-inside text-gray-100 mb-2 space-y-1">{children}</ol>
+          ol: ({ children, className, ...props }) => (
+            <ol {...withoutNode(props)} className={joinClasses('list-decimal list-inside text-gray-100 mb-2 space-y-1', className)}>{children}</ol>
           ),
-          li: ({ children }) => (
-            <li className="text-gray-100">{children}</li>
+          li: ({ children, className, ...props }) => (
+            <li {...withoutNode(props)} className={joinClasses('text-gray-100', className)}>{children}</li>
           ),
-          blockquote: ({ children }) => (
-            <blockquote className="border-l-2 border-gray-500 pl-3 my-2 text-gray-300 italic">
+          blockquote: ({ children, className, ...props }) => (
+            <blockquote {...withoutNode(props)} className={joinClasses('border-l-2 border-gray-500 pl-3 my-2 text-gray-300 italic', className)}>
               {children}
             </blockquote>
           ),
-          code: ({ children, className }) => {
+          code: ({ children, className, ...props }) => {
             const isBlock = className?.includes('language-');
             if (isBlock) {
               return (
                 <pre className="bg-[#1a1a1a] rounded p-3 my-2 overflow-x-auto">
-                  <code className="text-sm text-gray-200">{children}</code>
+                  <code {...withoutNode(props)} className={joinClasses('text-sm text-gray-200', className)}>{children}</code>
                 </pre>
               );
             }
             return (
-              <code className="bg-[#1a1a1a] text-gray-200 px-1 py-0.5 rounded text-sm">
+              <code {...withoutNode(props)} className={joinClasses('bg-[#1a1a1a] text-gray-200 px-1 py-0.5 rounded text-sm', className)}>
                 {children}
               </code>
             );
           },
           pre: ({ children }) => <>{children}</>,
-          hr: () => <hr className="border-[#3d3d3d] my-3" />,
-          img: ({ src, alt }) => (
+          hr: ({ className, ...props }) => <hr {...withoutNode(props)} className={joinClasses('border-[#3d3d3d] my-3', className)} />,
+          img: ({ src, alt, className, ...props }) => (
             <img
+              {...withoutNode(props)}
               src={src}
               alt={alt || ''}
-              className="max-w-full rounded my-2"
+              className={joinClasses('max-w-full rounded my-2', className)}
               loading="lazy"
             />
           ),


### PR DESCRIPTION
This fixes article footnotes in the full article `nevent` view by enabling GFM footnote parsing in `ArticleMarkdown`, preserving markdown-generated anchor attributes, and handling hash-link clicks so references and back-links scroll to the right spot. Fixes #290.

- add `remark-gfm` to the article markdown pipeline so `[^footnote]` syntax is parsed instead of rendered as raw text
- preserve generated `id`, `data-*`, and related attributes on markdown elements so footnote targets exist in the rendered DOM
- handle `#...` links as internal article anchors so footnote refs and back-links scroll within the page

Build preview: [issue example article](https://ants-git-fix-issue-290-dergigis-projects.vercel.app/e/nevent1qqs93zezydkcm3t54jdlga73rzqgjlfm9c39f8wthyjjmperv2l2pxqgyc73w)
