### PR TITLE
fix: prevent repeated search refreshes

### DIFF
--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -35,6 +35,7 @@ type Props = {
   onUrlUpdate?: (query: string) => void;
 };
 
+/** Renders the search interface and coordinates query state, filters, and URL sync. */
 export default function SearchView({ initialQuery = '', manageUrl = true, onUrlUpdate }: Props) {
   const router = useRouter();
   const pathname = usePathname();
@@ -148,11 +149,16 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
 
   const { setClearHandler } = useClearTrigger();
   const handleClear = useCallback(() => {
+    const cancelledSearchId = refs.currentSearchId.current;
     // Abort any ongoing search immediately
     if (refs.abortControllerRef.current) {
       refs.abortControllerRef.current.abort();
     }
     refs.currentSearchId.current++;
+    if (refs.activeSearchIdRef.current === cancelledSearchId) {
+      refs.activeSearchKeysRef.current.clear();
+      refs.activeSearchIdRef.current = null;
+    }
     setQuery('');
     setResults([]);
     setLoading(false);

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -82,6 +82,11 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
     handleExampleNext
   } = useSearchUi({ query, loading, setQuery, suppressSearchRef: refs.suppressSearchRef });
 
+  const handleSearchInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    refs.completedSearchKeysRef.current.clear();
+    handleInputChange(e);
+  }, [refs, handleInputChange]);
+
   const {
     runSlashCommand,
     topCommandText,
@@ -268,7 +273,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
           resolvingAuthor={resolvingAuthor}
           showExternalButton={showExternalButton}
           profileScopeUser={profileScopeUser}
-          onInputChange={handleInputChange}
+          onInputChange={handleSearchInputChange}
           onClear={handleClear}
           onOpenExternal={handleOpenExternal}
           onSubmit={handleSubmit}

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -85,6 +85,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
 
   const handleSearchInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     refs.completedSearchKeysRef.current.clear();
+    refs.lastExecutedQueryRef.current = null;
     handleInputChange(e);
   }, [refs, handleInputChange]);
 
@@ -160,6 +161,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       refs.activeSearchIdRef.current = null;
     }
     refs.completedSearchKeysRef.current.clear();
+    refs.lastExecutedQueryRef.current = null;
     setQuery('');
     setResults([]);
     setLoading(false);

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -159,6 +159,7 @@ export default function SearchView({ initialQuery = '', manageUrl = true, onUrlU
       refs.activeSearchKeysRef.current.clear();
       refs.activeSearchIdRef.current = null;
     }
+    refs.completedSearchKeysRef.current.clear();
     setQuery('');
     setResults([]);
     setLoading(false);

--- a/src/hooks/useSearchExecution.ts
+++ b/src/hooks/useSearchExecution.ts
@@ -57,10 +57,9 @@ export function useSearchExecution(options: SearchExecutionOptions) {
   const {
     currentSearchId, abortControllerRef, suppressSearchRef, lastIdentifierRedirectRef,
     initialSearchDoneRef, initialQueryNormalizedRef, initialQueryRef,
-    lastHashQueryRef, lastExecutedQueryRef, activeSearchKeysRef, completedSearchKeysRef
+    lastHashQueryRef, lastExecutedQueryRef, activeSearchIdRef, activeSearchKeysRef, completedSearchKeysRef
   } = refs;
 
-  // Helper to determine if current query is a direct identifier query
   const isDirectQuery = useMemo(() => {
     const trimmedQuery = query.trim();
     if (!trimmedQuery) return false;
@@ -94,7 +93,6 @@ export function useSearchExecution(options: SearchExecutionOptions) {
 
   const handleSearch = useCallback(async (searchQuery: string) => {
     if (suppressSearchRef.current) {
-      // Clear the flag and ignore this invocation
       suppressSearchRef.current = false;
       return;
     }
@@ -104,7 +102,6 @@ export function useSearchExecution(options: SearchExecutionOptions) {
       return;
     }
 
-    // Update URL immediately when search is triggered
     const normalizedInput = searchQuery.trim();
     if (activeSearchKeysRef.current.has(normalizedInput) || completedSearchKeysRef.current.has(normalizedInput)) {
       return;
@@ -152,9 +149,6 @@ export function useSearchExecution(options: SearchExecutionOptions) {
         }
       }
     }
-
-    activeSearchKeysRef.current = new Set([normalizedInput]);
-
     // Mark this URL state as already handled so URL sync does not immediately re-run the same search.
     // On profile pages, compare against the implicit URL form without the matching by:<current profile> token.
     const currentProfileNpubForUrl = getCurrentProfileNpub(pathname);
@@ -162,20 +156,18 @@ export function useSearchExecution(options: SearchExecutionOptions) {
       ? toImplicitUrlQuery(searchQuery, currentProfileNpubForUrl)
       : searchQuery.trim();
 
-    // Always update URL to reflect the current search
     updateUrlForSearch(searchQuery);
 
-    // Abort any ongoing search
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
     }
 
-    // Create new AbortController for this search
     const abortController = new AbortController();
     abortControllerRef.current = abortController;
     const searchId = ++currentSearchId.current;
+    activeSearchKeysRef.current = new Set([normalizedInput]);
+    activeSearchIdRef.current = searchId;
 
-    // Clear previous UI immediately
     const isCmd = isSlashCommand(searchQuery);
     if (!isCmd) {
       setTopCommandText(null);
@@ -198,7 +190,6 @@ export function useSearchExecution(options: SearchExecutionOptions) {
     }
 
     try {
-      // Check if search was aborted before making the call
       if (abortController.signal.aborted || currentSearchId.current !== searchId) {
         return;
       }
@@ -206,6 +197,10 @@ export function useSearchExecution(options: SearchExecutionOptions) {
       let effectiveQuery = searchQuery;
       if (authorTokens.length > 0) {
         const resolvedAuthors = await resolveScopedAuthorTokens(searchQuery, { onMissingMe: 'flag' });
+        if (abortController.signal.aborted || currentSearchId.current !== searchId) {
+          return;
+        }
+
         if (resolvedAuthors.needsLoginForAtMe) {
           triggerLogin();
           setLoading(false);
@@ -246,14 +241,17 @@ export function useSearchExecution(options: SearchExecutionOptions) {
       const searchKeys = new Set([normalizedInput, scopedQuery.trim()].filter(Boolean));
       const alreadyCompleted = Array.from(searchKeys).some((key) => completedSearchKeysRef.current.has(key));
       if (alreadyCompleted) {
-        activeSearchKeysRef.current.clear();
+        if (activeSearchIdRef.current === searchId) {
+          activeSearchKeysRef.current.clear();
+          activeSearchIdRef.current = null;
+        }
         return;
       }
       activeSearchKeysRef.current = searchKeys;
+      activeSearchIdRef.current = searchId;
       completedSearchKeysRef.current.clear();
       lastExecutedQueryRef.current = scopedQuery;
 
-      // Choose relay set based on query type
       let relaySet: NDKRelaySet | undefined;
       if (isDirectQuery) {
         // Direct queries (NIP-19): use all relays
@@ -281,7 +279,6 @@ export function useSearchExecution(options: SearchExecutionOptions) {
       }, relaySet, abortController.signal);
       searchSettled = true;
 
-      // Check if search was aborted after getting results
       if (abortController.signal.aborted || currentSearchId.current !== searchId) {
         return;
       }
@@ -315,9 +312,12 @@ export function useSearchExecution(options: SearchExecutionOptions) {
       console.error('Search error:', error);
       setResults([]);
     } finally {
+      if (activeSearchIdRef.current === searchId) {
+        activeSearchKeysRef.current.clear();
+        activeSearchIdRef.current = null;
+      }
       // Only update loading state if this is still the current search
       if (currentSearchId.current === searchId) {
-        activeSearchKeysRef.current.clear();
         // Ensure minimum loading time for direct lookups to show animation
         if (minLoadingTime > 0) {
           setTimeout(() => {
@@ -332,7 +332,7 @@ export function useSearchExecution(options: SearchExecutionOptions) {
         }
       }
     }
-  }, [pathname, router, updateUrlForSearch, profileScopeUser, initialQuery, manageUrl, isDirectQuery, triggerLogin, suppressSearchRef, abortControllerRef, currentSearchId, lastIdentifierRedirectRef, lastHashQueryRef, lastExecutedQueryRef, activeSearchKeysRef, completedSearchKeysRef, setResults, setLoading, setResolvingAuthor, setShowExternalButton, setSuccessfullyActiveRelays, setToggledRelays, setTopCommandText, setTopExamples, setKindsRules]);
+  }, [pathname, router, updateUrlForSearch, profileScopeUser, initialQuery, manageUrl, isDirectQuery, triggerLogin, suppressSearchRef, abortControllerRef, currentSearchId, lastIdentifierRedirectRef, lastHashQueryRef, lastExecutedQueryRef, activeSearchIdRef, activeSearchKeysRef, completedSearchKeysRef, setResults, setLoading, setResolvingAuthor, setShowExternalButton, setSuccessfullyActiveRelays, setToggledRelays, setTopCommandText, setTopExamples, setKindsRules]);
 
   // DRY helper function for root searches (always navigate to root path)
   const setQueryAndNavigateToRoot = useCallback((query: string) => {
@@ -394,11 +394,16 @@ export function useSearchExecution(options: SearchExecutionOptions) {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape' && loading) {
+        const cancelledSearchId = currentSearchId.current;
         // Abort any ongoing search
         if (abortControllerRef.current) {
           abortControllerRef.current.abort();
         }
         currentSearchId.current++;
+        if (activeSearchIdRef.current === cancelledSearchId) {
+          activeSearchKeysRef.current.clear();
+          activeSearchIdRef.current = null;
+        }
         setLoading(false);
         setResolvingAuthor(false);
       }
@@ -408,7 +413,7 @@ export function useSearchExecution(options: SearchExecutionOptions) {
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [loading, abortControllerRef, currentSearchId, setLoading, setResolvingAuthor]);
+  }, [loading, abortControllerRef, currentSearchId, activeSearchIdRef, activeSearchKeysRef, setLoading, setResolvingAuthor]);
 
   return { isDirectQuery, handleSearch, handleContentSearch };
 }

--- a/src/hooks/useSearchExecution.ts
+++ b/src/hooks/useSearchExecution.ts
@@ -54,7 +54,11 @@ export function useSearchExecution(options: SearchExecutionOptions) {
   } = options;
   const router = useRouter();
   const pathname = usePathname();
-  const { currentSearchId, abortControllerRef, suppressSearchRef, lastIdentifierRedirectRef, initialSearchDoneRef, initialQueryNormalizedRef, initialQueryRef, lastHashQueryRef, lastExecutedQueryRef } = refs;
+  const {
+    currentSearchId, abortControllerRef, suppressSearchRef, lastIdentifierRedirectRef,
+    initialSearchDoneRef, initialQueryNormalizedRef, initialQueryRef,
+    lastHashQueryRef, lastExecutedQueryRef, activeSearchKeysRef, completedSearchKeysRef
+  } = refs;
 
   // Helper to determine if current query is a direct identifier query
   const isDirectQuery = useMemo(() => {
@@ -102,6 +106,9 @@ export function useSearchExecution(options: SearchExecutionOptions) {
 
     // Update URL immediately when search is triggered
     const normalizedInput = searchQuery.trim();
+    if (activeSearchKeysRef.current.has(normalizedInput) || completedSearchKeysRef.current.has(normalizedInput)) {
+      return;
+    }
     const nip19Identifiers = extractNip19Identifiers(normalizedInput);
     const identifierToken = nip19Identifiers.length > 0 ? nip19Identifiers[0].trim() : null;
     const identifierLower = identifierToken ? identifierToken.toLowerCase() : null;
@@ -145,6 +152,8 @@ export function useSearchExecution(options: SearchExecutionOptions) {
         }
       }
     }
+
+    activeSearchKeysRef.current = new Set([normalizedInput]);
 
     // Mark this URL state as already handled so URL sync does not immediately re-run the same search.
     // On profile pages, compare against the implicit URL form without the matching by:<current profile> token.
@@ -234,6 +243,14 @@ export function useSearchExecution(options: SearchExecutionOptions) {
       const identifiers = getProfileScopeIdentifiers(profileScopeUser, currentProfileNpub);
       const shouldScope = identifiers ? hasProfileScope(expanded, identifiers) : false;
       const scopedQuery = shouldScope ? ensureAuthorForBackend(expanded, currentProfileNpub) : expanded;
+      const searchKeys = new Set([normalizedInput, scopedQuery.trim()].filter(Boolean));
+      const alreadyCompleted = Array.from(searchKeys).some((key) => completedSearchKeysRef.current.has(key));
+      if (alreadyCompleted) {
+        activeSearchKeysRef.current.clear();
+        return;
+      }
+      activeSearchKeysRef.current = searchKeys;
+      completedSearchKeysRef.current.clear();
       lastExecutedQueryRef.current = scopedQuery;
 
       // Choose relay set based on query type
@@ -289,6 +306,7 @@ export function useSearchExecution(options: SearchExecutionOptions) {
 
       // Check if this was a URL query and if we got 0 results
       setShowExternalButton(isUrlQuery(searchQuery) && filtered.length === 0);
+      completedSearchKeysRef.current = new Set(searchKeys);
     } catch (error) {
       // Don't log aborted searches as errors
       if (error instanceof Error && (error.name === 'AbortError' || error.message === 'Search aborted')) {
@@ -299,6 +317,7 @@ export function useSearchExecution(options: SearchExecutionOptions) {
     } finally {
       // Only update loading state if this is still the current search
       if (currentSearchId.current === searchId) {
+        activeSearchKeysRef.current.clear();
         // Ensure minimum loading time for direct lookups to show animation
         if (minLoadingTime > 0) {
           setTimeout(() => {
@@ -313,7 +332,7 @@ export function useSearchExecution(options: SearchExecutionOptions) {
         }
       }
     }
-  }, [pathname, router, updateUrlForSearch, profileScopeUser, initialQuery, manageUrl, isDirectQuery, triggerLogin, suppressSearchRef, abortControllerRef, currentSearchId, lastIdentifierRedirectRef, lastHashQueryRef, lastExecutedQueryRef, setResults, setLoading, setResolvingAuthor, setShowExternalButton, setSuccessfullyActiveRelays, setToggledRelays, setTopCommandText, setTopExamples, setKindsRules]);
+  }, [pathname, router, updateUrlForSearch, profileScopeUser, initialQuery, manageUrl, isDirectQuery, triggerLogin, suppressSearchRef, abortControllerRef, currentSearchId, lastIdentifierRedirectRef, lastHashQueryRef, lastExecutedQueryRef, activeSearchKeysRef, completedSearchKeysRef, setResults, setLoading, setResolvingAuthor, setShowExternalButton, setSuccessfullyActiveRelays, setToggledRelays, setTopCommandText, setTopExamples, setKindsRules]);
 
   // DRY helper function for root searches (always navigate to root path)
   const setQueryAndNavigateToRoot = useCallback((query: string) => {

--- a/src/hooks/useSearchViewRefs.ts
+++ b/src/hooks/useSearchViewRefs.ts
@@ -13,6 +13,7 @@ export type SearchViewRefs = {
   initialQueryRef: MutableRefObject<string>;
   lastHashQueryRef: MutableRefObject<string | null>;
   lastExecutedQueryRef: MutableRefObject<string | null>;
+  activeSearchIdRef: MutableRefObject<number | null>;
   activeSearchKeysRef: MutableRefObject<Set<string>>;
   completedSearchKeysRef: MutableRefObject<Set<string>>;
 };
@@ -31,6 +32,7 @@ export function useSearchViewRefs(initialQuery: string, manageUrl: boolean): Sea
   const initialQueryRef = useRef(initialQuery);
   const lastHashQueryRef = useRef<string | null>(bootstrapInitial);
   const lastExecutedQueryRef = useRef<string | null>(bootstrapInitial);
+  const activeSearchIdRef = useRef<number | null>(null);
   const activeSearchKeysRef = useRef<Set<string>>(new Set());
   const completedSearchKeysRef = useRef<Set<string>>(new Set());
 
@@ -44,6 +46,7 @@ export function useSearchViewRefs(initialQuery: string, manageUrl: boolean): Sea
     initialQueryRef,
     lastHashQueryRef,
     lastExecutedQueryRef,
+    activeSearchIdRef,
     activeSearchKeysRef,
     completedSearchKeysRef
   }), []);

--- a/src/hooks/useSearchViewRefs.ts
+++ b/src/hooks/useSearchViewRefs.ts
@@ -13,6 +13,8 @@ export type SearchViewRefs = {
   initialQueryRef: MutableRefObject<string>;
   lastHashQueryRef: MutableRefObject<string | null>;
   lastExecutedQueryRef: MutableRefObject<string | null>;
+  activeSearchKeysRef: MutableRefObject<Set<string>>;
+  completedSearchKeysRef: MutableRefObject<Set<string>>;
 };
 
 /** Mutable refs shared between the search execution and URL sync hooks */
@@ -29,6 +31,8 @@ export function useSearchViewRefs(initialQuery: string, manageUrl: boolean): Sea
   const initialQueryRef = useRef(initialQuery);
   const lastHashQueryRef = useRef<string | null>(bootstrapInitial);
   const lastExecutedQueryRef = useRef<string | null>(bootstrapInitial);
+  const activeSearchKeysRef = useRef<Set<string>>(new Set());
+  const completedSearchKeysRef = useRef<Set<string>>(new Set());
 
   return useMemo(() => ({
     currentSearchId,
@@ -39,6 +43,8 @@ export function useSearchViewRefs(initialQuery: string, manageUrl: boolean): Sea
     initialQueryNormalizedRef,
     initialQueryRef,
     lastHashQueryRef,
-    lastExecutedQueryRef
+    lastExecutedQueryRef,
+    activeSearchKeysRef,
+    completedSearchKeysRef
   }), []);
 }


### PR DESCRIPTION
Prevents completed searches from starting a same-query refresh that clears results and briefly shows the spinner again. The search view now tracks active and completed normalized search keys, including post-resolution author-scoped keys, and clears the completed guard when the user edits the input so real query changes still run normally.

- Fixes https://github.com/dergigi/ants/issues/303.
- Verified with `npm run lint`, `npm run build`, and focused Playwright smoke checks for same-query submit and edited-query restart.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate searches for the same query and scope.
  * Avoided re-running searches that have already completed.
  * Prevented older searches from affecting newer search results.
  * Improved cleanup when search input changes, searches finish, or searches are cancelled.
  * Ensured cancelled searches no longer leave stale active-search state behind.
  * Improved Escape-key and manual cancellation behavior for more reliable search state resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->