### PR TITLE
chore: release v0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.6] - 2026-08-19
+
+### Added
+- Added NIP-66 relay discovery as a source of candidate NIP-50 search relays
+- Added active NIP-50 behavior probes to reject relays that ignore `search` filters
+
+### Changed
+- Refreshed the hard-coded default, search, and profile search relay lists
+
+### Fixed
+- Prevent stale asynchronous relay probes from refilling cleared relay caches
+- Kept profile lookup on the curated profile search relay set so username resolution stays stable
+
 ## [0.4.5] - 2026-06-16
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ants.dergigi.com",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ants.dergigi.com",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
         "@fortawesome/free-brands-svg-icons": "^6.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ants.dergigi.com",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "private": true,
   "scripts": {
     "dev": "next dev --port 7473",


### PR DESCRIPTION
Prepares the v0.4.6 patch release for the relay health fix merged in #301. This bumps the package version and records the relay default refresh, NIP-66 candidate discovery, active NIP-50 behavior probes, and cache invalidation guards in `CHANGELOG.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NIP-66 relay discovery.
  * Added active NIP-50 behavior probes.
  * Refreshed relay lists for improved discovery.

* **Bug Fixes**
  * Prevented stale probe data from refilling the cache.
  * Improved stability when selecting relays for profile lookups.

* **Chores**
  * Updated the application version to 0.4.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->