### PR TITLE
chore: release v0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.7] - 2026-08-28
+
+### Fixed
+- Prevent repeated same-query search refreshes from briefly clearing rendered results and showing the loading spinner again
+- Reset completed and last-executed search guards when the search input is edited or cleared
+
 ## [0.4.6] - 2026-08-19
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ants.dergigi.com",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ants.dergigi.com",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
         "@fortawesome/free-brands-svg-icons": "^6.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ants.dergigi.com",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "private": true,
   "scripts": {
     "dev": "next dev --port 7473",


### PR DESCRIPTION
Bumps the app to `v0.4.7` for the search refresh fix from PR 304 and records the patch release in `CHANGELOG.md`.

- Updates `package.json` and `package-lock.json` to `0.4.7`.
- Adds changelog notes for the repeated search refresh fix and reset guard cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed repeated refreshes for the same search query.
  * Search behavior now resets correctly when the input changes or is cleared.

* **Chores**
  * Updated the package version to 0.4.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->