### PR TITLE
fix: bound search waits and clean up subscriptions

### DIFF
--- a/src/lib/ndk/subscribe.ts
+++ b/src/lib/ndk/subscribe.ts
@@ -37,7 +37,7 @@ export const isValidFilter = (filter: NDKFilter): boolean => {
  * @param options - Subscription options
  * @returns NDK subscription or null if filters are invalid
  */
-export const safeSubscribe = (filters: NDKFilter[], options: Record<string, unknown> = {}): NDKSubscription | null => {
+export const safeSubscribe = (filters: NDKFilter[], options: Record<string, unknown> = {}, autoStart = true): NDKSubscription | null => {
   const trackFilters = Boolean((options as { __trackFilters?: boolean }).__trackFilters);
   // Validate all filters
   const validFilters = filters.filter(isValidFilter);
@@ -63,7 +63,7 @@ export const safeSubscribe = (filters: NDKFilter[], options: Record<string, unkn
   }
 
   try {
-    return ndk.subscribe(reducedFilters, options);
+    return ndk.subscribe(reducedFilters, options, autoStart);
   } catch (error) {
     // If the sqlite-wasm cache throws the binding error, disable cache and retry once live-only
     if (isUndefinedBindWasmError(error)) {
@@ -72,7 +72,7 @@ export const safeSubscribe = (filters: NDKFilter[], options: Record<string, unkn
       try {
         // Force cache usage to ONLY_RELAY to bypass cache completely
         const liveOptions = { ...options, cacheUsage: NDKSubscriptionCacheUsage.ONLY_RELAY };
-        return ndk.subscribe(reducedFilters, liveOptions);
+        return ndk.subscribe(reducedFilters, liveOptions, autoStart);
       } catch (e2) {
         console.error('Failed to create NDK subscription after disabling cache:', e2);
         return null;

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -44,104 +44,108 @@ export async function searchEvents(
   }
 
   // Shared emitter: merges partials across all subscriptions of this search
-  const onPartialResults = createPartialEmitter(options?.onPartialResults);
-  const onProfileResultsUpdate = options?.onProfileResultsUpdate;
-
-  // Extract NIP-50 extensions first
-  const nip50Extraction = extractNip50Extensions(query);
-  const nip50Extensions = nip50Extraction.extensions;
-
-  // Remove legacy relay filters and choose the default search relay set
-  let chosenRelaySet: NDKRelaySet;
-  if (relaySetOverride) {
-    chosenRelaySet = relaySetOverride;
-  } else {
-    try {
-      chosenRelaySet = await getNip50SearchRelaySet();
-    } catch (error) {
-      console.warn('Failed to get NIP-50 search relay set, falling back to broader relay set:', error);
-      // Fallback to broader relay set if NIP-50 search fails
-      chosenRelaySet = await getBroadRelaySet();
-    }
-  }
-
-  // Strip legacy relay filters but keep the rest of the query intact
-  const extCleanedQuery = stripRelayFilters(nip50Extraction.cleaned);
-
-  // Apply simple replacements to expand is: patterns to kind: patterns
-  const { applySimpleReplacements } = await import('./search/replacements');
-  const preprocessedQuery = await applySimpleReplacements(extCleanedQuery);
-
-  // Parse query into structured format
-  const parsedQuery = parseSearchQuery(preprocessedQuery, SEARCH_DEFAULT_KINDS);
-  const { cleanedQuery, effectiveKinds, dateFilter, hasTopLevelOr, topLevelOrParts, extensionFilters } = parsedQuery;
-
-  // Build search context for strategies (needed early for author search)
-  const searchContext: SearchContext = {
-    effectiveKinds,
-    dateFilter,
-    nip50Extensions,
-    chosenRelaySet,
-    relaySetOverride,
-    abortSignal,
-    limit,
-    extensionFilters,
-    onPartialResults,
-    onProfileResultsUpdate
-  };
-
-  // Distribute parenthesized OR seeds across the entire query BEFORE any specialized handling
-  // e.g., "(GM OR GN) by:dergigi" => ["GM by:dergigi", "GN by:dergigi"]
-  const parenthesizedOrResults = await handleParenthesizedOr(cleanedQuery, searchContext);
-  if (parenthesizedOrResults !== null) {
-    return parenthesizedOrResults;
-  }
-
-  // EARLY: Author filter handling (resolve by:<author> to npub and use authors[] filter)
-  if (!hasTopLevelOr) {
-    const earlyAuthorResults = await tryHandleAuthorSearch(cleanedQuery, searchContext);
-    if (earlyAuthorResults) return earlyAuthorResults;
-  }
-
-  // Check for top-level OR operator (outside parentheses)
-  if (hasTopLevelOr) {
-    return handleTopLevelOr(topLevelOrParts, searchContext);
-  }
-
-  // Run search strategies in order
-  const strategyResults = await runSearchStrategies(extCleanedQuery, cleanedQuery, searchContext);
-  if (strategyResults) return strategyResults;
-
-  // Regular search without author filter
+  const onPartialResults = createPartialEmitter(options?.onPartialResults, abortSignal);
   try {
-    let results: NDKEvent[] = [];
-    const baseSearch = options?.exact ? `"${cleanedQuery}"` : cleanedQuery || undefined;
-    const searchQuery = baseSearch ? buildSearchQueryWithExtensions(baseSearch, nip50Extensions) : undefined;
-    // Create the filter object that will be sent to NDK
-    const searchFilter = applyDateFilter({
-      kinds: effectiveKinds,
-      search: searchQuery
-    }, dateFilter) as NDKFilter;
+    const onProfileResultsUpdate = options?.onProfileResultsUpdate;
 
-    results = await subscribeAndCollect(searchFilter, {
-      timeoutMs: 8000,
-      relaySet: chosenRelaySet,
+    // Extract NIP-50 extensions first
+    const nip50Extraction = extractNip50Extensions(query);
+    const nip50Extensions = nip50Extraction.extensions;
+
+    // Remove legacy relay filters and choose the default search relay set
+    let chosenRelaySet: NDKRelaySet;
+    if (relaySetOverride) {
+      chosenRelaySet = relaySetOverride;
+    } else {
+      try {
+        chosenRelaySet = await getNip50SearchRelaySet();
+      } catch (error) {
+        console.warn('Failed to get NIP-50 search relay set, falling back to broader relay set:', error);
+        // Fallback to broader relay set if NIP-50 search fails
+        chosenRelaySet = await getBroadRelaySet();
+      }
+    }
+
+    // Strip legacy relay filters but keep the rest of the query intact
+    const extCleanedQuery = stripRelayFilters(nip50Extraction.cleaned);
+
+    // Apply simple replacements to expand is: patterns to kind: patterns
+    const { applySimpleReplacements } = await import('./search/replacements');
+    const preprocessedQuery = await applySimpleReplacements(extCleanedQuery);
+
+    // Parse query into structured format
+    const parsedQuery = parseSearchQuery(preprocessedQuery, SEARCH_DEFAULT_KINDS);
+    const { cleanedQuery, effectiveKinds, dateFilter, hasTopLevelOr, topLevelOrParts, extensionFilters } = parsedQuery;
+
+    // Build search context for strategies (needed early for author search)
+    const searchContext: SearchContext = {
+      effectiveKinds,
+      dateFilter,
+      nip50Extensions,
+      chosenRelaySet,
+      relaySetOverride,
       abortSignal,
-      onPartial: onPartialResults
-    });
-    // Dedupe by id
-    const filtered = results.filter((e, idx, arr) => {
-      const firstIdx = arr.findIndex((x) => x.id === e.id);
-      return firstIdx === idx;
-    });
+      limit,
+      extensionFilters,
+      onPartialResults,
+      onProfileResultsUpdate
+    };
 
-    return sortEventsNewestFirst(filtered).slice(0, limit);
-  } catch (error) {
-    // Treat aborted searches as benign; return empty without logging an error
-    if (error instanceof Error && (error.name === 'AbortError' || error.message === 'Search aborted')) {
+    // Distribute parenthesized OR seeds across the entire query BEFORE any specialized handling
+    // e.g., "(GM OR GN) by:dergigi" => ["GM by:dergigi", "GN by:dergigi"]
+    const parenthesizedOrResults = await handleParenthesizedOr(cleanedQuery, searchContext);
+    if (parenthesizedOrResults !== null) {
+      return parenthesizedOrResults;
+    }
+
+    // EARLY: Author filter handling (resolve by:<author> to npub and use authors[] filter)
+    if (!hasTopLevelOr) {
+      const earlyAuthorResults = await tryHandleAuthorSearch(cleanedQuery, searchContext);
+      if (earlyAuthorResults) return earlyAuthorResults;
+    }
+
+    // Check for top-level OR operator (outside parentheses)
+    if (hasTopLevelOr) {
+      return handleTopLevelOr(topLevelOrParts, searchContext);
+    }
+
+    // Run search strategies in order
+    const strategyResults = await runSearchStrategies(extCleanedQuery, cleanedQuery, searchContext);
+    if (strategyResults) return strategyResults;
+
+    // Regular search without author filter
+    try {
+      let results: NDKEvent[] = [];
+      const baseSearch = options?.exact ? `"${cleanedQuery}"` : cleanedQuery || undefined;
+      const searchQuery = baseSearch ? buildSearchQueryWithExtensions(baseSearch, nip50Extensions) : undefined;
+      // Create the filter object that will be sent to NDK
+      const searchFilter = applyDateFilter({
+        kinds: effectiveKinds,
+        search: searchQuery
+      }, dateFilter) as NDKFilter;
+
+      results = await subscribeAndCollect(searchFilter, {
+        timeoutMs: 8000,
+        relaySet: chosenRelaySet,
+        abortSignal,
+        onPartial: onPartialResults
+      });
+      // Dedupe by id
+      const filtered = results.filter((e, idx, arr) => {
+        const firstIdx = arr.findIndex((x) => x.id === e.id);
+        return firstIdx === idx;
+      });
+
+      return sortEventsNewestFirst(filtered).slice(0, limit);
+    } catch (error) {
+      // Treat aborted searches as benign; return empty without logging an error
+      if (error instanceof Error && (error.name === 'AbortError' || error.message === 'Search aborted')) {
+        return [];
+      }
+      console.error('Error fetching events:', error);
       return [];
     }
-    console.error('Error fetching events:', error);
-    return [];
+  } finally {
+    onPartialResults?.dispose();
   }
 }

--- a/src/lib/search/__tests__/subscriptions.test.ts
+++ b/src/lib/search/__tests__/subscriptions.test.ts
@@ -1,0 +1,164 @@
+import { EventEmitter } from 'node:events';
+import type { NDKEvent, NDKRelaySet } from '@nostr-dev-kit/ndk';
+import { createPartialEmitter, subscribeAndCollect } from '../subscriptions';
+import { safeSubscribe } from '../../ndk';
+import { getSearchRelaySet } from '../relayManagement';
+import { filterNip50Relays } from '../../relays';
+import { trackEventRelay } from '../../eventRelayTracking';
+
+jest.mock('@nostr-dev-kit/ndk', () => ({ NDKSubscriptionCacheUsage: { ONLY_RELAY: 'relay' } }));
+jest.mock('../../ndk', () => ({ safeSubscribe: jest.fn(), isValidFilter: () => true, markRelayActivity: jest.fn() }));
+jest.mock('../../urlUtils', () => ({ normalizeRelayUrl: (url: string) => url }));
+jest.mock('../../eventRelayTracking', () => ({ trackEventRelay: jest.fn() }));
+jest.mock('../../relays', () => ({ filterNip50Relays: jest.fn(), getNip50SearchRelaySet: jest.fn(), createRelaySet: jest.fn() }));
+jest.mock('../relayManagement', () => ({ getSearchRelaySet: jest.fn() }));
+
+const relaySet = { relays: new Set([{ url: 'wss://search.example' }]) } as unknown as NDKRelaySet;
+const event = (id: string, created_at = 1) => ({ id, created_at }) as NDKEvent;
+let sub: EventEmitter & { start: jest.Mock; stop: jest.Mock };
+
+beforeEach(() => {
+  jest.useFakeTimers({ now: 1000 });
+  jest.clearAllMocks();
+  sub = Object.assign(new EventEmitter(), { start: jest.fn(), stop: jest.fn() });
+  jest.mocked(safeSubscribe).mockReturnValue(sub as never);
+  jest.mocked(getSearchRelaySet).mockResolvedValue(relaySet);
+  jest.mocked(filterNip50Relays).mockResolvedValue(['wss://search.example']);
+});
+afterEach(() => { jest.clearAllTimers(); jest.useRealTimers(); });
+
+async function tick() { await jest.advanceTimersByTimeAsync(0); }
+
+test('timeout includes stalled relay discovery', async () => {
+  jest.mocked(getSearchRelaySet).mockReturnValue(new Promise(() => {}));
+  const done = jest.fn();
+  void subscribeAndCollect({ kinds: [1] }, { timeoutMs: 100 }).then(done);
+  await jest.advanceTimersByTimeAsync(100);
+  expect(done).toHaveBeenCalledWith([]);
+});
+
+test('abort settles immediately during discovery and never opens a late subscription', async () => {
+  let resolveRelays!: (value: NDKRelaySet) => void;
+  jest.mocked(getSearchRelaySet).mockReturnValue(new Promise((resolve) => { resolveRelays = resolve; }));
+  const controller = new AbortController();
+  const done = jest.fn();
+  void subscribeAndCollect({ kinds: [1] }, { abortSignal: controller.signal }).then(done);
+  controller.abort();
+  await tick();
+  expect(done).toHaveBeenCalledWith([]);
+  resolveRelays(relaySet);
+  await tick();
+  expect(safeSubscribe).not.toHaveBeenCalled();
+});
+
+test('timeout includes NIP-50 capability discovery', async () => {
+  jest.mocked(filterNip50Relays).mockReturnValue(new Promise(() => {}));
+  const done = jest.fn();
+  void subscribeAndCollect({ search: 'bitcoin' }, { relaySet, timeoutMs: 100 }).then(done);
+  await jest.advanceTimersByTimeAsync(100);
+  expect(done).toHaveBeenCalledWith([]);
+  expect(safeSubscribe).not.toHaveBeenCalled();
+});
+
+test('starts once with listeners attached, then closes and detaches on EOSE', async () => {
+  sub.start.mockImplementation(() => { sub.emit('event', event('one')); sub.emit('eose'); });
+  const result = await subscribeAndCollect({ kinds: [1] }, { relaySet });
+  expect(result.map((evt) => evt.id)).toEqual(['one']);
+  expect(safeSubscribe).toHaveBeenCalledWith(expect.anything(), expect.anything(), false);
+  expect(sub.start).toHaveBeenCalledTimes(1);
+  expect(sub.stop).toHaveBeenCalledTimes(1);
+  expect(sub.listenerCount('event')).toBe(0);
+  expect(sub.listenerCount('eose')).toBe(0);
+  expect(jest.getTimerCount()).toBe(0);
+});
+
+test('start failures stop the subscription and clear its timer', async () => {
+  sub.start.mockImplementation(() => { throw new Error('start failed'); });
+  const warning = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  await expect(subscribeAndCollect({ kinds: [1] }, { relaySet })).resolves.toEqual([]);
+  expect(sub.stop).toHaveBeenCalledTimes(1);
+  expect(jest.getTimerCount()).toBe(0);
+  warning.mockRestore();
+});
+
+test('late events after cancellation do no tracking or UI work', async () => {
+  const controller = new AbortController();
+  const onPartial = jest.fn();
+  const result = subscribeAndCollect({ kinds: [1] }, { relaySet, onPartial, abortSignal: controller.signal });
+  await tick();
+  sub.emit('event', event('one'));
+  onPartial.mockClear();
+  jest.mocked(trackEventRelay).mockClear();
+  controller.abort();
+  await result;
+  sub.emit('event', event('late'));
+  expect(onPartial).not.toHaveBeenCalled();
+  expect(trackEventRelay).not.toHaveBeenCalled();
+});
+
+test('a throwing UI callback cannot prevent settlement or cleanup', async () => {
+  const warning = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  const result = subscribeAndCollect({ kinds: [1] }, { relaySet, onPartial: () => { throw new Error('UI failed'); } });
+  await tick();
+  expect(() => sub.emit('event', event('one'))).not.toThrow();
+  sub.emit('eose');
+  await expect(result).resolves.toHaveLength(1);
+  expect(sub.stop).toHaveBeenCalledTimes(1);
+  warning.mockRestore();
+});
+
+test('duplicate batches do not sort and notify the UI again', async () => {
+  const notify = jest.fn();
+  const emit = createPartialEmitter(notify)!;
+  emit([event('one')]);
+  for (let i = 0; i < 1000; i++) emit([event('one')]);
+  await jest.advanceTimersByTimeAsync(500);
+  expect(notify).toHaveBeenCalledTimes(1);
+});
+
+test('partials merge different subscriptions and deliver the trailing batch', async () => {
+  const notify = jest.fn();
+  const emit = createPartialEmitter(notify)!;
+  emit([event('old', 1)]);
+  emit([event('new', 2)]);
+  await jest.advanceTimersByTimeAsync(500);
+  expect(notify).toHaveBeenLastCalledWith([event('new', 2), event('old', 1)]);
+});
+
+test('abort cancels pending partial updates and rejects later batches', async () => {
+  const controller = new AbortController();
+  const notify = jest.fn();
+  const emit = createPartialEmitter(notify, controller.signal)!;
+  emit([event('one')]);
+  emit([event('two')]);
+  controller.abort();
+  emit([event('late')]);
+  await jest.advanceTimersByTimeAsync(500);
+  expect(notify).toHaveBeenCalledTimes(1);
+  expect(jest.getTimerCount()).toBe(0);
+});
+
+test('completion disposes the pending partial timer', async () => {
+  const notify = jest.fn();
+  const emit = createPartialEmitter(notify)!;
+  emit([event('one')]);
+  emit([event('two')]);
+  emit.dispose();
+  emit.dispose();
+  await jest.advanceTimersByTimeAsync(500);
+  expect(notify).toHaveBeenCalledTimes(1);
+  expect(jest.getTimerCount()).toBe(0);
+});
+
+test('10,000 duplicate relay deliveries across 100 batches produce no extra UI updates', async () => {
+  const notify = jest.fn();
+  const emit = createPartialEmitter(notify)!;
+  const events = Array.from({ length: 100 }, (_, i) => event(String(i), i));
+  emit(events);
+  for (let i = 0; i < 100; i++) {
+    await jest.advanceTimersByTimeAsync(500);
+    emit(events);
+  }
+  expect(notify).toHaveBeenCalledTimes(1);
+  emit.dispose();
+});

--- a/src/lib/search/subscriptions.ts
+++ b/src/lib/search/subscriptions.ts
@@ -1,4 +1,4 @@
-import { NDKEvent, NDKFilter, NDKRelaySet, NDKSubscriptionCacheUsage, NDKRelay } from '@nostr-dev-kit/ndk';
+import { NDKEvent, NDKFilter, NDKRelaySet, NDKSubscriptionCacheUsage, NDKSubscription, NDKRelay } from '@nostr-dev-kit/ndk';
 import { safeSubscribe, isValidFilter, markRelayActivity } from '../ndk';
 import { normalizeRelayUrl } from '../urlUtils';
 import { trackEventRelay } from '../eventRelayTracking';
@@ -49,23 +49,32 @@ export type CollectOptions = {
  * lands). Multi-seed paths (OR queries, author fallbacks) share one emitter
  * so partials accumulate instead of clobbering each other.
  */
+export type PartialEmitter = ((events: NDKEvent[]) => void) & { dispose: () => void };
+
 export function createPartialEmitter(
-  onPartialResults?: (events: NDKEvent[]) => void
-): ((events: NDKEvent[]) => void) | undefined {
+  onPartialResults?: (events: NDKEvent[]) => void,
+  abortSignal?: AbortSignal
+): PartialEmitter | undefined {
   if (!onPartialResults) return undefined;
   const all = new Map<string, NDKEvent>();
-  let lastEmitTime = 0;
+  let lastEmitTime = -Infinity;
+  let disposed = false;
   let trailingTimer: ReturnType<typeof setTimeout> | null = null;
 
   const flush = () => {
+    if (disposed) return;
     lastEmitTime = Date.now();
-    onPartialResults(sortEventsNewestFirst(Array.from(all.values())));
+    try { onPartialResults(sortEventsNewestFirst(Array.from(all.values()))); }
+    catch (error) { console.warn('Search partial callback failed:', error); }
   };
 
-  return (events: NDKEvent[]) => {
+  const emit = (events: NDKEvent[]) => {
+    if (disposed) return;
+    let changed = false;
     for (const evt of events) {
-      if (evt.id && !all.has(evt.id)) all.set(evt.id, evt);
+      if (evt.id && !all.has(evt.id)) { all.set(evt.id, evt); changed = true; }
     }
+    if (!changed) return;
     const elapsed = Date.now() - lastEmitTime;
     if (elapsed >= PARTIAL_EMIT_INTERVAL_MS) {
       if (trailingTimer) { clearTimeout(trailingTimer); trailingTimer = null; }
@@ -77,6 +86,17 @@ export function createPartialEmitter(
       }, PARTIAL_EMIT_INTERVAL_MS - elapsed);
     }
   };
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    if (trailingTimer) clearTimeout(trailingTimer);
+    trailingTimer = null;
+    all.clear();
+    abortSignal?.removeEventListener('abort', dispose);
+  };
+  abortSignal?.addEventListener('abort', dispose, { once: true });
+  if (abortSignal?.aborted) dispose();
+  return Object.assign(emit, { dispose });
 }
 
 /**
@@ -88,95 +108,70 @@ export async function subscribeAndCollect(filter: NDKFilter, options: CollectOpt
   const { timeoutMs = 8000, relaySet, abortSignal, onPartial } = options;
 
   return new Promise<NDKEvent[]>((resolve) => {
-    // Check if already aborted
-    if (abortSignal?.aborted) {
+    if (abortSignal?.aborted || !isValidFilter(filter)) {
       resolve([]);
       return;
     }
 
-    // Validate filter - ensure it has at least one meaningful property
-    if (!isValidFilter(filter)) {
-      console.warn('Invalid filter passed to subscribeAndCollect, returning empty results');
-      resolve([]);
-      return;
-    }
-
-    const collected: Map<string, NDKEvent> = new Map();
+    const collected = new Map<string, NDKEvent>();
     let settled = false;
+    let sub: NDKSubscription | null = null;
 
-    (async () => {
-      let rs: NDKRelaySet;
+    const emit = (events: NDKEvent[]) => {
+      if (!onPartial || abortSignal?.aborted || events.length === 0) return;
+      try { onPartial(events); }
+      catch (error) { console.warn('Search partial callback failed:', error); }
+    };
+    const onEvent = (event: NDKEvent, relay: NDKRelay | undefined) => {
+      if (settled || abortSignal?.aborted) return;
+      const relayUrl = relay?.url || 'unknown';
+      if (relayUrl !== 'unknown') {
+        try { markRelayActivity(relayUrl); } catch {}
+      }
+      trackEventRelay(event, normalizeRelayUrl(relayUrl));
+      if (event.id && !collected.has(event.id)) {
+        collected.set(event.id, event);
+        emit([event]);
+      }
+    };
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      abortSignal?.removeEventListener('abort', finish);
+      if (sub) {
+        sub.removeListener('event', onEvent);
+        sub.removeListener('eose', finish);
+        try { sub.stop(); } catch {}
+      }
+      const results = Array.from(collected.values());
+      emit(results);
+      resolve(results);
+    };
+
+    // The deadline includes relay discovery and NIP-50 capability checks.
+    const timer = setTimeout(finish, timeoutMs);
+    abortSignal?.addEventListener('abort', finish, { once: true });
+
+    void (async () => {
       try {
-        rs = relaySet || await getSearchRelaySet();
-      } catch (error) {
-        console.warn('Failed to resolve relay set in subscribeAndCollect:', error);
-        resolve([]);
-        return;
-      }
+        let rs = relaySet || await getSearchRelaySet();
+        if (settled) return;
+        if (filter.search) rs = await restrictToNip50Relays(rs);
+        if (settled) return;
 
-      if (filter.search) {
-        rs = await restrictToNip50Relays(rs);
-      }
-
-      // An abort may have fired while awaiting the relay set
-      if (abortSignal?.aborted) {
-        resolve([]);
-        return;
-      }
-
-      try {
-        const sub = safeSubscribe([filter], { closeOnEose: true, cacheUsage: NDKSubscriptionCacheUsage.ONLY_RELAY, relaySet: rs, __trackFilters: true });
-
-        if (!sub) {
-          console.warn('Failed to create subscription in subscribeAndCollect');
-          resolve([]);
-          return;
-        }
-
-        const finish = () => {
-          if (settled) return;
-          settled = true;
-          clearTimeout(timer);
-          if (abortSignal) {
-            try { abortSignal.removeEventListener('abort', abortHandler); } catch {}
-          }
-          try { sub.stop(); } catch {}
-          const finalResults = Array.from(collected.values());
-          // Final emission so shared emitters see this subscription's full set
-          if (onPartial && finalResults.length > 0) {
-            onPartial(finalResults);
-          }
-          resolve(finalResults);
-        };
-
-        const timer = setTimeout(finish, timeoutMs);
-        const abortHandler = () => finish();
-
-        if (abortSignal) {
-          abortSignal.addEventListener('abort', abortHandler);
-        }
-
-        sub.on('event', (event: NDKEvent, relay: NDKRelay | undefined) => {
-          const relayUrl = relay?.url || 'unknown';
-          if (relayUrl !== 'unknown') {
-            try { markRelayActivity(relayUrl); } catch {}
-          }
-          const normalizedUrl = normalizeRelayUrl(relayUrl);
-          trackEventRelay(event, normalizedUrl);
-          if (!collected.has(event.id)) {
-            collected.set(event.id, event);
-            // Throttling happens in the shared emitter (createPartialEmitter)
-            if (onPartial && !settled) onPartial([event]);
-          }
-        });
-
+        // NDK otherwise schedules an automatic start in addition to ours.
+        sub = safeSubscribe([filter], {
+          closeOnEose: true, cacheUsage: NDKSubscriptionCacheUsage.ONLY_RELAY,
+          relaySet: rs, __trackFilters: true
+        }, false);
+        if (!sub) { finish(); return; }
+        sub.on('event', onEvent);
         sub.on('eose', finish);
-
         sub.start();
       } catch (error) {
         console.warn('subscribeAndCollect setup failed:', error);
-        settled = true;
-        resolve(Array.from(collected.values()));
+        finish();
       }
     })();
   });


### PR DESCRIPTION
Search collection could wait indefinitely during relay discovery because its timeout started only after discovery. Setup failures could leave subscriptions or timers alive, cancelled searches still emitted final batches, and NDK scheduled an automatic start in addition to the collector's explicit start.

The collector now applies its deadline and cancellation handler before discovery, starts once after listeners are attached, and uses one cleanup path for EOSE, timeout, cancellation, and setup failure. Late events and callback failures cannot interfere with settlement. Shared partial emitters skip unchanged batches and release their timers and accumulated events when a search finishes or aborts.

Validation: lint/TypeScript, all 43 Jest tests, and production build passed. Eight regression checks failed on the original code and pass with these changes. Twelve lifecycle/partial-update tests cover discovery stalls, late callbacks, setup failure, cancellation, and cleanup; a deterministic workload of 10,000 duplicate deliveries across 100 batches produces no extra UI updates after the initial result set.

This is a focused reliability and redundant-work improvement. It does not establish a whole-app performance budget or change search syntax.
