### PR TITLE
refactor: extract shared query preprocessing

### DIFF
--- a/src/components/QueryTranslation.tsx
+++ b/src/components/QueryTranslation.tsx
@@ -4,10 +4,9 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faEquals, faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
 import { expandParenthesizedOr, parseOrQuery } from '@/lib/search/queryTransforms';
-import { resolveAuthorToNpub } from '@/lib/vertex';
+import { resolveScopedAuthorTokens } from '@/lib/search/queryPreprocessing';
 import { applySimpleReplacements } from '@/lib/search/replacements';
 import { resolveRelativeDates } from '@/lib/search/relativeDates';
-import { getStoredPubkey } from '@/lib/nip07';
 import { nip19 } from 'nostr-tools';
 import { getLastReducedFilters } from '@/lib/ndk';
 
@@ -62,55 +61,6 @@ export default function QueryTranslation({ query, onAuthorResolved }: QueryTrans
       // 2) Recursive OR substitution (distribute parentheses)
       const distributed = expandParenthesizedOr(afterReplacements);
 
-      const resolveAuthorToken = async (token: string): Promise<string> => {
-        if (/^npub1[0-9a-z]+$/i.test(token)) return token;
-        if (/^@me$/i.test(token)) {
-          try {
-            const storedPubkey = getStoredPubkey();
-            return storedPubkey ? nip19.npubEncode(storedPubkey) : token;
-          } catch {
-            return token;
-          }
-        }
-
-        if (authorResolutionCache.current.has(token)) {
-          return authorResolutionCache.current.get(token) || token;
-        }
-
-        try {
-          const npub = await resolveAuthorToNpub(token);
-          if (npub) {
-            authorResolutionCache.current.set(token, npub);
-            return npub;
-          }
-        } catch {}
-
-        return token;
-      };
-
-      // Helper: resolve all by:/mentions: author tokens within a single query string
-      const resolveAuthorScopedTokensInQuery = async (q: string): Promise<string> => {
-        const rx = /(^|\s)(by|mentions):(\S+)/gi;
-        let result = '';
-        let lastIndex = 0;
-        let m: RegExpExecArray | null;
-        while ((m = rx.exec(q)) !== null) {
-          const full = m[0];
-          const pre = m[1] || '';
-          const scope = m[2] || '';
-          const raw = m[3] || '';
-          const match = raw.match(/^([^),.;]+)([),.;]*)$/);
-          const core = (match && match[1]) || raw;
-          const suffix = (match && match[2]) || '';
-          const replacement = skipAuthorResolution ? core : await resolveAuthorToken(core);
-          result += q.slice(lastIndex, m.index);
-          result += `${pre}${scope}:${replacement}${suffix}`;
-          lastIndex = m.index + full.length;
-        }
-        result += q.slice(lastIndex);
-        return result;
-      };
-
       // Helper: normalize p:<token> where token may be hex, npub or nprofile
       const resolvePTokensInQuery = (q: string): string => {
         const rx = /(^|\s)p:(\S+)/gi;
@@ -149,7 +99,10 @@ export default function QueryTranslation({ query, onAuthorResolved }: QueryTrans
       // 3) Resolve authors inside each distributed branch (if not skipping)
       const resolvedDistributed = skipAuthorResolution 
         ? distributed 
-        : await Promise.all(distributed.map((q) => resolveAuthorScopedTokensInQuery(q)));
+        : await Promise.all(distributed.map(async (q) => {
+          const resolved = await resolveScopedAuthorTokens(q, { cache: authorResolutionCache.current });
+          return resolved.query;
+        }));
 
       const withPResolved = resolvedDistributed.map((q) => resolvePTokensInQuery(q));
 

--- a/src/hooks/useSearchExecution.ts
+++ b/src/hooks/useSearchExecution.ts
@@ -3,18 +3,16 @@
 import { useEffect, useCallback, useMemo, type Dispatch, type SetStateAction } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { NDKEvent, NDKRelaySet, NDKUser } from '@nostr-dev-kit/ndk';
-import { nip19 } from 'nostr-tools';
 import { connect, ConnectionStatus } from '@/lib/ndk';
 import { searchEvents } from '@/lib/search';
-import { resolveAuthorToNpub } from '@/lib/vertex';
 import { extractRelaySourcesFromEvent, createRelaySet } from '@/lib/urlUtils';
 import { extractNip19Identifiers, decodeNip19Identifier } from '@/lib/utils/nostrIdentifiers';
 import { getCurrentProfileNpub, toImplicitUrlQuery, ensureAuthorForBackend } from '@/lib/search/queryTransforms';
+import { extractScopedAuthorTokens, isNpubAuthorToken, resolveScopedAuthorTokens } from '@/lib/search/queryPreprocessing';
 import { getProfileScopeIdentifiers, hasProfileScope } from '@/lib/search/profileScope';
 import { relaySets, getNip50SearchRelaySet } from '@/lib/relays';
 import { prewarmSearchRuntime } from '@/lib/search/prewarm';
 import { isSlashCommand, isUrlQuery, buildCli } from '@/lib/utils/searchViewUtils';
-import { getStoredPubkey } from '@/lib/nip07';
 import { type SearchViewRefs } from '@/hooks/useSearchViewRefs';
 
 type SearchExecutionOptions = {
@@ -183,26 +181,8 @@ export function useSearchExecution(options: SearchExecutionOptions) {
     const isDirectLookup = !manageUrl && initialQuery === searchQuery;
     const minLoadingTime = isDirectLookup ? 800 : 0;
 
-    // Expand by:@me / mentions:@me to the logged-in user's npub
-    const atMePattern = /(?:^|\s)(?:by|mentions):@me\b/i;
-    if (atMePattern.test(searchQuery)) {
-      const storedPubkey = getStoredPubkey();
-      if (storedPubkey) {
-        const myNpub = nip19.npubEncode(storedPubkey);
-        searchQuery = searchQuery.replace(/((?:by|mentions):)@me\b/gi, `$1${myNpub}`);
-      } else {
-        triggerLogin();
-        setLoading(false);
-        setResolvingAuthor(false);
-        return;
-      }
-    }
-
-    // Check if we need to resolve an author first
-    const byMatch = searchQuery.match(/(?:^|\s)by:(\S+)(?:\s|$)/i);
-    const mentionsMatch = searchQuery.match(/(?:^|\s)mentions:(\S+)(?:\s|$)/i);
-    const needsAuthorResolution = (byMatch && !/^npub1[0-9a-z]+$/i.test(byMatch[1]))
-      || (mentionsMatch && !/^npub1[0-9a-z]+$/i.test(mentionsMatch[1]));
+    const authorTokens = extractScopedAuthorTokens(searchQuery);
+    const needsAuthorResolution = authorTokens.some(({ core }) => !isNpubAuthorToken(core));
 
     if (needsAuthorResolution) {
       setResolvingAuthor(true);
@@ -214,50 +194,38 @@ export function useSearchExecution(options: SearchExecutionOptions) {
         return;
       }
 
-      // Pre-resolve by:<author> to npub (if needed) BEFORE searching
       let effectiveQuery = searchQuery;
-      if (needsAuthorResolution && byMatch) {
-        const author = (byMatch[1] || '').trim();
-        let resolvedNpub: string | null = null;
-        try {
-          const TIMEOUT_MS = 2500;
-          const timed = new Promise<null>((resolve) => setTimeout(() => resolve(null), TIMEOUT_MS));
-          resolvedNpub = (await Promise.race([resolveAuthorToNpub(author), timed])) as string | null;
-        } catch {}
-        // If we resolved successfully, replace only the matched by: token with the resolved npub.
-        // If resolution failed, proceed without modifying the query; the backend search will fallback.
-        if (resolvedNpub) {
-          // Replace by: token with resolved npub
-          effectiveQuery = effectiveQuery.replace(/(^|\s)by:(\S+)(?=\s|$)/i, (m, pre) => `${pre}by:${resolvedNpub}`);
-
-          // If currently on a profile page and the resolved author differs, navigate there and carry query
-          const onProfilePage = /^\/p\//i.test(pathname || '');
-          const currentProfileMatch = (pathname || '').match(/^\/p\/(npub1[0-9a-z]+)/i);
-          const currentProfileNpub = currentProfileMatch ? currentProfileMatch[1] : null;
-          if (onProfilePage && currentProfileNpub && currentProfileNpub.toLowerCase() !== resolvedNpub.toLowerCase()) {
-            const implicitQ = toImplicitUrlQuery(effectiveQuery, resolvedNpub);
-            const carry = encodeURIComponent(implicitQ);
-            router.push(`/p/${resolvedNpub}?q=${carry}`);
-            setResolvingAuthor(false);
-            setLoading(false);
-            return;
-          }
+      if (authorTokens.length > 0) {
+        const resolvedAuthors = await resolveScopedAuthorTokens(searchQuery, { onMissingMe: 'flag' });
+        if (resolvedAuthors.needsLoginForAtMe) {
+          triggerLogin();
+          setLoading(false);
+          setResolvingAuthor(false);
+          return;
         }
-        // Resolution phase complete (either way)
-        setResolvingAuthor(false);
+
+        effectiveQuery = resolvedAuthors.query;
+
+        const onProfilePage = /^\/p\//i.test(pathname || '');
+        const currentProfileNpub = getCurrentProfileNpub(pathname);
+        const uniqueByAuthors = Array.from(new Set(
+          resolvedAuthors.byAuthors
+            .filter((author) => isNpubAuthorToken(author))
+            .map((author) => author.toLowerCase())
+        ));
+
+        if (onProfilePage && currentProfileNpub && uniqueByAuthors.length === 1 && currentProfileNpub.toLowerCase() !== uniqueByAuthors[0]) {
+          const targetProfileNpub = uniqueByAuthors[0];
+          const implicitQ = toImplicitUrlQuery(effectiveQuery, targetProfileNpub);
+          const carry = encodeURIComponent(implicitQ);
+          router.push(`/p/${targetProfileNpub}?q=${carry}`);
+          setResolvingAuthor(false);
+          setLoading(false);
+          return;
+        }
       }
 
-      if (mentionsMatch && !/^npub1[0-9a-z]+$/i.test(mentionsMatch[1])) {
-        const author = (mentionsMatch[1] || '').trim();
-        let resolvedNpub: string | null = null;
-        try {
-          const TIMEOUT_MS = 2500;
-          const timed = new Promise<null>((resolve) => setTimeout(() => resolve(null), TIMEOUT_MS));
-          resolvedNpub = (await Promise.race([resolveAuthorToNpub(author), timed])) as string | null;
-        } catch {}
-        if (resolvedNpub) {
-          effectiveQuery = effectiveQuery.replace(/(^|\s)mentions:(\S+)(?=\s|$)/i, (m, pre) => `${pre}mentions:${resolvedNpub}`);
-        }
+      if (needsAuthorResolution) {
         setResolvingAuthor(false);
       }
 

--- a/src/lib/search/queryPreprocessing.ts
+++ b/src/lib/search/queryPreprocessing.ts
@@ -61,7 +61,7 @@ export function extractScopedAuthorTokens(query: string): ScopedAuthorToken[] {
 
   while ((match = AUTHOR_SCOPE_RX.exec(query)) !== null) {
     const pre = match[1] || '';
-    const scope = ((match[2] || '') as 'by' | 'mentions');
+    const scope = (match[2] || '').toLowerCase() as 'by' | 'mentions';
     const raw = match[3] || '';
     const { core, suffix } = splitTokenSuffix(raw);
     tokens.push({

--- a/src/lib/search/queryPreprocessing.ts
+++ b/src/lib/search/queryPreprocessing.ts
@@ -1,0 +1,168 @@
+import { nip19 } from 'nostr-tools';
+import { getStoredPubkey } from '@/lib/nip07';
+import { resolveAuthorToNpub } from '@/lib/vertex';
+
+const NPUB_RX = /^npub1[0-9a-z]+$/i;
+const AUTHOR_SCOPE_RX = /(^|\s)(by|mentions):(\S+)/gi;
+const TRAILING_PUNCT_RX = /^([^),.;]+)([),.;]*)$/;
+const DEFAULT_AUTHOR_RESOLUTION_TIMEOUT_MS = 2500;
+
+export type ScopedAuthorToken = {
+  pre: string;
+  scope: 'by' | 'mentions';
+  raw: string;
+  core: string;
+  suffix: string;
+  index: number;
+  full: string;
+};
+
+export type ScopedAuthorResolutionOptions = {
+  onMissingMe?: 'keep' | 'flag';
+  timeoutMs?: number;
+  cache?: Map<string, string>;
+  authorResolver?: (author: string) => Promise<string | null>;
+};
+
+export type ScopedAuthorResolutionResult = {
+  query: string;
+  byAuthors: string[];
+  mentionAuthors: string[];
+  needsLoginForAtMe: boolean;
+  changed: boolean;
+};
+
+function splitTokenSuffix(raw: string): { core: string; suffix: string } {
+  const match = raw.match(TRAILING_PUNCT_RX);
+  return {
+    core: (match && match[1]) || raw,
+    suffix: (match && match[2]) || ''
+  };
+}
+
+function getStoredNpub(): string | null {
+  const storedPubkey = getStoredPubkey();
+  if (!storedPubkey) return null;
+  try {
+    return nip19.npubEncode(storedPubkey);
+  } catch {
+    return null;
+  }
+}
+
+export function isNpubAuthorToken(token: string): boolean {
+  return NPUB_RX.test((token || '').trim());
+}
+
+export function extractScopedAuthorTokens(query: string): ScopedAuthorToken[] {
+  AUTHOR_SCOPE_RX.lastIndex = 0;
+  const tokens: ScopedAuthorToken[] = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = AUTHOR_SCOPE_RX.exec(query)) !== null) {
+    const pre = match[1] || '';
+    const scope = ((match[2] || '') as 'by' | 'mentions');
+    const raw = match[3] || '';
+    const { core, suffix } = splitTokenSuffix(raw);
+    tokens.push({
+      pre,
+      scope,
+      raw,
+      core,
+      suffix,
+      index: match.index,
+      full: match[0]
+    });
+  }
+
+  return tokens;
+}
+
+async function resolveAuthorCore(
+  core: string,
+  options: ScopedAuthorResolutionOptions
+): Promise<{ value: string; needsLoginForAtMe: boolean }> {
+  if (isNpubAuthorToken(core)) {
+    return { value: core, needsLoginForAtMe: false };
+  }
+
+  if (/^@me$/i.test(core)) {
+    const storedNpub = getStoredNpub();
+    return storedNpub
+      ? { value: storedNpub, needsLoginForAtMe: false }
+      : { value: core, needsLoginForAtMe: true };
+  }
+
+  const cacheKey = core.trim();
+  const cached = options.cache?.get(cacheKey);
+  if (cached) {
+    return { value: cached, needsLoginForAtMe: false };
+  }
+
+  const resolver = options.authorResolver || resolveAuthorToNpub;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_AUTHOR_RESOLUTION_TIMEOUT_MS;
+
+  try {
+    const timed = new Promise<null>((resolve) => setTimeout(() => resolve(null), timeoutMs));
+    const resolved = await Promise.race([resolver(core), timed]);
+    if (resolved) {
+      options.cache?.set(cacheKey, resolved);
+      return { value: resolved, needsLoginForAtMe: false };
+    }
+  } catch {}
+
+  return { value: core, needsLoginForAtMe: false };
+}
+
+export async function resolveScopedAuthorTokens(
+  query: string,
+  options: ScopedAuthorResolutionOptions = {}
+): Promise<ScopedAuthorResolutionResult> {
+  const tokens = extractScopedAuthorTokens(query);
+  if (!tokens.length) {
+    return {
+      query,
+      byAuthors: [],
+      mentionAuthors: [],
+      needsLoginForAtMe: false,
+      changed: false
+    };
+  }
+
+  let result = '';
+  let lastIndex = 0;
+  let changed = false;
+  let needsLoginForAtMe = false;
+  const byAuthors: string[] = [];
+  const mentionAuthors: string[] = [];
+  const onMissingMe = options.onMissingMe || 'keep';
+
+  for (const token of tokens) {
+    const { value, needsLoginForAtMe: tokenNeedsLogin } = await resolveAuthorCore(token.core, options);
+    const resolvedValue = tokenNeedsLogin && onMissingMe === 'flag' ? token.core : value;
+    const replacement = `${token.pre}${token.scope}:${resolvedValue}${token.suffix}`;
+
+    needsLoginForAtMe ||= tokenNeedsLogin;
+    changed ||= replacement !== token.full;
+
+    result += query.slice(lastIndex, token.index);
+    result += replacement;
+    lastIndex = token.index + token.full.length;
+
+    if (token.scope === 'by') {
+      byAuthors.push(resolvedValue);
+    } else {
+      mentionAuthors.push(resolvedValue);
+    }
+  }
+
+  result += query.slice(lastIndex);
+
+  return {
+    query: result,
+    byAuthors,
+    mentionAuthors,
+    needsLoginForAtMe,
+    changed
+  };
+}


### PR DESCRIPTION
This extracts scoped author query preprocessing into a shared helper so search execution and query translation resolve `@me`, `by:`, and `mentions:` tokens the same way, which closes the drift tracked in issue 272. It also trims `useSearchExecution.ts` back under the repo file-size limit and keeps the profile-page redirect behavior driven by the resolved query output. Fixes #272.

- add `src/lib/search/queryPreprocessing.ts` for shared scoped-author token parsing and resolution
- wire `useSearchExecution` and `QueryTranslation` through the shared helper instead of maintaining separate resolution code paths
- keep local validation green with `npm run lint` and `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated author token resolution logic in search queries to improve maintainability and reduce code duplication across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->