### PR TITLE
fix: prevent duplicate result refreshes

### DIFF
--- a/src/hooks/useSearchExecution.ts
+++ b/src/hooks/useSearchExecution.ts
@@ -56,7 +56,7 @@ export function useSearchExecution(options: SearchExecutionOptions) {
   } = options;
   const router = useRouter();
   const pathname = usePathname();
-  const { currentSearchId, abortControllerRef, suppressSearchRef, lastIdentifierRedirectRef, initialSearchDoneRef, initialQueryNormalizedRef, initialQueryRef, lastHashQueryRef } = refs;
+  const { currentSearchId, abortControllerRef, suppressSearchRef, lastIdentifierRedirectRef, initialSearchDoneRef, initialQueryNormalizedRef, initialQueryRef, lastHashQueryRef, lastExecutedQueryRef } = refs;
 
   // Helper to determine if current query is a direct identifier query
   const isDirectQuery = useMemo(() => {
@@ -147,6 +147,14 @@ export function useSearchExecution(options: SearchExecutionOptions) {
         }
       }
     }
+
+    // Mark this URL state as already handled so URL sync does not immediately re-run the same search.
+    // On profile pages, compare against the implicit URL form without the matching by:<current profile> token.
+    const currentProfileNpubForUrl = getCurrentProfileNpub(pathname);
+    lastHashQueryRef.current = currentProfileNpubForUrl
+      ? toImplicitUrlQuery(searchQuery, currentProfileNpubForUrl)
+      : searchQuery.trim();
+    lastExecutedQueryRef.current = searchQuery;
 
     // Always update URL to reflect the current search
     updateUrlForSearch(searchQuery);
@@ -337,7 +345,7 @@ export function useSearchExecution(options: SearchExecutionOptions) {
         }
       }
     }
-  }, [pathname, router, updateUrlForSearch, profileScopeUser, initialQuery, manageUrl, isDirectQuery, triggerLogin, suppressSearchRef, abortControllerRef, currentSearchId, lastIdentifierRedirectRef, setResults, setLoading, setResolvingAuthor, setShowExternalButton, setSuccessfullyActiveRelays, setToggledRelays, setTopCommandText, setTopExamples, setKindsRules]);
+  }, [pathname, router, updateUrlForSearch, profileScopeUser, initialQuery, manageUrl, isDirectQuery, triggerLogin, suppressSearchRef, abortControllerRef, currentSearchId, lastIdentifierRedirectRef, lastHashQueryRef, lastExecutedQueryRef, setResults, setLoading, setResolvingAuthor, setShowExternalButton, setSuccessfullyActiveRelays, setToggledRelays, setTopCommandText, setTopExamples, setKindsRules]);
 
   // DRY helper function for root searches (always navigate to root path)
   const setQueryAndNavigateToRoot = useCallback((query: string) => {

--- a/src/hooks/useSearchExecution.ts
+++ b/src/hooks/useSearchExecution.ts
@@ -154,7 +154,6 @@ export function useSearchExecution(options: SearchExecutionOptions) {
     lastHashQueryRef.current = currentProfileNpubForUrl
       ? toImplicitUrlQuery(searchQuery, currentProfileNpubForUrl)
       : searchQuery.trim();
-    lastExecutedQueryRef.current = searchQuery;
 
     // Always update URL to reflect the current search
     updateUrlForSearch(searchQuery);
@@ -267,6 +266,7 @@ export function useSearchExecution(options: SearchExecutionOptions) {
       const identifiers = getProfileScopeIdentifiers(profileScopeUser, currentProfileNpub);
       const shouldScope = identifiers ? hasProfileScope(expanded, identifiers) : false;
       const scopedQuery = shouldScope ? ensureAuthorForBackend(expanded, currentProfileNpub) : expanded;
+      lastExecutedQueryRef.current = scopedQuery;
 
       // Choose relay set based on query type
       let relaySet: NDKRelaySet | undefined;

--- a/src/hooks/useUrlSync.ts
+++ b/src/hooks/useUrlSync.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useRef } from 'react';
 import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import { NDKUser } from '@nostr-dev-kit/ndk';
 import { getCurrentProfileNpub, toImplicitUrlQuery, toExplicitInputFromUrl, ensureAuthorForBackend, decodeUrlQuery } from '@/lib/search/queryTransforms';
@@ -126,6 +126,16 @@ export function useUrlSync(options: {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const { initialQueryRef, initialQueryNormalizedRef, initialSearchDoneRef, lastHashQueryRef, lastExecutedQueryRef } = refs;
+  const handleSearchRef = useRef(handleSearch);
+  const runSlashCommandRef = useRef(runSlashCommand);
+
+  useEffect(() => {
+    handleSearchRef.current = handleSearch;
+  }, [handleSearch]);
+
+  useEffect(() => {
+    runSlashCommandRef.current = runSlashCommand;
+  }, [runSlashCommand]);
 
   useEffect(() => {
     if (!manageUrl) return;
@@ -137,7 +147,7 @@ export function useUrlSync(options: {
     const executeSearch = (displayValue: string, backendValue: string) => {
       setQuery(displayValue);
       lastExecutedQueryRef.current = displayValue;
-      handleSearch(backendValue);
+      handleSearchRef.current(backendValue);
     };
 
     if (currentProfileNpub) {
@@ -161,7 +171,7 @@ export function useUrlSync(options: {
 
       if (isSlashCommand(normalizedQuery)) {
         executeSearch(normalizedQuery, normalizedQuery);
-        const unknownCmd = runSlashCommand(normalizedQuery);
+        const unknownCmd = runSlashCommandRef.current(normalizedQuery);
         if (unknownCmd) {
           setTopCommandText(buildCli(unknownCmd, 'Unknown command'));
           setTopExamples(null);
@@ -194,7 +204,7 @@ export function useUrlSync(options: {
 
     if (isSlashCommand(normalizedQuery)) {
       executeSearch(normalizedQuery, normalizedQuery);
-      const unknownCmd = runSlashCommand(normalizedQuery);
+      const unknownCmd = runSlashCommandRef.current(normalizedQuery);
       if (unknownCmd) {
         setTopCommandText(buildCli(unknownCmd, 'Unknown command'));
         setTopExamples(null);
@@ -204,7 +214,7 @@ export function useUrlSync(options: {
     }
 
     executeSearch(normalizedQuery, normalizedQuery);
-  }, [manageUrl, searchParams, pathname, router, runSlashCommand, handleSearch, profileScopeUser, profileIdentifier, setQuery, setTopCommandText, setTopExamples, setKindsRules, lastHashQueryRef, lastExecutedQueryRef, initialQueryNormalizedRef]);
+  }, [manageUrl, searchParams, pathname, router, profileScopeUser, profileIdentifier, setQuery, setTopCommandText, setTopExamples, setKindsRules, lastHashQueryRef, lastExecutedQueryRef, initialQueryNormalizedRef]);
 
   // Reset query tracking refs when the initialQuery prop changes
   useEffect(() => {

--- a/src/hooks/useUrlSync.ts
+++ b/src/hooks/useUrlSync.ts
@@ -135,8 +135,6 @@ export function useUrlSync(options: {
     const currentProfileNpub = getCurrentProfileNpub(pathname);
 
     const executeSearch = (displayValue: string, backendValue: string) => {
-      if (lastHashQueryRef.current === displayValue) return;
-      lastHashQueryRef.current = displayValue;
       setQuery(displayValue);
       lastExecutedQueryRef.current = displayValue;
       handleSearch(backendValue);


### PR DESCRIPTION
This prevents the search flow from re-running the same query after submit just because the URL `q` parameter changed. `handleSearch()` now records the normalized URL state before calling `updateUrlForSearch()`, and keeps `lastExecutedQueryRef` aligned with the canonical query that actually runs, so `useUrlSync()` treats the URL update as already handled instead of firing the same search again a moment later. Fixes #289.

- store the implicit profile-page query in `lastHashQueryRef` before updating the URL
- keep `lastExecutedQueryRef` synced with the canonicalized scoped query that actually reaches search execution
- stop `useUrlSync()` from overwriting that dedupe state with the display query
